### PR TITLE
fix: clear the search cache on logout and session start

### DIFF
--- a/frontend/src/context/auth-context.test.tsx
+++ b/frontend/src/context/auth-context.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useContext } from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { AuthContext, AuthProvider } from './auth-context';
+import { useSearchStore } from '@/features/dashboard/stores/use-search-store';
+import type { SearchResult } from '@opndrive/s3-api';
+
+/**
+ * Regression test for the search cache surviving a session change.
+ *
+ * The search store is module-level, so it outlives every component - but a
+ * bucket switch happens entirely client-side with no reload. clearSession()
+ * cleared the drive store and the upload store and left this one untouched,
+ * so repeating a search after switching accounts was served the previous
+ * account's object keys straight out of the 5 minute TTL cache.
+ *
+ * This mounts the real AuthProvider rather than asserting on the store in
+ * isolation. A store-only test would pass with or without the fix, since
+ * clearCache() already existed and worked - the defect was that nothing in
+ * the session lifecycle ever called it.
+ */
+
+const pushMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => '/dashboard',
+}));
+
+vi.mock('@opndrive/s3-api', () => ({
+  BYOS3ApiProvider: class {
+    getS3Client() {
+      return {};
+    }
+    getBucketName() {
+      return 'test-bucket';
+    }
+  },
+  UploadManager: {
+    getInstance: () => ({}),
+    disposeInstance: async () => {},
+  },
+  SignedUrlUploadManager: {
+    getInstance: () => ({}),
+    disposeInstance: async () => {},
+  },
+}));
+
+const bucketAResults: SearchResult = {
+  files: [{ Key: 'private/bucket-a/salaries.xlsx' } as never],
+  folders: [{ Key: 'private/bucket-a/' } as never],
+  totalFiles: 1,
+  totalFolders: 1,
+  totalKeys: 2,
+  isTruncated: false,
+};
+
+function SessionControls() {
+  const { clearSession, createSession } = useContext(AuthContext);
+  return (
+    <div>
+      <button onClick={() => clearSession()}>logout</button>
+      <button
+        onClick={() =>
+          void createSession({
+            accessKeyId: 'AKIA_B',
+            secretAccessKey: 'secret-b',
+            region: 'us-east-1',
+          } as never)
+        }
+      >
+        connect
+      </button>
+    </div>
+  );
+}
+
+async function renderProvider() {
+  render(
+    <AuthProvider>
+      <SessionControls />
+    </AuthProvider>
+  );
+  // AuthProvider swaps children for a placeholder until its restore pass
+  // settles, so wait for the controls to actually exist.
+  await waitFor(() => expect(screen.getByText('logout')).toBeDefined());
+}
+
+describe('session changes must not leak the search cache', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    localStorage.clear();
+    useSearchStore.getState().clearCache();
+    useSearchStore.getState().setLoading(false);
+  });
+
+  it('clears cached search results on logout', async () => {
+    await renderProvider();
+
+    useSearchStore.getState().setSearchResults('payroll', '', bucketAResults);
+    useSearchStore.getState().setCurrentQuery('payroll', '');
+    // Precondition: the cache really does answer a repeat query. If this stops
+    // holding, the leak stops existing and so does the need for the fix.
+    expect(useSearchStore.getState().getCachedOrNull('payroll', '')).not.toBeNull();
+
+    await act(async () => {
+      screen.getByText('logout').click();
+    });
+
+    expect(useSearchStore.getState().getCachedOrNull('payroll', '')).toBeNull();
+    expect(useSearchStore.getState().searchCache.size).toBe(0);
+    expect(useSearchStore.getState().currentQuery).toBeNull();
+  });
+
+  it('clears cached search results when a new session starts', async () => {
+    await renderProvider();
+
+    useSearchStore.getState().setSearchResults('payroll', '', bucketAResults);
+    expect(useSearchStore.getState().getCachedOrNull('payroll', '')).not.toBeNull();
+
+    // /connect is reachable client-side without logging out first, so a
+    // session can begin without clearSession ever having run.
+    await act(async () => {
+      screen.getByText('connect').click();
+    });
+
+    await waitFor(() =>
+      expect(useSearchStore.getState().getCachedOrNull('payroll', '')).toBeNull()
+    );
+    expect(useSearchStore.getState().searchCache.size).toBe(0);
+  });
+});

--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -11,6 +11,7 @@ import {
 } from '@opndrive/s3-api';
 import { useDriveStore } from './data-context';
 import { useUploadStore } from '@/features/upload/stores/use-upload-store';
+import { useSearchStore } from '@/features/dashboard/stores/use-search-store';
 
 interface AuthContextType {
   apiS3: BYOS3ApiProvider | null;
@@ -78,6 +79,13 @@ async function initializeUploadManagers(
   creds: Credentials
 ): Promise<{ manager: UploadManager; signedUrlManager: SignedUrlUploadManager }> {
   await disposeUploadManagers();
+
+  // Establishing a session must not inherit a previous one's search results.
+  // clearSession() already does this, but /connect is reachable client-side
+  // without logging out first, so a session can start without one ever having
+  // been cleared. Same belt-and-braces reasoning as disposing the upload
+  // managers on both edges rather than only on logout.
+  useSearchStore.getState().clearCache();
 
   const manager = UploadManager.getInstance({
     s3: api.getS3Client(),
@@ -162,6 +170,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     };
 
     checkAuth();
+    // Mount-only on purpose. This restores a persisted session exactly once
+    // per app load; including `pathname`/`router` would re-run the whole
+    // restore on every client-side navigation, and including `clearSession`
+    // would re-run it whenever the provider re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Create a session & persist in localStorage
@@ -214,6 +227,13 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       // UploadProvider unmounts - without this, records from this bucket would
       // still be on screen after connecting to a different one.
       useUploadStore.getState().clearSessionData();
+
+      // And the search cache, which holds raw object keys from this bucket.
+      // It is keyed by query+prefix with a 5 minute TTL and nothing else
+      // clears it, so without this a repeat search after switching accounts
+      // is served the previous account's file and folder names straight out
+      // of memory.
+      useSearchStore.getState().clearCache();
 
       // Clear localStorage
       localStorage.removeItem(STORAGE_KEY);


### PR DESCRIPTION
The search store held raw object keys with a five minute TTL and nothing in the session lifecycle ever cleared it, so reconnecting to a different bucket and repeating a query served the previous account's file and folder names out of memory.

Cleared on both edges, matching how the upload managers are disposed, since /connect is reachable without logging out first.
