### PR TITLE
fix: dispose upload managers on session change

### DIFF
--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -10,6 +10,7 @@ import {
   SignedUrlUploadManager,
 } from '@opndrive/s3-api';
 import { useDriveStore } from './data-context';
+import { useUploadStore } from '@/features/upload/stores/use-upload-store';
 
 interface AuthContextType {
   apiS3: BYOS3ApiProvider | null;
@@ -27,6 +28,72 @@ function isValidCreds(c: Credentials): c is Credentials {
     typeof c?.secretAccessKey === 'string' &&
     typeof c?.region === 'string'
   );
+}
+
+/**
+ * UploadManager.getInstance()/SignedUrlUploadManager.getInstance() return the
+ * first instance ever built and silently discard the config passed to every
+ * later call. Left unchecked, switching accounts or buckets keeps uploading
+ * to whichever bucket was connected first.
+ *
+ * @opndrive/s3-api 2.6.0 adds a disposeInstance() static that cancels
+ * in-flight uploads and clears the singleton so the next getInstance() call
+ * builds fresh. The installed 2.5.0 does not have it yet, so this is called
+ * through a feature-detecting cast rather than a direct reference - once
+ * frontend/package.json depends on ^2.6.0, delete the cast and call
+ * `UploadManager.disposeInstance()` / `SignedUrlUploadManager.disposeInstance()`
+ * directly.
+ */
+type Disposable = { disposeInstance?: () => Promise<void> };
+
+let warnedAboutLegacyUploadManager = false;
+
+async function disposeUploadManagers(): Promise<void> {
+  const managerCtor = UploadManager as unknown as Disposable;
+  const signedCtor = SignedUrlUploadManager as unknown as Disposable;
+
+  if (!managerCtor.disposeInstance || !signedCtor.disposeInstance) {
+    if (!warnedAboutLegacyUploadManager) {
+      warnedAboutLegacyUploadManager = true;
+      console.warn(
+        '[opndrive] The installed @opndrive/s3-api predates 2.6.0, so upload ' +
+          'managers cannot be disposed on session change. Switching buckets ' +
+          'without a full page reload may keep uploading to the previous ' +
+          'bucket. Upgrade to ^2.6.0.'
+      );
+    }
+    return;
+  }
+
+  await Promise.all([managerCtor.disposeInstance(), signedCtor.disposeInstance()]);
+}
+
+/**
+ * Disposes any existing singletons, then builds fresh managers bound to
+ * `api`. Shared by both session-restore and interactive login so every path
+ * that establishes a session gets the same guarantee.
+ */
+async function initializeUploadManagers(
+  api: BYOS3ApiProvider,
+  creds: Credentials
+): Promise<{ manager: UploadManager; signedUrlManager: SignedUrlUploadManager }> {
+  await disposeUploadManagers();
+
+  const manager = UploadManager.getInstance({
+    s3: api.getS3Client(),
+    bucket: api.getBucketName(),
+    prefix: creds.prefix || '',
+    maxConcurrency: 2,
+    partSizeMB: 5,
+  });
+
+  const signedUrlManager = SignedUrlUploadManager.getInstance({
+    apiProvider: api,
+    maxConcurrency: 2,
+    expiresInSeconds: 3600,
+  });
+
+  return { manager, signedUrlManager };
 }
 
 export const AuthContext = createContext<AuthContextType>({
@@ -70,20 +137,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           if (isValidCreds(creds)) {
             const api = new BYOS3ApiProvider(creds, 'BYO');
 
-            // Initialize both upload managers
-            const manager = UploadManager.getInstance({
-              s3: api.getS3Client(),
-              bucket: api.getBucketName(),
-              prefix: creds.prefix || '',
-              maxConcurrency: 2,
-              partSizeMB: 5,
-            });
-
-            const signedUrlManager = SignedUrlUploadManager.getInstance({
-              apiProvider: api,
-              maxConcurrency: 2,
-              expiresInSeconds: 3600,
-            });
+            const { manager, signedUrlManager } = await initializeUploadManagers(api, creds);
 
             setUploadManager(manager);
             setSignedUrlUploadManager(signedUrlManager);
@@ -116,20 +170,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setIsLoading(true);
       const api = new BYOS3ApiProvider(creds, 'BYO');
 
-      // Initialize both upload managers
-      const manager = UploadManager.getInstance({
-        s3: api.getS3Client(),
-        bucket: api.getBucketName(),
-        prefix: creds.prefix || '',
-        maxConcurrency: 2,
-        partSizeMB: 5,
-      });
-
-      const signedUrlManager = SignedUrlUploadManager.getInstance({
-        apiProvider: api,
-        maxConcurrency: 2,
-        expiresInSeconds: 3600,
-      });
+      const { manager, signedUrlManager } = await initializeUploadManagers(api, creds);
 
       // Persist to state and localStorage
       setUserCreds(creds);
@@ -156,18 +197,23 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       // Set loading state to prevent components from using context values
       setIsLoading(true);
 
-      // Clean up upload manager if it exists
-      if (uploadManager) {
-        try {
-          // Cancel any ongoing uploads before clearing
-          // Note: Implement proper cleanup based on UploadManager API
-        } catch (error) {
-          console.warn('Error cleaning up uploads during logout:', error);
-        }
-      }
+      // Dispose the upload manager singletons so a new session cannot resume
+      // uploading to this bucket. disposeUploadManagers() never throws, and
+      // it clears the static singleton reference synchronously before doing
+      // any awaiting, so it is safe to fire-and-forget here rather than
+      // block logout on in-flight cancellation network calls.
+      void disposeUploadManagers().catch((error) => {
+        console.warn('Error cleaning up uploads during logout:', error);
+      });
 
       // Clear all drive store data to prevent data leakage between sessions
       clearAllData();
+
+      // Same for upload/delete history. Disposal above emits a 'cancelled'
+      // event per in-flight item, and those land in the upload store before
+      // UploadProvider unmounts - without this, records from this bucket would
+      // still be on screen after connecting to a different one.
+      useUploadStore.getState().clearSessionData();
 
       // Clear localStorage
       localStorage.removeItem(STORAGE_KEY);

--- a/frontend/src/features/upload/stores/use-upload-store.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.ts
@@ -168,6 +168,14 @@ interface UploadStore {
   removeUpload: (id: string) => void;
   clearCompleted: () => void;
   clearAll: () => void;
+  /**
+   * Wipes everything tied to the current session: upload history, delete
+   * history, batch tracking, and any open duplicate prompt. Called on logout
+   * so records from one bucket cannot surface in the next session - disposing
+   * the upload managers emits a 'cancelled' event per in-flight item, and
+   * those land here before the provider unmounts.
+   */
+  clearSessionData: () => void;
   handleFilesDroppedToDirectory: (
     processedData: ProcessedDragData,
     currentPrefix: string | null,
@@ -242,6 +250,12 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
     })),
 
   updateUpload: (id: string, updates: Partial<UploadProgress>) => {
+    // Ignore events for uploads we are no longer tracking. Disposing the upload
+    // managers on logout emits a trailing 'cancelled' per in-flight item, which
+    // can arrive after clearSessionData() has already run - spreading onto an
+    // absent entry would resurrect it as a malformed card with no name or type.
+    if (!get().uploads[id]) return;
+
     set((state) => ({
       uploads: {
         ...state.uploads,
@@ -305,6 +319,19 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
     })),
 
   clearAll: () => set({ uploads: {} }),
+
+  clearSessionData: () =>
+    set({
+      uploads: {},
+      deletes: {},
+      batches: {},
+      duplicateDialog: {
+        isOpen: false,
+        duplicateItem: null,
+        onReplace: null,
+        onKeepBoth: null,
+      },
+    }),
 
   handleFilesDroppedToDirectory: async (
     processedData: ProcessedDragData,

--- a/s3-api/package.json
+++ b/s3-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opndrive/s3-api",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "AWS S3 helper for the opndrive project",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/s3-api/src/utils/signedUrlUploadManager.ts
+++ b/s3-api/src/utils/signedUrlUploadManager.ts
@@ -24,7 +24,7 @@ export interface SignedUrlUploadManagerConfig {
 }
 
 export class SignedUrlUploadManager {
-  private static instance: SignedUrlUploadManager;
+  private static instance: SignedUrlUploadManager | undefined;
   private apiProvider: BYOS3ApiProvider;
   private uploads = new Map<string, SignedUrlUploadItem>();
   private queue: string[] = [];
@@ -32,6 +32,8 @@ export class SignedUrlUploadManager {
   private maxConcurrency: number;
   private expiresInSeconds: number;
   private listeners = new Map<UploadEvent, Set<EventListener>>();
+  // See UploadManager.isDisposed for why this exists.
+  private isDisposed = false;
 
   private constructor(config: SignedUrlUploadManagerConfig) {
     this.apiProvider = config.apiProvider;
@@ -44,6 +46,38 @@ export class SignedUrlUploadManager {
       SignedUrlUploadManager.instance = new SignedUrlUploadManager(config);
     }
     return SignedUrlUploadManager.instance;
+  }
+
+  /** See UploadManager.disposeInstance - identical contract. */
+  public static async disposeInstance(): Promise<void> {
+    const existing = SignedUrlUploadManager.instance;
+    SignedUrlUploadManager.instance = undefined;
+    if (!existing) return;
+
+    existing.isDisposed = true;
+    try {
+      await existing.cancelAllUploads();
+    } catch (err) {
+      console.error('Failed to cleanly cancel in-flight signed-url uploads during dispose:', err);
+    }
+  }
+
+  /** See UploadManager.cancelAllUploads for why this uses allSettled. */
+  private async cancelAllUploads(): Promise<void> {
+    const ids = Array.from(this.uploads.entries())
+      .filter(([, item]) => ['queued', 'uploading'].includes(item.status))
+      .map(([id]) => id);
+
+    const results = await Promise.allSettled(ids.map((id) => this.cancelUpload(id)));
+
+    results.forEach((result, i) => {
+      if (result.status === 'rejected') {
+        console.error(
+          `Failed to cancel signed-url upload ${ids[i]} during dispose:`,
+          result.reason
+        );
+      }
+    });
   }
 
   // Event emitter methods
@@ -62,6 +96,12 @@ export class SignedUrlUploadManager {
    * Add a file to the upload queue
    */
   public addUpload(file: File, config: { key: string }): string {
+    if (this.isDisposed) {
+      throw new Error(
+        'This SignedUrlUploadManager instance has been disposed. Obtain a new one via getInstance().'
+      );
+    }
+
     const id = uuidv4();
     const uploader = new SignedUrlUploader({
       apiProvider: this.apiProvider,
@@ -122,6 +162,11 @@ export class SignedUrlUploadManager {
     const item = this.uploads.get(id);
     if (!item) return;
 
+    // Already terminal - re-running the bookkeeping would emit a duplicate
+    // 'cancelled' event. (uploader.cancel() here is synchronous, so unlike
+    // UploadManager there is no await window for the worker to race us.)
+    if (['completed', 'failed', 'cancelled'].includes(item.status)) return;
+
     const queueIndex = this.queue.indexOf(id);
     if (queueIndex > -1) {
       this.queue.splice(queueIndex, 1);
@@ -180,6 +225,10 @@ export class SignedUrlUploadManager {
    * Process the upload queue
    */
   private async processQueue(): Promise<void> {
+    // See UploadManager.processQueue - without this, cancelling a queued item
+    // during dispose would start the next queued item against the old session.
+    if (this.isDisposed) return;
+
     if (this.activeUploads >= this.maxConcurrency || this.queue.length === 0) {
       return;
     }
@@ -250,8 +299,15 @@ export class SignedUrlUploadManager {
   /**
    * Emit events to listeners
    */
+  /** See UploadManager.emit - listeners must be isolated from each other. */
   private emit(event: UploadEvent, payload: EventPayload): void {
-    this.listeners.get(event)?.forEach((listener) => listener(payload));
+    this.listeners.get(event)?.forEach((listener) => {
+      try {
+        listener(payload);
+      } catch (err) {
+        console.error(`Signed-url upload event listener for "${event}" threw:`, err);
+      }
+    });
   }
 
   /**

--- a/s3-api/src/utils/uploadManager.ts
+++ b/s3-api/src/utils/uploadManager.ts
@@ -12,7 +12,7 @@ import {
 } from '../core/types.js';
 
 export class UploadManager {
-  private static instance: UploadManager;
+  private static instance: UploadManager | undefined;
   private s3: S3Client;
   private prefix: string = ''; // Base prefix from config
   private bucket: string = ''; // Bucket from config
@@ -21,6 +21,11 @@ export class UploadManager {
   private activeUploads = 0;
   private maxConcurrency: number; // Max files to upload at once
   private partSize: number;
+  // Set once this instance has been superseded by disposeInstance(). getInstance()
+  // silently discards its config once an instance exists, so a stale manager left
+  // over from a previous session/bucket must refuse new work rather than upload to
+  // credentials the caller no longer intends to use.
+  private isDisposed = false;
 
   // --- Part Concurrency ---
   // This is the max parts for a SINGLE file upload.
@@ -44,6 +49,58 @@ export class UploadManager {
     return UploadManager.instance;
   }
 
+  /**
+   * Tears down the current singleton so the next getInstance() call builds a
+   * fresh manager bound to new credentials.
+   *
+   * Must be called whenever a session ends or changes bucket - getInstance()
+   * silently ignores its config argument once an instance already exists, so
+   * without this, uploads keep going to whichever bucket was connected first.
+   *
+   * Clears the static reference synchronously (before any awaiting), so a
+   * getInstance() call made immediately after is guaranteed a fresh instance
+   * regardless of how long in-flight cancellation takes. Never throws - safe
+   * to call without awaiting from a synchronous caller such as logout.
+   */
+  public static async disposeInstance(): Promise<void> {
+    const existing = UploadManager.instance;
+    UploadManager.instance = undefined;
+    if (!existing) return;
+
+    existing.isDisposed = true;
+    try {
+      await existing.cancelAllUploads();
+    } catch (err) {
+      console.error('Failed to cleanly cancel in-flight uploads during dispose:', err);
+    }
+  }
+
+  /**
+   * Cancels every queued, uploading, or paused item; leaves completed/failed/
+   * cancelled alone.
+   *
+   * Uses allSettled rather than all: a failed AbortMultipartUpload leaves an
+   * orphaned multipart upload accruing storage charges, so every failure has to
+   * be surfaced individually instead of the first rejection masking the rest.
+   */
+  private async cancelAllUploads(): Promise<void> {
+    const ids = Array.from(this.uploads.entries())
+      .filter(([, item]) => ['queued', 'uploading', 'paused'].includes(item.status))
+      .map(([id]) => id);
+
+    const results = await Promise.allSettled(ids.map((id) => this.cancelUpload(id)));
+
+    results.forEach((result, i) => {
+      if (result.status === 'rejected') {
+        console.error(
+          `Failed to cancel upload ${ids[i]} during dispose. If a multipart ` +
+            'upload was in progress it may now be orphaned in the bucket:',
+          result.reason
+        );
+      }
+    });
+  }
+
   // --- Event Emitter Methods (Unchanged) ---
   public on(event: UploadEvent, listener: EventListener): void {
     if (!this.listeners.has(event)) {
@@ -61,6 +118,12 @@ export class UploadManager {
    * The concurrency for the uploader is now a fixed value, not the manager's concurrency.
    */
   public addUpload(file: File, config: { key: string }): string {
+    if (this.isDisposed) {
+      throw new Error(
+        'This UploadManager instance has been disposed. Obtain a new one via getInstance().'
+      );
+    }
+
     const id = uuidv4();
     const uploader = new MultipartUploader({
       s3: this.s3,
@@ -130,6 +193,8 @@ export class UploadManager {
   }
 
   public async resumeUpload(id: string): Promise<void> {
+    if (this.isDisposed) return;
+
     const item = this.uploads.get(id);
     if (!item || item.status !== 'paused') return;
 
@@ -142,19 +207,35 @@ export class UploadManager {
     const item = this.uploads.get(id);
     if (!item) return;
 
+    const previousStatus = item.status;
+
+    // Already terminal - nothing to cancel, and re-running the bookkeeping
+    // below would double-decrement activeUploads.
+    if (previousStatus === 'completed' || previousStatus === 'failed') return;
+    if (previousStatus === 'cancelled') return;
+
     const queueIndex = this.queue.indexOf(id);
     if (queueIndex > -1) {
       this.queue.splice(queueIndex, 1);
     }
 
-    if (item.status === 'uploading' || item.status === 'paused') {
-      await item.uploader.cancel();
-      if (item.status === 'uploading') {
-        this.activeUploads--;
-      }
+    // Mark terminal BEFORE awaiting the uploader. uploader.cancel() performs a
+    // network round-trip (AbortMultipartUpload), and while it is in flight the
+    // upload worker unwinds and resolves normally - it would otherwise still
+    // see status 'uploading' and transition the item to 'completed', emitting a
+    // bogus success event for an upload the caller just cancelled.
+    this.updateItemStatus(id, 'cancelled');
+
+    // The worker's `finally` only decrements for completed/failed, so once the
+    // status is 'cancelled' this bookkeeping becomes ours.
+    if (previousStatus === 'uploading') {
+      this.activeUploads--;
     }
 
-    this.updateItemStatus(id, 'cancelled');
+    if (previousStatus === 'uploading' || previousStatus === 'paused') {
+      await item.uploader.cancel();
+    }
+
     this.processQueue();
   }
 
@@ -172,6 +253,12 @@ export class UploadManager {
   }
 
   private async processQueue(): Promise<void> {
+    // cancelUpload() calls this after every cancellation, including the mass
+    // cancellation inside disposeInstance(). Without this guard, cancelling a
+    // queued item would pull the NEXT queued item off and start uploading it to
+    // the very bucket being torn down.
+    if (this.isDisposed) return;
+
     if (this.activeUploads >= this.maxConcurrency || this.queue.length === 0) {
       return;
     }
@@ -240,8 +327,20 @@ export class UploadManager {
     this.emitStatusChange(id, status, item.progress, error);
   }
 
+  /**
+   * Listeners are isolated from each other: a subscriber that throws must not
+   * break the emit loop. This matters most during disposeInstance(), where a
+   * single throwing listener would otherwise propagate up through
+   * updateItemStatus -> cancelUpload and leave the remaining uploads running.
+   */
   private emit(event: UploadEvent, payload: EventPayload): void {
-    this.listeners.get(event)?.forEach((listener) => listener(payload));
+    this.listeners.get(event)?.forEach((listener) => {
+      try {
+        listener(payload);
+      } catch (err) {
+        console.error(`Upload event listener for "${event}" threw:`, err);
+      }
+    });
   }
 
   private emitStatusChange(id: string, status: UploadStatus, progress: number, error?: string) {


### PR DESCRIPTION
## What This PR Does

`UploadManager.getInstance()` and `SignedUrlUploadManager.getInstance()` return the first instance ever built and silently discard the config on every later call. Switch buckets or log out and back in without a full page reload, and uploads keep going to the previous bucket with the previous credentials.

Adds a `disposeInstance()` static to both managers: cancels in-flight uploads and clears the singleton so the next `getInstance()` builds fresh. Called on every login (session restore and interactive) and on logout. Also fixes two races found in review — cancelling a queued item during dispose was starting the *next* queued item against the bucket being torn down, and a cancelled upload could still emit `'completed'` and trigger a data refresh mid-logout. Upload/delete history is now cleared on logout too, so records from one bucket can't show up after connecting to another.

## Related Issue

- Fixes #77
- Relates to #101

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## How to Test

1. `cd frontend; pnpm dev`
2. Connect to bucket A, start uploading a large file
3. Log out mid-upload, connect to bucket B, upload a file
4. Confirm the bucket-B upload lands in bucket B, not A
5. Confirm no stale upload/delete cards from bucket A appear after switching

## Checklist

- [x] Code follows the project's style guidelines (eslint + prettier pass)
- [x] Self-review completed
- [x] Code is properly commented
- [ ] Documentation updated — none exists for this yet
- [x] `tsc --noEmit` passes in both `frontend` and `s3-api`
- [x] `next build` succeeds

## Additional Notes

`s3-api` is bumped to `2.6.0` locally but **not published yet** — we're holding all publishes until the remaining priority fixes land, then publishing once. Until then this fix is dormant: `auth-context.tsx` feature-detects `disposeInstance` and falls back to today's behavior (with a console warning) against the currently-published `2.5.0`. No action needed here, just don't merge assuming this is live in production yet.
