### PR TITLE
feat : signed URL upload

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/client-s3": "^3.862.0",
     "@hookform/resolvers": "^4.1.3",
     "@monaco-editor/react": "^4.7.0",
-    "@opndrive/s3-api": "^2.3.1",
+    "@opndrive/s3-api": "^2.4.0",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@opndrive/s3-api':
-        specifier: ^2.3.1
-        version: 2.3.1
+        specifier: ^2.4.0
+        version: 2.4.0
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.6
         version: 1.1.14(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -624,8 +624,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@opndrive/s3-api@2.3.1':
-    resolution: {integrity: sha512-d7k7Yy/4BKZl7SVKNrBeCFbKzjJJfu3+Y3qHD8eBAv4jY/tm7aao98eWfRuKXgnbuMadcX1TB2fcaQZORQei4A==}
+  '@opndrive/s3-api@2.4.0':
+    resolution: {integrity: sha512-FLvvUHFzrA1TcPMuMl075SNaKAf0WBp6kzDMnom4N6lIsAK+aqDpfVToIbkjJFvzXaKdaSbSwVRmWnmHmLyJ6w==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2988,7 +2988,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.2.4':
     optional: true
 
-  '@opndrive/s3-api@2.3.1':
+  '@opndrive/s3-api@2.4.0':
     dependencies:
       '@aws-sdk/client-s3': 3.862.0
       '@aws-sdk/s3-request-presigner': 3.862.0

--- a/frontend/src/app/dashboard/browse/page.tsx
+++ b/frontend/src/app/dashboard/browse/page.tsx
@@ -52,7 +52,7 @@ function BrowsePageContent() {
     setApiS3,
   } = useDriveStore();
 
-  const { apiS3, uploadManager, isLoading, isAuthenticated } = useAuthGuard();
+  const { apiS3, isLoading, isAuthenticated } = useAuthGuard();
 
   const { handleFilesDroppedToDirectory, handleFilesDroppedToFolder } = useUploadStore();
 
@@ -176,22 +176,16 @@ function BrowsePageContent() {
 
   const handleFilesDroppedToDirectoryWrapper = useCallback(
     async (processedData: ProcessedDragData) => {
-      await handleFilesDroppedToDirectory(processedData, currentPrefix, apiS3, uploadManager);
+      await handleFilesDroppedToDirectory(processedData, currentPrefix, apiS3);
     },
-    [currentPrefix, handleFilesDroppedToDirectory, apiS3, uploadManager]
+    [currentPrefix, handleFilesDroppedToDirectory, apiS3]
   );
 
   const handleFilesDroppedToFolderWrapper = useCallback(
     async (processedData: ProcessedDragData, targetFolder: DragDropTarget) => {
-      await handleFilesDroppedToFolder(
-        processedData,
-        targetFolder,
-        currentPrefix,
-        apiS3,
-        uploadManager
-      );
+      await handleFilesDroppedToFolder(processedData, targetFolder, apiS3);
     },
-    [currentPrefix, handleFilesDroppedToFolder, apiS3, uploadManager]
+    [handleFilesDroppedToFolder, apiS3]
   );
 
   const handleSync = async () => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -41,7 +41,7 @@ export default function HomePage() {
   const [isLoadingMoreFiles, setIsLoadingMoreFiles] = useState(false);
   const [isLoadingMoreFolders, setIsLoadingMoreFolders] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
-  const { apiS3, uploadManager, isLoading, isAuthenticated } = useAuthGuard();
+  const { apiS3, isLoading, isAuthenticated } = useAuthGuard();
 
   const { isOpen, currentFiles, openMultiShareDialog, closeMultiShareDialog, generateShareLinks } =
     useMultiShareDialog();
@@ -121,22 +121,16 @@ export default function HomePage() {
 
   const handleFilesDroppedToDirectoryWrapper = useCallback(
     async (processedData: ProcessedDragData) => {
-      await handleFilesDroppedToDirectory(processedData, currentPrefix, apiS3, uploadManager);
+      await handleFilesDroppedToDirectory(processedData, currentPrefix, apiS3);
     },
-    [currentPrefix, handleFilesDroppedToDirectory, apiS3, uploadManager]
+    [handleFilesDroppedToDirectory, apiS3, currentPrefix]
   );
 
   const handleFilesDroppedToFolderWrapper = useCallback(
     async (processedData: ProcessedDragData, targetFolder: DragDropTarget) => {
-      await handleFilesDroppedToFolder(
-        processedData,
-        targetFolder,
-        currentPrefix,
-        apiS3,
-        uploadManager
-      );
+      await handleFilesDroppedToFolder(processedData, targetFolder, apiS3);
     },
-    [currentPrefix, handleFilesDroppedToFolder, apiS3, uploadManager]
+    [handleFilesDroppedToFolder, apiS3]
   );
 
   const handleLoadMoreFiles = async () => {

--- a/frontend/src/context/zustand-bridge.tsx
+++ b/frontend/src/context/zustand-bridge.tsx
@@ -3,15 +3,24 @@
 import { useContext, useEffect } from 'react';
 import { AuthContext } from './auth-context';
 import { useUploadStore } from '@/features/upload/stores/use-upload-store';
+import { useUploadSettingsStore } from '@/features/upload/stores/use-upload-settings-store';
 
 export function ZustandBridge() {
-  const { uploadManager } = useContext(AuthContext);
+  const { uploadManager, signedUrlUploadManager } = useContext(AuthContext);
+  const { uploadMode } = useUploadSettingsStore();
 
   const setUploadManager = useUploadStore((state) => state.setUploadManager);
 
   useEffect(() => {
+    console.log('Here i am changing the upload manager type');
+    if (uploadMode === 'signed-url') {
+      console.log('inside signed url');
+      setUploadManager(signedUrlUploadManager);
+      return;
+    }
+    console.log('inside multipart url');
     setUploadManager(uploadManager);
-  }, [uploadManager, setUploadManager]);
+  }, [uploadMode, uploadManager, signedUrlUploadManager, setUploadManager]);
 
   return null;
 }

--- a/frontend/src/context/zustand-bridge.tsx
+++ b/frontend/src/context/zustand-bridge.tsx
@@ -12,13 +12,10 @@ export function ZustandBridge() {
   const setUploadManager = useUploadStore((state) => state.setUploadManager);
 
   useEffect(() => {
-    console.log('Here i am changing the upload manager type');
     if (uploadMode === 'signed-url') {
-      console.log('inside signed url');
       setUploadManager(signedUrlUploadManager);
       return;
     }
-    console.log('inside multipart url');
     setUploadManager(uploadManager);
   }, [uploadMode, uploadManager, signedUrlUploadManager, setUploadManager]);
 

--- a/frontend/src/features/settings/components/general-settings-panel.tsx
+++ b/frontend/src/features/settings/components/general-settings-panel.tsx
@@ -4,6 +4,7 @@ import { GeneralSettings } from '../types';
 import { START_PAGE_OPTIONS, BULK_SHARE_DURATION_OPTIONS, isValidDuration } from '../constants';
 import { RadioGroup } from './radio-group';
 import { CustomDropdown } from '@/shared/components/ui/custom-dropdown';
+import { UploadModeSettings } from '@/features/upload';
 
 interface GeneralSettingsPanelProps {
   settings: GeneralSettings;
@@ -44,6 +45,18 @@ export function GeneralSettingsPanel({ settings, onUpdate }: GeneralSettingsPane
             options={startPageOptions}
             name="startPage"
           />
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        <div className="border-b border-border pb-4">
+          <h3 className="text-lg font-medium text-foreground">Upload method</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Choose how files are uploaded to your S3 bucket. Changes apply to new uploads.
+          </p>
+        </div>
+        <div className="pl-0">
+          <UploadModeSettings />
         </div>
       </div>
 

--- a/frontend/src/features/upload/components/operations-modal.tsx
+++ b/frontend/src/features/upload/components/operations-modal.tsx
@@ -9,7 +9,8 @@ import { FolderIcon } from '@/shared/components/icons/folder-icons';
 import { DuplicateDialog } from './duplicate-dialog';
 import type { FileExtension } from '@/config/file-extensions';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
-import { useUploadManager } from '@/hooks/use-auth';
+import { useActiveUploadManager } from '@/hooks/use-auth';
+import { useUploadSettingsStore } from '@/features/upload/stores/use-upload-settings-store';
 
 interface OperationItem {
   id: string;
@@ -88,7 +89,11 @@ export const OperationsModal: React.FC = () => {
   const [isExpanded, setIsExpanded] = useState(true);
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
-  const uploadManager = useUploadManager();
+  const uploadManager = useActiveUploadManager();
+  const { uploadMode } = useUploadSettingsStore();
+
+  // Check if pause/resume is supported in current mode
+  const supportsPauseResume = uploadMode === 'multipart';
 
   if (!uploadManager) {
     return 'Loading...';
@@ -755,8 +760,9 @@ export const OperationsModal: React.FC = () => {
 
                     {/* Pause/Resume Buttons and Progress Circle */}
                     <div className="flex-shrink-0 flex items-center gap-2">
-                      {/* Pause/Resume Buttons for file uploads only */}
-                      {operation.operationType === 'upload' &&
+                      {/* Pause/Resume Buttons for file uploads only - only in multipart mode */}
+                      {supportsPauseResume &&
+                        operation.operationType === 'upload' &&
                         operation.type === 'file' &&
                         (isActive || operation.status === 'paused') && (
                           <div className="flex items-center">

--- a/frontend/src/features/upload/components/upload-mode-settings.tsx
+++ b/frontend/src/features/upload/components/upload-mode-settings.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React from 'react';
+import { useUploadSettingsStore } from '@/features/upload/stores/use-upload-settings-store';
+import { UPLOAD_MODES, UploadMode } from '@/features/upload/types';
+import { Check, Upload, Zap } from 'lucide-react';
+
+export const UploadModeSettings: React.FC = () => {
+  const { uploadMode, setUploadMode } = useUploadSettingsStore();
+
+  const handleModeChange = (mode: UploadMode) => {
+    setUploadMode(mode);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        {Object.values(UPLOAD_MODES).map((config) => {
+          const isSelected = uploadMode === config.mode;
+          const Icon = config.mode === 'multipart' ? Upload : Zap;
+
+          return (
+            <button
+              key={config.mode}
+              onClick={() => handleModeChange(config.mode)}
+              className={`w-full text-left p-4 rounded-lg border-2 transition-all ${
+                isSelected
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border hover:border-primary/50 hover:bg-accent/50'
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <div
+                  className={`flex-shrink-0 mt-0.5 ${
+                    isSelected ? 'text-primary' : 'text-muted-foreground'
+                  }`}
+                >
+                  <Icon className="h-5 w-5" />
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <h4 className="font-medium text-foreground">{config.label}</h4>
+                    {isSelected && (
+                      <div className="flex-shrink-0">
+                        <Check className="h-4 w-4 text-primary" />
+                      </div>
+                    )}
+                  </div>
+
+                  <p className="text-sm text-muted-foreground mb-3">{config.description}</p>
+
+                  <div className="flex flex-wrap gap-2">
+                    {config.features.pauseResume && (
+                      <span className="inline-flex items-center px-2 py-1 rounded-md bg-green-500/10 text-green-600 dark:text-green-400 text-xs font-medium">
+                        Pause/Resume
+                      </span>
+                    )}
+                    {config.features.largeFiles && (
+                      <span className="inline-flex items-center px-2 py-1 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs font-medium">
+                        Large Files
+                      </span>
+                    )}
+                    {config.features.fasterSmallFiles && (
+                      <span className="inline-flex items-center px-2 py-1 rounded-md bg-purple-500/10 text-purple-600 dark:text-purple-400 text-xs font-medium">
+                        Faster Small Files
+                      </span>
+                    )}
+                    {!config.features.pauseResume && (
+                      <span className="inline-flex items-center px-2 py-1 rounded-md bg-orange-500/10 text-orange-600 dark:text-orange-400 text-xs font-medium">
+                        Cancel Only
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-4 p-4 rounded-lg bg-muted/50 border border-border">
+        <h4 className="text-sm font-medium text-foreground mb-2">💡 Which should I choose?</h4>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li className="flex gap-2">
+            <span className="flex-shrink-0">•</span>
+            <span>
+              <strong>Multipart:</strong> Best for large files (&gt;100MB). Supports pause/resume.
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <span className="flex-shrink-0">•</span>
+            <span>
+              <strong>Signed URL:</strong> Faster for small files (&lt;100MB). Simpler, more direct.
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/upload/components/upload-operations-card.tsx
+++ b/frontend/src/features/upload/components/upload-operations-card.tsx
@@ -3,11 +3,11 @@
 import React from 'react';
 import { useUploadStore } from '@/features/upload/stores/use-upload-store';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/components/ui/card';
-import { useUploadManager } from '@/hooks/use-auth';
+import { useActiveUploadManager } from '@/hooks/use-auth';
 
 export const UploadOperationsCard: React.FC = () => {
   const { uploads } = useUploadStore();
-  const uploadManager = useUploadManager();
+  const uploadManager = useActiveUploadManager();
 
   if (!uploadManager) {
     return 'Loading...';

--- a/frontend/src/features/upload/context/upload-context.tsx
+++ b/frontend/src/features/upload/context/upload-context.tsx
@@ -3,13 +3,13 @@
 import React, { createContext, useContext, useEffect, ReactNode } from 'react';
 import { UploadStatus } from '@opndrive/s3-api';
 import { useUploadStore } from '@/features/upload/stores/use-upload-store';
-import { useUploadManager } from '@/hooks/use-auth';
+import { useActiveUploadManager } from '@/hooks/use-auth';
 
 const UploadContext = createContext<null>(null);
 
 export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { updateUpload } = useUploadStore();
-  const uploadManager = useUploadManager();
+  const uploadManager = useActiveUploadManager();
 
   useEffect(() => {
     if (!uploadManager) return;

--- a/frontend/src/features/upload/index.ts
+++ b/frontend/src/features/upload/index.ts
@@ -1,6 +1,10 @@
 // Upload feature exports
-export type { UploadItem, UploadState, UploadProgress, UploadMethod } from './types';
+export type { UploadItem, UploadState, UploadProgress, UploadMethod, UploadMode } from './types';
 
 // Components
 export { UploadCard } from './components/upload-card';
 export { OperationsModal } from './components/operations-modal';
+export { UploadModeSettings } from './components/upload-mode-settings';
+
+// Stores
+export { useUploadSettingsStore } from './stores/use-upload-settings-store';

--- a/frontend/src/features/upload/stores/use-upload-settings-store.ts
+++ b/frontend/src/features/upload/stores/use-upload-settings-store.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { UploadMode } from '../types';
+
+interface UploadSettingsStore {
+  uploadMode: UploadMode;
+  setUploadMode: (mode: UploadMode) => void;
+}
+
+export const useUploadSettingsStore = create<UploadSettingsStore>()(
+  persist(
+    (set) => ({
+      uploadMode: 'multipart',
+      setUploadMode: (mode: UploadMode) => set({ uploadMode: mode }),
+    }),
+    {
+      name: 'upload-settings-storage',
+    }
+  )
+);

--- a/frontend/src/features/upload/stores/use-upload-store.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.ts
@@ -1,6 +1,11 @@
 'use client';
 
-import { UploadStatus, BYOS3ApiProvider, UploadManager } from '@opndrive/s3-api';
+import {
+  UploadStatus,
+  BYOS3ApiProvider,
+  UploadManager,
+  SignedUrlUploadManager,
+} from '@opndrive/s3-api';
 import { create } from 'zustand';
 import { ProcessedDragData } from '@/features/upload/types/folder-upload-types';
 import { DragDropTarget } from '@/features/upload/types/drag-drop-types';
@@ -151,12 +156,12 @@ interface DeleteProgress {
 }
 
 interface UploadStore {
-  uploadManager: UploadManager | null;
+  uploadManager: UploadManager | SignedUrlUploadManager | null;
   uploads: Record<string, UploadProgress>;
   deletes: Record<string, DeleteProgress>;
   batches: Record<string, UploadBatch>;
   duplicateDialog: DuplicateDialogState;
-  setUploadManager: (manager: UploadManager | null) => void;
+  setUploadManager: (manager: UploadManager | SignedUrlUploadManager | null) => void;
   setUploads: (uploads: Record<string, UploadProgress>) => void;
   addUpload: (id: string, upload: UploadProgress) => void;
   updateUpload: (id: string, updates: Partial<UploadProgress>) => void;
@@ -166,15 +171,12 @@ interface UploadStore {
   handleFilesDroppedToDirectory: (
     processedData: ProcessedDragData,
     currentPrefix: string | null,
-    apiS3?: BYOS3ApiProvider,
-    uploadManager?: UploadManager | null
+    apiS3?: BYOS3ApiProvider
   ) => Promise<void>;
   handleFilesDroppedToFolder: (
     processedData: ProcessedDragData,
     targetFolder: DragDropTarget,
-    currentPrefix: string | null,
-    apiS3?: BYOS3ApiProvider,
-    uploadManager?: UploadManager | null
+    apiS3?: BYOS3ApiProvider
   ) => Promise<void>;
 
   // Delete operation methods
@@ -588,11 +590,9 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
   handleFilesDroppedToFolder: async (
     processedData: ProcessedDragData,
     targetFolder: DragDropTarget,
-    currentPrefix: string | null,
-    apiS3?: BYOS3ApiProvider,
-    uploadManager?: UploadManager | null
+    apiS3?: BYOS3ApiProvider
   ) => {
-    const { addUpload, showDuplicateDialog } = get();
+    const { uploadManager, addUpload, showDuplicateDialog } = get();
 
     if (!uploadManager) {
       return;

--- a/frontend/src/features/upload/types/index.ts
+++ b/frontend/src/features/upload/types/index.ts
@@ -36,3 +36,5 @@ export interface UploadProgress {
 }
 
 export type UploadMethod = 'auto' | 'signed-url' | 'multipart' | 'multipart-concurrent';
+
+export * from './upload-mode';

--- a/frontend/src/features/upload/types/upload-mode.ts
+++ b/frontend/src/features/upload/types/upload-mode.ts
@@ -1,0 +1,36 @@
+// Upload mode types
+export type UploadMode = 'multipart' | 'signed-url';
+
+export interface UploadModeConfig {
+  mode: UploadMode;
+  label: string;
+  description: string;
+  features: {
+    pauseResume: boolean;
+    largeFiles: boolean;
+    fasterSmallFiles: boolean;
+  };
+}
+
+export const UPLOAD_MODES: Record<UploadMode, UploadModeConfig> = {
+  multipart: {
+    mode: 'multipart',
+    label: 'Multipart Upload',
+    description: 'Advanced upload with pause/resume support. Best for large files.',
+    features: {
+      pauseResume: true,
+      largeFiles: true,
+      fasterSmallFiles: false,
+    },
+  },
+  'signed-url': {
+    mode: 'signed-url',
+    label: 'Signed URL Upload',
+    description: 'Simple direct upload. Faster for small files. Cancel only (no pause/resume).',
+    features: {
+      pauseResume: false,
+      largeFiles: false,
+      fasterSmallFiles: true,
+    },
+  },
+};

--- a/frontend/src/hooks/use-auth-guard.tsx
+++ b/frontend/src/hooks/use-auth-guard.tsx
@@ -10,7 +10,7 @@ import { useEffect } from 'react';
  * Redirects to home page if not authenticated
  */
 export function useAuthGuard() {
-  const { apiS3, uploadManager, userCreds, isLoading } = useAuth();
+  const { apiS3, uploadManager, signedUrlUploadManager, userCreds, isLoading } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
@@ -24,6 +24,7 @@ export function useAuthGuard() {
   return {
     apiS3: !isLoading && userCreds ? apiS3 : null,
     uploadManager: !isLoading && userCreds ? uploadManager : null,
+    signedUrlUploadManager: !isLoading && userCreds ? signedUrlUploadManager : null,
     userCreds: !isLoading ? userCreds : null,
     isAuthenticated: !isLoading && !!userCreds && !!apiS3,
     isLoading,

--- a/frontend/src/hooks/use-auth.tsx
+++ b/frontend/src/hooks/use-auth.tsx
@@ -25,3 +25,34 @@ export function useUploadManager() {
   }
   return uploadManager;
 }
+
+export function useSignedUrlUploadManager() {
+  const { signedUrlUploadManager, isLoading } = useAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (!signedUrlUploadManager) {
+    return null;
+  }
+  return signedUrlUploadManager;
+}
+
+export function useActiveUploadManager() {
+  const { uploadManager, signedUrlUploadManager, isLoading } = useAuth();
+  const { uploadMode } = useUploadSettingsStore();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (uploadMode === 'signed-url') {
+    return signedUrlUploadManager;
+  }
+
+  return uploadManager;
+}
+
+// Import at the bottom to avoid circular dependency
+import { useUploadSettingsStore } from '@/features/upload/stores/use-upload-settings-store';


### PR DESCRIPTION
This pull request introduces support for selecting between two different S3 upload methods—Multipart and Signed URL—via a new setting in the UI. It updates the authentication context to initialize and provide both upload managers, and ensures the correct manager is used based on the user's chosen upload mode. Additionally, it updates dependencies to use the latest version of `@opndrive/s3-api` and refactors upload handler functions to align with the new upload manager logic.

## Related Issue

- Fixes #56 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Code is properly commented
- [ ] Documentation updated (if needed)