### PR TITLE
style: fix prettier formatting in file-preview.ts

### DIFF
--- a/frontend/src/types/file-preview.ts
+++ b/frontend/src/types/file-preview.ts
@@ -15,13 +15,7 @@ export interface PreviewableFile {
 }
 
 export type FilePreviewType =
-  | 'image'
-  | 'pdf'
-  | 'document'
-  | 'code'
-  | 'video'
-  | 'audio'
-  | 'unsupported';
+  'image' | 'pdf' | 'document' | 'code' | 'video' | 'audio' | 'unsupported';
 
 export interface FilePreviewState {
   isOpen: boolean;


### PR DESCRIPTION
## What this does

Fixes the sole formatting violation flagged by CI's `Format check` step — `frontend/src/types/file-preview.ts`, collapsing the manually-line-broken union type onto one line per Prettier's default formatting.

## Why

This has been failing CI on `main` for a while (pre-dates PR #117 and #116 — last touched in an unrelated commit). It was called out explicitly in #117's description as an existing, unrelated baseline issue, and it's currently the only reason `Lint & format` / `CI OK` show red on main.

No logic changes — purely `prettier --write` output.

## Verification

- `pnpm exec prettier --check "frontend/src/types/file-preview.ts"` passes now.