### PR TITLE
fix: real download progress, working cancel, and correct filenames (#84)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "@aws-sdk/client-s3": "^3.1095.0",
     "@hookform/resolvers": "^4.1.3",
     "@monaco-editor/react": "^4.7.0",
-    "@opndrive/s3-api": "^2.5.0",
+    "@opndrive/s3-api": "^2.8.0",
     "@radix-ui/react-alert-dialog": "^1.1.23",
     "@radix-ui/react-avatar": "^1.2.6",
     "@radix-ui/react-checkbox": "^1.3.11",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@opndrive/s3-api':
-        specifier: ^2.5.0
-        version: 2.5.0
+        specifier: ^2.8.0
+        version: 2.8.0
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.23
         version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -225,10 +225,6 @@ packages:
     resolution: {integrity: sha512-eeobm3TKci47CTTHIxc5s5UDjLL0gTKfjlcyzKU+NMoeIJ3flKPq51Fhi2nUDiMNbzsY5HAynM3bHAQFHxRTUw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.862.0':
-    resolution: {integrity: sha512-oJ5Au3QCAQmOmh7PD7dUxnPDxWsT9Z95XEOiJV027//11pwRSUMiNSvW8srPa3i7CZRNjz5QHX6O4KqX9PxNsQ==}
-    engines: {node: '>=18.0.0'}
-
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
@@ -265,10 +261,6 @@ packages:
     resolution: {integrity: sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.862.0':
-    resolution: {integrity: sha512-rDRHxxZuY9E7py/OVYN1VQRAw0efEThvK5sZ3HfNNpL6Zk4HeOGtc6NtULSfeCeyHCVlJsdOVkIxJge2Ax5vSA==}
-    engines: {node: '>=18.0.0'}
-
   '@aws-sdk/middleware-sdk-s3@3.972.66':
     resolution: {integrity: sha512-sTZKP1+SvyzWc/3alO8AM/PUiEzDCmn2P/KOcFFSk2UKzKZkB5ZxXdlHVtACE7DHaMFvx6DY0bognwHa1qTv4g==}
     engines: {node: '>=20.0.0'}
@@ -277,13 +269,9 @@ packages:
     resolution: {integrity: sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/s3-request-presigner@3.862.0':
-    resolution: {integrity: sha512-GkWvScAlg1YPLBc7tXmaMJ3i3qi6pCbKmMASnwcSdJufWQtnMqXwiHzDlxheGodx68MC/sOryuQGtKVdAkPwOg==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.862.0':
-    resolution: {integrity: sha512-ZAjrbXnu3yTxXMPiEVxDP/I8zfssrLQGgUi0NgJP6Cz/mOS/S/3hfOZrMown1jLhkTrzLpjNE8Q2n18VtRbScQ==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/s3-request-presigner@3.1095.0':
+    resolution: {integrity: sha512-Xhzt3Okc8UrxOnOR8zE2/aG12g8A9I9f8DVF4LX9k3QVKt0c7d9wT4VcM5/6gfFRhtsflFMGdo49pEqawiAS2Q==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.42':
     resolution: {integrity: sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==}
@@ -293,25 +281,9 @@ packages:
     resolution: {integrity: sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.862.0':
-    resolution: {integrity: sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==}
-    engines: {node: '>=18.0.0'}
-
   '@aws-sdk/types@3.974.2':
     resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-arn-parser@3.804.0':
-    resolution: {integrity: sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/util-format-url@3.862.0':
-    resolution: {integrity: sha512-4kd2PYUMA/fAnIcVVwBIDCa2KCuUPrS3ELgScLjBaESP0NN+K163m40U5RbzNec/elOcJHR8lEThzzSb7vXH6w==}
-    engines: {node: '>=18.0.0'}
-
-  '@aws-sdk/xml-builder@3.862.0':
-    resolution: {integrity: sha512-6Ed0kmC1NMbuFTEgNmamAUU1h5gShgxL1hBVLbEzUa3trX5aJBz1vU4bXaBTvOYUAnOHtiy1Ml4AMStd6hJnFA==}
-    engines: {node: '>=18.0.0'}
 
   '@aws-sdk/xml-builder@3.972.37':
     resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
@@ -929,8 +901,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@opndrive/s3-api@2.5.0':
-    resolution: {integrity: sha512-S4mpXxgjt7pXkOP9zTlsS3YDJjzKO+vbEhQvUb733cYAja6dhDSRgwKL5FJPwcDDizgWgWX0QydguuSwVML9Yg==}
+  '@opndrive/s3-api@2.8.0':
+    resolution: {integrity: sha512-3h02ckmg7EhMqXZ97SFSRNdiAGZ3CBjGG7aGfIdXg4MlptN7VmVuIbXQBGBHXziLqle17D9PIAW+AOYdC01yBw==}
 
   '@radix-ui/number@1.1.3':
     resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
@@ -1532,64 +1504,16 @@ packages:
     resolution: {integrity: sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.6.14':
-    resolution: {integrity: sha512-QEeW1R9y4ShiTEqCRibijbUtdT435QneaLZnVvII+wCh+WZk9JIE2wA5k8z3/eqfxfqfSb8NdonIh/zP0+akRg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.5.14':
-    resolution: {integrity: sha512-6iv9dLiDX4he0KLFr2vw2u98Q+lIEsF0G+1MZVy5kWjZRLYXvY6S4uJ+R3aC4xYBkjljAtCB3uG9Y8pBL3O3Ug==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.9.11':
     resolution: {integrity: sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.4.14':
-    resolution: {integrity: sha512-zF/MIfH99pVoYWZedI87udXf3NpSf8xvwIWD77rQ3qcD7rpCxyabweinDJw1DRGN+vdQ/LcolY87L4rsJ/gPdA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.5.14':
-    resolution: {integrity: sha512-R+aYfS8kDXMwO+LfpiWTJjjUsR+se4cd2ZBjMU3fqJmoSZ1jenTpgb4/k1SvvXcM9f0232KvufZoO5XRWoiPBw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-builder@4.4.14':
-    resolution: {integrity: sha512-jdEhAXhZnkigO6tMNqSfyPu3d+fyW3kcV9dpWh0609f2U/M/RISKvpFzBAf5nUPbIFZuKvg+eLavCkYQBs2xdA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.10':
     resolution: {integrity: sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.14.14':
-    resolution: {integrity: sha512-epzar5Uc3+YZ8jNybEzz4R4cZva2bJqg2QyHRt+kR2oMK9EWJFW1MsuBszU0exjfR6ziYfapxJGRlFdnSMA91Q==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/types@4.16.1':
     resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.5.14':
-    resolution: {integrity: sha512-intksPGZMv2v+neBuH90UQH6b1th+YBiUG9wNXZMwnQZJRiInU5QnY8DAWbvlqP1H+f/08j8vRXcoU1ZHOOKtg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-browser@4.4.14':
-    resolution: {integrity: sha512-uKX3MPwdx7+REHZQsZ9EVc650vKqz58zEMD0PCnRW7kUCxcaJjLE31upDU1uI8g6ewrxbvDV5+720Ny6l+i8SA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-config-provider@4.4.14':
-    resolution: {integrity: sha512-Vyjv65ZzYGl5hCUtKAyGFDAy2UMdMDzXRQsNFR58PTEu/dIEIaSSHkvWp6pfbDmVJ3OXRrNQaIh2zlxiGKRc9w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-middleware@4.4.14':
-    resolution: {integrity: sha512-KBcBQhuWujUMyU/lqCDlQHSfComVk2DJeK4dJGeoJm+aQlo6CbnIZw3G6THPdZwGyVhDJd5yzx8pqMTo5kcSZg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.7.14':
-    resolution: {integrity: sha512-92Y8IdPUdtpdjt2OUxdLCJhHO05RfulfOLQG1A29x8nI4SZ0U3WpkdZWRkI8oCkU11E1qmjzJ/OszpDjtMNWPA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-utf8@4.4.14':
-    resolution: {integrity: sha512-zpHIvgr2NWASkgWgv1O0zPPX7VFdkHKa9NxxjGseGvSY2DRZgRsnoXuEcjETwPeqP92blsINwfbIJz0F0/0Skg==}
     engines: {node: '>=18.0.0'}
 
   '@standard-schema/utils@0.3.0':
@@ -1870,9 +1794,6 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  anynum@1.0.1:
-    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
-
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -2124,10 +2045,6 @@ packages:
   fast-equals@5.2.2:
     resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
     engines: {node: '>=6.0.0'}
-
-  fast-xml-parser@5.2.5:
-    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
-    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2674,9 +2591,6 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  strnum@2.4.1:
-    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
-
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2804,8 +2718,8 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@13.0.2:
-    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   victory-vendor@36.9.2:
@@ -3012,24 +2926,6 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.862.0':
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/xml-builder': 3.862.0
-      '@smithy/core': 3.30.0
-      '@smithy/node-config-provider': 4.5.14
-      '@smithy/property-provider': 4.4.14
-      '@smithy/protocol-http': 5.5.14
-      '@smithy/signature-v4': 5.6.10
-      '@smithy/smithy-client': 4.14.14
-      '@smithy/types': 4.16.1
-      '@smithy/util-base64': 4.5.14
-      '@smithy/util-body-length-browser': 4.4.14
-      '@smithy/util-middleware': 4.4.14
-      '@smithy/util-utf8': 4.4.14
-      fast-xml-parser: 5.2.5
-      tslib: 2.8.1
-
   '@aws-sdk/core@3.977.1':
     dependencies:
       '@aws-sdk/types': 3.974.2
@@ -3125,23 +3021,6 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.862.0':
-    dependencies:
-      '@aws-sdk/core': 3.862.0
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/util-arn-parser': 3.804.0
-      '@smithy/core': 3.30.0
-      '@smithy/node-config-provider': 4.5.14
-      '@smithy/protocol-http': 5.5.14
-      '@smithy/signature-v4': 5.6.10
-      '@smithy/smithy-client': 4.14.14
-      '@smithy/types': 4.16.1
-      '@smithy/util-config-provider': 4.4.14
-      '@smithy/util-middleware': 4.4.14
-      '@smithy/util-stream': 4.7.14
-      '@smithy/util-utf8': 4.4.14
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-sdk-s3@3.972.66':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -3162,23 +3041,12 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/s3-request-presigner@3.862.0':
+  '@aws-sdk/s3-request-presigner@3.1095.0':
     dependencies:
-      '@aws-sdk/signature-v4-multi-region': 3.862.0
-      '@aws-sdk/types': 3.862.0
-      '@aws-sdk/util-format-url': 3.862.0
-      '@smithy/middleware-endpoint': 4.6.14
-      '@smithy/protocol-http': 5.5.14
-      '@smithy/smithy-client': 4.14.14
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.862.0':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.862.0
-      '@aws-sdk/types': 3.862.0
-      '@smithy/protocol-http': 5.5.14
-      '@smithy/signature-v4': 5.6.10
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.42
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -3198,28 +3066,7 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/types@3.862.0':
-    dependencies:
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
   '@aws-sdk/types@3.974.2':
-    dependencies:
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-arn-parser@3.804.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-format-url@3.862.0':
-    dependencies:
-      '@aws-sdk/types': 3.862.0
-      '@smithy/querystring-builder': 4.4.14
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.862.0':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -3693,12 +3540,12 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.22':
     optional: true
 
-  '@opndrive/s3-api@2.5.0':
+  '@opndrive/s3-api@2.8.0':
     dependencies:
       '@aws-sdk/client-s3': 3.1095.0
-      '@aws-sdk/s3-request-presigner': 3.862.0
+      '@aws-sdk/s3-request-presigner': 3.1095.0
       dotenv: 17.4.2
-      uuid: 13.0.2
+      uuid: 14.0.1
 
   '@radix-ui/number@1.1.3': {}
 
@@ -4258,35 +4105,10 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.6.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.5.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
   '@smithy/node-http-handler@4.9.11':
     dependencies:
       '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@smithy/property-provider@4.4.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.5.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.4.14':
-    dependencies:
-      '@smithy/core': 3.30.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.10':
@@ -4295,44 +4117,8 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.14.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
   '@smithy/types@4.16.1':
     dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.5.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.4.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
-  '@smithy/util-config-provider@4.4.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@4.4.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.7.14':
-    dependencies:
-      '@smithy/core': 3.30.0
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@4.4.14':
-    dependencies:
-      '@smithy/core': 3.30.0
       tslib: 2.8.1
 
   '@standard-schema/utils@0.3.0': {}
@@ -4620,8 +4406,6 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  anynum@1.0.1: {}
-
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -4863,10 +4647,6 @@ snapshots:
   expect-type@1.4.0: {}
 
   fast-equals@5.2.2: {}
-
-  fast-xml-parser@5.2.5:
-    dependencies:
-      strnum: 2.4.1
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -5410,10 +5190,6 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strnum@2.4.1:
-    dependencies:
-      anynum: 1.0.1
-
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
@@ -5504,7 +5280,7 @@ snapshots:
 
   uuid@11.1.1: {}
 
-  uuid@13.0.2: {}
+  uuid@14.0.1: {}
 
   victory-vendor@36.9.2:
     dependencies:

--- a/frontend/src/components/file-preview/preview-content.tsx
+++ b/frontend/src/components/file-preview/preview-content.tsx
@@ -10,7 +10,7 @@ import { ExcelViewer } from './viewers/excel-viewer';
 import { CodeViewer } from './viewers/code-viewer';
 import { checkPreviewEligibility } from '@/services/file-size-limits';
 import { Download } from 'lucide-react';
-import { useDownload } from '@/features/dashboard/hooks/use-download';
+import { useDownloadActions, useIsFileDownloading } from '@/features/dashboard/hooks/use-download';
 import {
   isFileInCategory,
   getFileExtension,
@@ -30,7 +30,8 @@ function isFileType(
 }
 
 export function PreviewContent({ file }: PreviewContentProps) {
-  const { downloadFile, isDownloading } = useDownload();
+  const { downloadFile } = useDownloadActions();
+  const isDownloading = useIsFileDownloading(file.id);
 
   // Get file size from either 'size' or 'Size' property
   const fileSize =
@@ -109,10 +110,10 @@ export function PreviewContent({ file }: PreviewContentProps) {
               color: 'var(--primary-foreground)',
             }}
             onClick={handleDownload}
-            disabled={isDownloading(file.id)}
+            disabled={isDownloading}
           >
             <Download size={18} />
-            {isDownloading(file.id) ? 'Downloading...' : 'Download File'}
+            {isDownloading ? 'Downloading...' : 'Download File'}
           </button>
         </div>
       </div>

--- a/frontend/src/components/file-preview/preview-header.tsx
+++ b/frontend/src/components/file-preview/preview-header.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { X, Download, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/shared/components/ui/button';
 import { PreviewableFile } from '@/types/file-preview';
-import { useDownload } from '@/features/dashboard/hooks/use-download';
+import { useDownloadActions, useIsFileDownloading } from '@/features/dashboard/hooks/use-download';
 import { FileIcon } from '@/shared/components/icons/file-icons';
 import { FileExtension } from '@/features/dashboard/types/file';
 import { getFileExtensionWithoutDot, getEffectiveExtension } from '@/config/file-extensions';
@@ -32,7 +32,8 @@ export function PreviewHeader({
   canNavigateNext,
   canNavigatePrevious,
 }: PreviewHeaderProps) {
-  const { downloadFile, isDownloading } = useDownload();
+  const { downloadFile } = useDownloadActions();
+  const isDownloading = useIsFileDownloading(file.id);
 
   const handleDownload = () => {
     const fileItem = {
@@ -165,7 +166,7 @@ export function PreviewHeader({
           variant="ghost"
           size="icon"
           onClick={handleDownload}
-          disabled={isDownloading(file.id)}
+          disabled={isDownloading}
           className="hover:bg-accent h-8 w-8 sm:h-10 sm:w-10 rounded-full"
           style={{ color: 'var(--foreground)' }}
           title="Download file"

--- a/frontend/src/features/dashboard/components/ui/download-progress-manager.tsx
+++ b/frontend/src/features/dashboard/components/ui/download-progress-manager.tsx
@@ -2,12 +2,12 @@
 
 import React from 'react';
 import { X, Download, CheckCircle, AlertCircle } from 'lucide-react';
-import { useDownload } from '@/features/dashboard/hooks/use-download';
+import { useDownloadList } from '@/features/dashboard/hooks/use-download';
 import { cn } from '@/shared/utils/utils';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 
 export const DownloadProgressManager: React.FC = () => {
-  const { getAllDownloads, cancelDownload } = useDownload();
+  const { getAllDownloads, cancelDownload } = useDownloadList();
   const downloads = getAllDownloads();
 
   if (downloads.length === 0) return null;

--- a/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.tsx
@@ -13,7 +13,7 @@ import {
   ChevronRight,
   ExternalLink,
 } from 'lucide-react';
-import { useDownload } from '@/features/dashboard/hooks/use-download';
+import { useDownloadActions, useIsFileDownloading } from '@/features/dashboard/hooks/use-download';
 import { useDeleteWithProgress } from '@/features/dashboard/hooks/use-delete-with-progress';
 import { useRename } from '@/context/rename-context';
 import { useDetails } from '@/context/details-context';
@@ -56,7 +56,8 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
   );
   const [openWithButtonRef, setOpenWithButtonRef] = useState<HTMLButtonElement | null>(null);
 
-  const { downloadFile, isDownloading } = useDownload();
+  const { downloadFile } = useDownloadActions();
+  const isDownloading = useIsFileDownloading(file.id);
   const { isRenaming, showRenameDialog: openRenameDialog } = useRename();
   const { open: openDetails } = useDetails();
   const { openPreview } = useFilePreview();
@@ -105,80 +106,82 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
     onClose();
   };
 
-  const getDefaultFileMenuActions = (file: FileItem): FileMenuAction[] => [
-    {
-      id: 'open',
-      label: 'Open with',
-      icon: MdOpenWith,
-      // This will be handled specially to show submenu
-      onClick: () => {
-        // Submenu handles the actual actions
-      },
-    },
-    {
-      id: 'download',
-      label: 'Download',
-      icon: Download,
-      disabled: isDownloading(file.id),
-      onClick: (file) => {
-        setTimeout(() => downloadFile(file), 0);
-        onClose();
-      },
-    },
-    {
-      id: 'share',
-      label: 'Share',
-      icon: Share,
-      onClick: () => {
-        openShareDialog(file);
-        onClose();
-      },
-    },
-    {
-      id: 'rename',
-      label: 'Rename',
-      icon: Edit3,
-      disabled: isRenaming(file.id || file.Key || file.name),
-      onClick: () => {
-        openRenameDialog(file, 'file', currentPrefix || '');
-        onClose();
-      },
-    },
-    {
-      id: 'info',
-      label: 'File information',
-      icon: Info,
-      onClick: () => {
-        openDetails(file);
-        onClose();
-      },
-    },
-    {
-      id: 'delete',
-      label: isDeleting(file.id || file.Key || file.name) ? 'Deleting...' : 'Delete forever',
-      icon: Trash2,
-      variant: 'destructive' as const,
-      disabled: isDeleting(file.id || file.Key || file.name),
-      onClick: async () => {
-        const confirmDelete = window.confirm(
-          `Are you sure you want to delete "${file.name}" forever? This action cannot be undone.`
-        );
-
-        if (confirmDelete) {
-          try {
-            await deleteFile(file);
-          } catch (error) {
-            console.error('Delete failed:', error);
-          }
-        }
-        onClose();
-      },
-    },
-  ];
-
   // Merge additional actions with default actions
   const actions = React.useMemo(() => {
-    const defaultActions = getDefaultFileMenuActions(file);
+    // Built inside the memo so React can see what it actually depends on. As a
+    // hoisted helper its live reads - download/rename/delete `disabled` - were
+    // invisible to the dependency array, so those states stayed stale until an
+    // unrelated prop happened to change.
+    const defaultActions: FileMenuAction[] = [
+      {
+        id: 'open',
+        label: 'Open with',
+        icon: MdOpenWith,
+        // This will be handled specially to show submenu
+        onClick: () => {
+          // Submenu handles the actual actions
+        },
+      },
+      {
+        id: 'download',
+        label: 'Download',
+        icon: Download,
+        disabled: isDownloading,
+        onClick: (file) => {
+          setTimeout(() => downloadFile(file), 0);
+          onClose();
+        },
+      },
+      {
+        id: 'share',
+        label: 'Share',
+        icon: Share,
+        onClick: () => {
+          openShareDialog(file);
+          onClose();
+        },
+      },
+      {
+        id: 'rename',
+        label: 'Rename',
+        icon: Edit3,
+        disabled: isRenaming(file.id || file.Key || file.name),
+        onClick: () => {
+          openRenameDialog(file, 'file', currentPrefix || '');
+          onClose();
+        },
+      },
+      {
+        id: 'info',
+        label: 'File information',
+        icon: Info,
+        onClick: () => {
+          openDetails(file);
+          onClose();
+        },
+      },
+      {
+        id: 'delete',
+        label: isDeleting(file.id || file.Key || file.name) ? 'Deleting...' : 'Delete forever',
+        icon: Trash2,
+        variant: 'destructive' as const,
+        disabled: isDeleting(file.id || file.Key || file.name),
+        onClick: async () => {
+          const confirmDelete = window.confirm(
+            `Are you sure you want to delete "${file.name}" forever? This action cannot be undone.`
+          );
+
+          if (confirmDelete) {
+            try {
+              await deleteFile(file);
+            } catch (error) {
+              console.error('Delete failed:', error);
+            }
+          }
+          onClose();
+        },
+      },
+    ];
 
     if (additionalActions.length === 0) {
       return defaultActions;
@@ -200,7 +203,21 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
       ...additionalActions,
       ...defaultActions.slice(insertIndex + 1),
     ];
-  }, [file, additionalActions, insertAdditionalActionsAfter]);
+  }, [
+    file,
+    additionalActions,
+    insertAdditionalActionsAfter,
+    isDownloading,
+    downloadFile,
+    onClose,
+    openShareDialog,
+    isRenaming,
+    openRenameDialog,
+    currentPrefix,
+    openDetails,
+    isDeleting,
+    deleteFile,
+  ]);
 
   // Prevent body scroll when menu is open
   useEffect(() => {

--- a/frontend/src/features/dashboard/hooks/use-download.ts
+++ b/frontend/src/features/dashboard/hooks/use-download.ts
@@ -1,138 +1,120 @@
-import { useState, useCallback } from 'react';
-import { createDownloadService, type DownloadProgress } from '../services/download-service';
+import { useCallback, useMemo } from 'react';
+import { type DownloadProgress } from '../services/download-service';
+import { useDownloadStore } from '../stores/use-download-store';
 import { useNotification } from '@/context/notification-context';
 import type { FileItem } from '@/features/dashboard/types/file';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
 
-export const useDownload = () => {
-  const [downloadProgress, setDownloadProgress] = useState<Map<string, DownloadProgress>>(
-    new Map()
-  );
+/**
+ * How many files stream at once when several are downloaded together.
+ *
+ * Each in-flight download buffers its whole body in memory before handing it to
+ * disk, so an unbounded fan-out over a multi-select turns straight into peak
+ * RAM. Three keeps the pipe busy without letting a 20-file selection allocate
+ * twenty file bodies at the same time.
+ */
+const MULTI_DOWNLOAD_CONCURRENCY = 3;
 
+/** Runs `task` over `items`, keeping at most `limit` in flight. */
+async function withConcurrency<T>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<void>
+): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const item = items[cursor++];
+      await task(item);
+    }
+  });
+  await Promise.all(workers);
+}
+
+/**
+ * Actions only - deliberately subscribes to no store state.
+ *
+ * Zustand action identities are stable, so components using this hook do not
+ * re-render as progress ticks. This matters because the overflow menu mounts
+ * once per file row: subscribing it to the downloads map would re-render every
+ * row in the listing on every chunk of every download.
+ */
+export const useDownloadActions = () => {
   const { error: showError, info } = useNotification();
   const { apiS3 } = useAuthGuard();
 
-  if (!apiS3) {
-    return {
-      downloadFile: async () => {},
-      downloadMultipleFiles: async () => {},
-      cancelDownload: () => {},
-      isDownloading: () => false,
-      getAllDownloads: () => [],
-      downloadProgress: [],
-    };
-  }
-
-  const downloadService = createDownloadService(apiS3);
-
-  const updateProgress = useCallback((progress: DownloadProgress) => {
-    setDownloadProgress((prev) => new Map(prev.set(progress.fileId, progress)));
-  }, []);
-
-  const handleComplete = useCallback((fileId: string) => {
-    setDownloadProgress((prev) => {
-      const newMap = new Map(prev);
-      const progress = newMap.get(fileId);
-      if (progress) {
-        newMap.set(fileId, { ...progress, status: 'completed', progress: 100 });
-      }
-      return newMap;
-    });
-
-    setTimeout(() => {
-      setDownloadProgress((prev) => {
-        const newMap = new Map(prev);
-        newMap.delete(fileId);
-        return newMap;
-      });
-    }, 3000);
-  }, []);
+  const startDownload = useDownloadStore((state) => state.startDownload);
+  const cancelInStore = useDownloadStore((state) => state.cancelDownload);
 
   const handleError = useCallback(
-    (fileId: string, error: string) => {
-      setDownloadProgress((prev) => {
-        const newMap = new Map(prev);
-        const progress = newMap.get(fileId);
-        if (progress) {
-          newMap.set(fileId, { ...progress, status: 'error', error });
-          showError(`Failed to download ${progress.fileName}`);
-        }
-        return newMap;
-      });
+    (_fileId: string, error: string) => {
+      showError(error);
     },
     [showError]
   );
 
   const downloadFile = useCallback(
     async (file: FileItem) => {
+      // Guarded here rather than by an early return above the hooks: bailing out
+      // before the useCallbacks changed the hook count between renders once
+      // apiS3 resolved, which React rejects outright.
+      if (!apiS3) return;
+
       try {
-        await downloadService.downloadFile(file, {
-          onProgress: updateProgress,
-          onComplete: handleComplete,
-          onError: handleError,
-        });
+        await startDownload(apiS3, file, { onError: handleError });
       } catch (error) {
         showError(`Failed to download ${file.name}, ${error}`);
       }
     },
-    [updateProgress, handleComplete, handleError, showError]
+    [apiS3, startDownload, handleError, showError]
   );
 
   const downloadMultipleFiles = useCallback(
     async (files: FileItem[]) => {
-      if (files.length === 0) return;
+      if (!apiS3 || files.length === 0) return;
 
       info(`Downloading ${files.length} file${files.length > 1 ? 's' : ''}...`);
-
-      // Start all downloads immediately
-      files.forEach((file) => {
-        downloadFile(file);
-      });
+      await withConcurrency(files, MULTI_DOWNLOAD_CONCURRENCY, downloadFile);
     },
-    [downloadFile, info]
+    [apiS3, downloadFile, info]
   );
 
   const cancelDownload = useCallback(
     (fileId: string) => {
-      downloadService.cancelDownload(fileId);
-      setDownloadProgress((prev) => {
-        const newMap = new Map(prev);
-        const progress = newMap.get(fileId);
-        if (progress) {
-          newMap.set(fileId, { ...progress, status: 'cancelled' });
-          setTimeout(() => {
-            setDownloadProgress((current) => {
-              const updated = new Map(current);
-              updated.delete(fileId);
-              return updated;
-            });
-          }, 2000);
-        }
-        return newMap;
-      });
+      cancelInStore(fileId);
       info('Download cancelled');
     },
-    [info]
+    [cancelInStore, info]
   );
 
-  const isDownloading = useCallback(
-    (fileId: string): boolean => {
-      const progress = downloadProgress.get(fileId);
-      return progress?.status === 'downloading' || progress?.status === 'pending';
-    },
+  return { downloadFile, downloadMultipleFiles, cancelDownload };
+};
+
+/**
+ * Subscribes to a single file's download state.
+ *
+ * The selector collapses to a boolean, so a row re-renders only when its own
+ * download starts or stops - not on every progress update of every file.
+ */
+export const useIsFileDownloading = (fileId: string): boolean =>
+  useDownloadStore((state) => {
+    const status = state.downloads.get(fileId)?.status;
+    return status === 'downloading' || status === 'pending' || status === 'queued';
+  });
+
+/**
+ * Full download list. Only for the components that render progress UI - this
+ * re-renders on every progress update by design.
+ */
+export const useDownloadList = () => {
+  const downloads = useDownloadStore((state) => state.downloads);
+  const { cancelDownload } = useDownloadActions();
+
+  const downloadProgress = useMemo(() => Array.from(downloads.values()), [downloads]);
+  const getAllDownloads = useCallback(
+    (): DownloadProgress[] => downloadProgress,
     [downloadProgress]
   );
 
-  const getAllDownloads = useCallback((): DownloadProgress[] => {
-    return Array.from(downloadProgress.values());
-  }, [downloadProgress]);
-
-  return {
-    downloadFile,
-    downloadMultipleFiles,
-    cancelDownload,
-    isDownloading,
-    getAllDownloads,
-    downloadProgress: Array.from(downloadProgress.values()),
-  };
+  return { downloadProgress, getAllDownloads, cancelDownload };
 };

--- a/frontend/src/features/dashboard/hooks/use-multi-select-actions.ts
+++ b/frontend/src/features/dashboard/hooks/use-multi-select-actions.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { FileItem } from '../types/file';
 import { Folder } from '../types/folder';
-import { useDownload } from './use-download';
+import { useDownloadActions } from './use-download';
 import { useDeleteWithProgress } from './use-delete-with-progress';
 import { useFilePreview } from '@/context/file-preview-context';
 import { getFileExtensionWithoutDot } from '@/config/file-extensions';
@@ -12,7 +12,7 @@ interface UseMultiSelectActionsProps {
 }
 
 export function useMultiSelectActions({ openMultiShareDialog }: UseMultiSelectActionsProps) {
-  const { downloadMultipleFiles } = useDownload();
+  const { downloadMultipleFiles } = useDownloadActions();
   const { deleteFile, deleteFolder, batchDeleteFiles } = useDeleteWithProgress();
   const { openPreview } = useFilePreview();
   const { clearSelection } = useMultiSelectStore();

--- a/frontend/src/features/dashboard/services/download-service.test.ts
+++ b/frontend/src/features/dashboard/services/download-service.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { BYOS3ApiProvider } from '@opndrive/s3-api';
+import { createDownloadService, type DownloadProgress } from './download-service';
+import type { FileItem } from '../types/file';
+
+const SIGNED_URL = 'https://test-bucket.s3.amazonaws.com/folder/abc123hash?X-Amz-Signature=sig';
+
+function makeFile(overrides: Partial<FileItem> = {}): FileItem {
+  return {
+    id: 'file-1',
+    name: 'quarterly report.pdf',
+    Key: 'folder/abc123hash',
+    Size: 12,
+    extension: 'pdf',
+    size: { value: 12, unit: 'B' },
+    ...overrides,
+  } as FileItem;
+}
+
+function makeApi(getSignedUrl = vi.fn().mockResolvedValue(SIGNED_URL)) {
+  return { getSignedUrl } as unknown as BYOS3ApiProvider;
+}
+
+/**
+ * Minimal Response stand-in. The service only reads ok/status/headers/body/blob,
+ * and hand-rolling it keeps the chunk boundaries exact so progress values are
+ * predictable.
+ */
+function streamingResponse(chunks: Uint8Array[], opts: { contentLength?: number } = {}) {
+  const total = opts.contentLength ?? chunks.reduce((n, c) => n + c.byteLength, 0);
+  const headers = new Headers();
+  if (opts.contentLength !== 0) headers.set('Content-Length', String(total));
+
+  return {
+    ok: true,
+    status: 200,
+    headers,
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        chunks.forEach((chunk) => controller.enqueue(chunk));
+        controller.close();
+      },
+    }),
+    blob: async () => new Blob(chunks as BlobPart[]),
+  } as unknown as Response;
+}
+
+/** A stream that yields one chunk then stalls until the signal aborts it. */
+function stallingResponse(signal: AbortSignal, first: Uint8Array) {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'Content-Length': '1000' }),
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(first);
+        signal.addEventListener('abort', () =>
+          controller.error(new DOMException('Aborted', 'AbortError'))
+        );
+      },
+    }),
+  } as unknown as Response;
+}
+
+let clicks: { href: string; download: string }[];
+let revoked: string[];
+
+beforeEach(() => {
+  clicks = [];
+  revoked = [];
+
+  // jsdom implements neither of these.
+  globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock/object-url');
+  globalThis.URL.revokeObjectURL = vi.fn((url: string) => void revoked.push(url));
+
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+    this: HTMLAnchorElement
+  ) {
+    clicks.push({ href: this.href, download: this.download });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('downloadFile progress', () => {
+  it('reports real byte progress instead of synthetic values', async () => {
+    // Four 3-byte chunks of a 12-byte file => exact quarters.
+    const chunks = [1, 2, 3, 4].map(() => new Uint8Array([1, 2, 3]));
+    const fetchMock = vi.fn().mockResolvedValue(streamingResponse(chunks));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const updates: DownloadProgress[] = [];
+    await createDownloadService(makeApi()).downloadFile(makeFile(), {
+      onProgress: (p) => updates.push(p),
+    });
+
+    const streaming = updates.filter((u) => u.status === 'downloading' && u.loadedBytes);
+    expect(streaming.map((u) => u.loadedBytes)).toEqual([3, 6, 9, 12]);
+    expect(streaming.map((u) => Math.round(u.progress))).toEqual([25, 50, 75, 99]);
+
+    // The old implementation ended on a fixed timer regardless of bytes; this
+    // one only completes after the body is fully drained.
+    const last = updates[updates.length - 1];
+    expect(last.status).toBe('completed');
+    expect(last.progress).toBe(100);
+    expect(last.loadedBytes).toBe(12);
+  });
+
+  it('never reports 100% while bytes are still arriving', async () => {
+    const chunks = Array.from({ length: 5 }, () => new Uint8Array([9, 9]));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(streamingResponse(chunks)));
+
+    const updates: DownloadProgress[] = [];
+    await createDownloadService(makeApi()).downloadFile(makeFile({ Size: 10 }), {
+      onProgress: (p) => updates.push(p),
+    });
+
+    const midFlight = updates.filter((u) => u.status === 'downloading');
+    expect(midFlight.every((u) => u.progress < 100)).toBe(true);
+  });
+
+  it('holds at zero when the server sends no Content-Length', async () => {
+    const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4])];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(streamingResponse(chunks, { contentLength: 0 }))
+    );
+
+    const updates: DownloadProgress[] = [];
+    await createDownloadService(makeApi()).downloadFile(makeFile(), {
+      onProgress: (p) => updates.push(p),
+    });
+
+    // No honest percentage is available, but byte counts still advance.
+    const streaming = updates.filter((u) => u.status === 'downloading' && u.loadedBytes);
+    expect(streaming.map((u) => u.progress)).toEqual([0, 0]);
+    expect(streaming.map((u) => u.loadedBytes)).toEqual([2, 4]);
+    expect(updates[updates.length - 1].status).toBe('completed');
+  });
+});
+
+describe('downloadFile cancellation', () => {
+  it('passes the abort signal to fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(streamingResponse([new Uint8Array([1])]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await createDownloadService(makeApi()).downloadFile(makeFile());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('aborts the live request and reports cancelled, not error', async () => {
+    const fetchMock = vi.fn((_url: string, init: RequestInit) =>
+      Promise.resolve(stallingResponse(init.signal as AbortSignal, new Uint8Array([1, 2, 3])))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = createDownloadService(makeApi());
+    const updates: DownloadProgress[] = [];
+    const onError = vi.fn();
+
+    const file = makeFile();
+    const pending = service.downloadFile(file, { onProgress: (p) => updates.push(p), onError });
+
+    // Let the first chunk land so the read loop is genuinely in flight.
+    await vi.waitFor(() => expect(updates.some((u) => u.loadedBytes === 3)).toBe(true));
+    service.cancelDownload(file.id);
+    await pending;
+
+    expect(updates[updates.length - 1].status).toBe('cancelled');
+    // A user-initiated cancel is not a failure.
+    expect(onError).not.toHaveBeenCalled();
+    expect(clicks).toHaveLength(0);
+  });
+
+  it('does not save a file when cancelled after the last chunk', async () => {
+    const service = createDownloadService(makeApi());
+    const file = makeFile();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async () => {
+        // Abort in the window between the body completing and the save.
+        queueMicrotask(() => service.cancelDownload(file.id));
+        return streamingResponse([new Uint8Array([1, 2, 3])]);
+      })
+    );
+
+    const updates: DownloadProgress[] = [];
+    await service.downloadFile(file, { onProgress: (p) => updates.push(p) });
+
+    expect(updates[updates.length - 1].status).toBe('cancelled');
+    expect(clicks).toHaveLength(0);
+  });
+});
+
+describe('downloadFile progress volume', () => {
+  it('coalesces thousands of chunks into at most one update per percent', async () => {
+    // 1000 single-byte chunks: forwarding each one would re-render every
+    // progress subscriber a thousand times for one download.
+    const chunks = Array.from({ length: 1000 }, () => new Uint8Array([7]));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(streamingResponse(chunks)));
+
+    const updates: DownloadProgress[] = [];
+    await createDownloadService(makeApi()).downloadFile(makeFile({ Size: 1000 }), {
+      onProgress: (p) => updates.push(p),
+    });
+
+    const streaming = updates.filter((u) => u.status === 'downloading' && u.loadedBytes);
+    // ~1 per percent, versus 1000 without coalescing.
+    expect(streaming.length).toBeLessThanOrEqual(101);
+    // Still fine-grained enough to animate smoothly.
+    expect(streaming.length).toBeGreaterThan(50);
+    // Coalescing must not lose the final byte count.
+    expect(streaming[streaming.length - 1].loadedBytes).toBe(1000);
+    expect(streaming.every((u) => u.progress < 100)).toBe(true);
+  });
+});
+
+describe('downloadFile abort hygiene', () => {
+  it('produces no unhandled promise rejection when aborted mid-stream', async () => {
+    const seen: unknown[] = [];
+    const onUnhandled = (reason: unknown) => seen.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn((_url: string, init: RequestInit) =>
+          Promise.resolve(stallingResponse(init.signal as AbortSignal, new Uint8Array([1, 2, 3])))
+        )
+      );
+
+      const service = createDownloadService(makeApi());
+      const file = makeFile();
+      const updates: DownloadProgress[] = [];
+      const pending = service.downloadFile(file, { onProgress: (p) => updates.push(p) });
+
+      await vi.waitFor(() => expect(updates.some((u) => u.loadedBytes === 3)).toBe(true));
+      service.cancelDownload(file.id);
+      await pending;
+
+      // Give any stray rejection a turn of the loop to surface.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(seen).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('does not hand a large file to the browser when cancelled while signing', async () => {
+    let releaseUrl: (url: string) => void = () => {};
+    const getSignedUrl = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          releaseUrl = resolve;
+        })
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = createDownloadService(makeApi(getSignedUrl));
+    const file = makeFile({ Size: 3 * 1024 * 1024 * 1024 });
+    const updates: DownloadProgress[] = [];
+
+    const pending = service.downloadFile(file, { onProgress: (p) => updates.push(p) });
+    await vi.waitFor(() => expect(getSignedUrl).toHaveBeenCalled());
+
+    // Signing is not abortable, so the cancel lands while it is still pending.
+    service.cancelDownload(file.id);
+    releaseUrl(SIGNED_URL);
+    await pending;
+
+    // The browser hand-off is irreversible, so it must not happen at all.
+    expect(clicks).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(updates[updates.length - 1].status).toBe('cancelled');
+  });
+});
+
+describe('downloadFile filename handling', () => {
+  it('requests an attachment filename on the presigned URL', async () => {
+    const getSignedUrl = vi.fn().mockResolvedValue(SIGNED_URL);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(streamingResponse([new Uint8Array([1])])));
+
+    await createDownloadService(makeApi(getSignedUrl)).downloadFile(makeFile());
+
+    expect(getSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'folder/abc123hash',
+        isPreview: false,
+        downloadFilename: 'quarterly report.pdf',
+      })
+    );
+  });
+
+  it('saves via a same-origin blob URL so the download attribute is honoured', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(streamingResponse([new Uint8Array([1])])));
+
+    await createDownloadService(makeApi()).downloadFile(makeFile());
+
+    expect(clicks).toHaveLength(1);
+    // The old code pointed the anchor at the cross-origin S3 URL, where the
+    // browser ignores `download` and names the file after the key.
+    expect(clicks[0].href).toContain('blob:');
+    expect(clicks[0].href).not.toContain('s3.amazonaws.com');
+    expect(clicks[0].download).toBe('quarterly report.pdf');
+  });
+
+  it('releases the object URL after handing the blob to the browser', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(streamingResponse([new Uint8Array([1])])));
+
+    await createDownloadService(makeApi()).downloadFile(makeFile());
+
+    expect(revoked).toHaveLength(0); // not revoked synchronously - that can kill the download
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(revoked).toEqual(['blob:mock/object-url']);
+  });
+});
+
+describe('downloadFile large files', () => {
+  it('hands files above the streaming cap to the browser instead of buffering', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const updates: DownloadProgress[] = [];
+    const huge = makeFile({ Size: 3 * 1024 * 1024 * 1024 });
+    await createDownloadService(makeApi()).downloadFile(huge, {
+      onProgress: (p) => updates.push(p),
+    });
+
+    // Buffering 3 GB into a Blob would risk killing the tab.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(clicks).toHaveLength(1);
+    // Navigates to the presigned URL; Content-Disposition supplies the name.
+    expect(clicks[0].href).toContain('s3.amazonaws.com');
+    expect(clicks[0].download).toBe('');
+    expect(updates[updates.length - 1].status).toBe('completed');
+  });
+});
+
+describe('downloadFile failures', () => {
+  it('surfaces a failed response as an error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 403, headers: new Headers() } as Response)
+    );
+
+    const updates: DownloadProgress[] = [];
+    const onError = vi.fn();
+    await createDownloadService(makeApi()).downloadFile(makeFile(), {
+      onProgress: (p) => updates.push(p),
+      onError,
+    });
+
+    expect(updates[updates.length - 1].status).toBe('error');
+    expect(onError).toHaveBeenCalledWith('file-1', expect.stringContaining('403'));
+    expect(clicks).toHaveLength(0);
+  });
+
+  it('reports an error when no signed URL comes back', async () => {
+    const onError = vi.fn();
+    await createDownloadService(makeApi(vi.fn().mockResolvedValue(''))).downloadFile(makeFile(), {
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith('file-1', 'Failed to get download URL');
+  });
+});
+
+describe('active download tracking', () => {
+  it('clears the download from the active set once finished', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(streamingResponse([new Uint8Array([1])])));
+
+    const service = createDownloadService(makeApi());
+    await service.downloadFile(makeFile());
+
+    expect(service.isDownloadActive('file-1')).toBe(false);
+    expect(service.getActiveDownloads()).toEqual([]);
+  });
+});

--- a/frontend/src/features/dashboard/services/download-service.ts
+++ b/frontend/src/features/dashboard/services/download-service.ts
@@ -9,12 +9,72 @@ export interface DownloadProgress {
   status: 'queued' | 'pending' | 'downloading' | 'completed' | 'error' | 'cancelled';
   error?: string;
   queuePosition?: number;
+  /** Bytes received so far. Absent until the first chunk arrives. */
+  loadedBytes?: number;
+  /** Total bytes expected, or 0 when the server sends no Content-Length. */
+  totalBytes?: number;
 }
 
 export interface DownloadOptions {
   onProgress?: (progress: DownloadProgress) => void;
   onComplete?: (fileId: string) => void;
   onError?: (fileId: string, error: string) => void;
+}
+
+const SIGNED_URL_EXPIRY_SECONDS = 900;
+
+/**
+ * Streaming a download means holding the whole file in tab memory before it is
+ * handed to disk. Past this size we give up progress reporting and let the
+ * browser's own download manager take the transfer instead of risking an OOM.
+ */
+const STREAM_MAX_BYTES = 2 * 1024 * 1024 * 1024; // 2 GB
+
+/**
+ * Streaming progress is capped just below completion so that 100% is only ever
+ * shown once the blob has actually been handed to the browser.
+ */
+const MAX_STREAMING_PROGRESS = 99;
+
+/**
+ * Give the browser time to start reading the blob before the URL is revoked.
+ * The download begins synchronously on click, so this only needs to outlast
+ * that hand-off - holding longer just pins the whole file in memory.
+ */
+const OBJECT_URL_REVOKE_DELAY_MS = 10_000;
+
+/**
+ * Matches on `name` rather than `instanceof Error`: the DOM spec only promises
+ * an object whose `name` is 'AbortError', and DOMException does not extend
+ * Error in every runtime. Getting this wrong reports a user's cancel as a
+ * failed download.
+ */
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { name?: string }).name === 'AbortError'
+  );
+}
+
+/**
+ * Clicks a synthetic anchor. Used both for blob downloads and for the
+ * large-file hand-off to the browser's download manager.
+ *
+ * `download` is only set for blob URLs: they are same-origin, so the attribute
+ * is honoured. On a cross-origin presigned URL the attribute is ignored and the
+ * filename comes from the `Content-Disposition` header instead.
+ */
+function clickDownloadLink(url: string, fileName?: string): void {
+  const link = document.createElement('a');
+  link.href = url;
+  if (fileName) link.download = fileName;
+  // Deliberately no target="_blank" - it suppresses the download attribute.
+  link.rel = 'noopener';
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
 }
 
 class DownloadService {
@@ -25,6 +85,85 @@ class DownloadService {
   }
 
   private activeDownloads = new Map<string, AbortController>();
+
+  /**
+   * Drains the response body, reporting real byte progress as chunks arrive.
+   *
+   * The reader is tied to the same `AbortSignal` passed to `fetch`, so
+   * cancelling tears down the live connection rather than merely hiding the UI.
+   */
+  private async collectWithProgress(
+    response: Response,
+    file: FileItem,
+    onProgress: DownloadOptions['onProgress']
+  ): Promise<Blob> {
+    const headerLength = Number(response.headers.get('Content-Length'));
+    const total = Number.isFinite(headerLength) && headerLength > 0 ? headerLength : 0;
+
+    // A body-less response (or a runtime without streams) still yields a
+    // correct file - only the progress detail is lost.
+    if (!response.body) return response.blob();
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let loaded = 0;
+    let lastPercent = -1;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+
+        chunks.push(value);
+        loaded += value.byteLength;
+
+        // Without Content-Length there is no honest percentage to report, so
+        // hold at the starting value and let the byte counters carry the detail.
+        const rawPercent = total ? (loaded / total) * 100 : 0;
+
+        // Emit only when the whole percent advances. A 1 GB body arrives in
+        // tens of thousands of chunks, and every update re-renders each
+        // progress subscriber - roughly one update per percent is plenty.
+        // Unknown-length responses (which S3 does not produce) fall back to
+        // per-chunk emission since there is no percentage to debounce on.
+        //
+        // Throttling on the uncapped percent matters: capping first would pin
+        // the last ~1% of chunks to the same bucket and freeze the byte
+        // counter short of the true total.
+        const wholePercent = Math.floor(rawPercent);
+        if (total === 0 || wholePercent > lastPercent) {
+          lastPercent = wholePercent;
+          onProgress?.({
+            fileId: file.id,
+            fileName: file.name,
+            progress: Math.min(MAX_STREAMING_PROGRESS, rawPercent),
+            status: 'downloading',
+            loadedBytes: loaded,
+            totalBytes: total,
+          });
+        }
+      }
+    } finally {
+      // Release the lock even when the read rejects, so an aborted stream is
+      // not left holding a reader.
+      reader.releaseLock();
+    }
+
+    const contentType = response.headers.get('Content-Type');
+    return new Blob(chunks as BlobPart[], contentType ? { type: contentType } : undefined);
+  }
+
+  private saveBlob(blob: Blob, fileName: string): void {
+    const objectUrl = URL.createObjectURL(blob);
+    try {
+      clickDownloadLink(objectUrl, fileName);
+    } finally {
+      // Revoking synchronously can cancel the download in some browsers before
+      // it has read the blob, so release on a timer instead.
+      setTimeout(() => URL.revokeObjectURL(objectUrl), OBJECT_URL_REVOKE_DELAY_MS);
+    }
+  }
 
   async downloadFile(file: FileItem, options: DownloadOptions = {}): Promise<void> {
     const { onProgress, onComplete, onError } = options;
@@ -41,56 +180,86 @@ class DownloadService {
 
       const downloadUrl = await this.api.getSignedUrl({
         key: file.Key || file.name,
-        expiryInSeconds: 900,
+        expiryInSeconds: SIGNED_URL_EXPIRY_SECONDS,
         isPreview: false,
+        // Cross-origin presigned URLs ignore <a download>, so the filename has
+        // to travel with the response itself.
+        downloadFilename: file.name,
       });
 
       if (!downloadUrl) {
         throw new Error('Failed to get download URL');
       }
 
-      onProgress?.({
-        fileId: file.id,
-        fileName: file.name,
-        progress: 5,
-        status: 'downloading',
-      });
+      // Signing is not abortable, so a cancel during it only lands here. Both
+      // paths below are side-effecting, and the large-file one cannot be undone
+      // once the browser has the URL.
+      if (abortController.signal.aborted) {
+        throw new DOMException('Download cancelled', 'AbortError');
+      }
 
-      const link = document.createElement('a');
-      link.href = downloadUrl;
-      link.target = '_blank';
-      link.download = file.name;
-      link.style.display = 'none';
-      document.body.appendChild(link);
+      const knownSize = typeof file.Size === 'number' ? file.Size : 0;
 
-      let progress = 10;
-      const progressInterval = setInterval(() => {
-        if (progress < 90) {
-          progress += Math.random() * 10;
-          onProgress?.({
-            fileId: file.id,
-            fileName: file.name,
-            progress: Math.min(90, progress),
-            status: 'downloading',
-          });
-        }
-      }, 200);
-
-      link.click();
-
-      document.body.removeChild(link);
-
-      setTimeout(() => {
-        clearInterval(progressInterval);
+      if (knownSize > STREAM_MAX_BYTES) {
+        // Handed to the browser: it downloads straight to disk under the name
+        // from Content-Disposition, but we can no longer observe or cancel it.
+        clickDownloadLink(downloadUrl);
         onProgress?.({
           fileId: file.id,
           fileName: file.name,
           progress: 100,
           status: 'completed',
+          totalBytes: knownSize,
         });
         onComplete?.(file.id);
-      }, 1000);
+        return;
+      }
+
+      onProgress?.({
+        fileId: file.id,
+        fileName: file.name,
+        progress: 0,
+        status: 'downloading',
+        loadedBytes: 0,
+        totalBytes: knownSize,
+      });
+
+      const response = await fetch(downloadUrl, { signal: abortController.signal });
+      if (!response.ok) {
+        throw new Error(`Download failed with status ${response.status}`);
+      }
+
+      const blob = await this.collectWithProgress(response, file, onProgress);
+
+      // Cancelling between the final chunk and the save would otherwise still
+      // drop a file on the user's disk.
+      if (abortController.signal.aborted) {
+        throw new DOMException('Download cancelled', 'AbortError');
+      }
+
+      this.saveBlob(blob, file.name);
+
+      onProgress?.({
+        fileId: file.id,
+        fileName: file.name,
+        progress: 100,
+        status: 'completed',
+        loadedBytes: blob.size,
+        totalBytes: blob.size,
+      });
+      onComplete?.(file.id);
     } catch (error) {
+      // A cancel is a user action, not a failure - it must not raise an error toast.
+      if (isAbortError(error)) {
+        onProgress?.({
+          fileId: file.id,
+          fileName: file.name,
+          progress: 0,
+          status: 'cancelled',
+        });
+        return;
+      }
+
       const errorMessage = error instanceof Error ? error.message : 'Download failed';
 
       onProgress?.({
@@ -156,6 +325,8 @@ class DownloadService {
     return Array.from(this.activeDownloads.keys());
   }
 }
+
+export type { DownloadService };
 
 export const createDownloadService = (api: BYOS3ApiProvider) => {
   return new DownloadService(api);

--- a/frontend/src/features/dashboard/stores/use-download-store.ts
+++ b/frontend/src/features/dashboard/stores/use-download-store.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared download state.
+ *
+ * This lives in a store rather than in `useState` inside `useDownload` because
+ * the components that *start* downloads (overflow menu, preview header/content,
+ * multi-select actions) are disjoint from the ones that *display* them
+ * (download progress manager, operations modal). With per-hook local state each
+ * component held its own map and its own service instance, so the display
+ * components rendered from a map that was never written to and their cancel
+ * button addressed a service that never owned the download.
+ */
+
+import { create } from 'zustand';
+import { BYOS3ApiProvider } from '@opndrive/s3-api';
+import {
+  createDownloadService,
+  type DownloadProgress,
+  type DownloadService,
+} from '../services/download-service';
+import type { FileItem } from '../types/file';
+
+/** How long a finished row lingers before it clears itself from the list. */
+const COMPLETED_LINGER_MS = 3000;
+const CANCELLED_LINGER_MS = 2000;
+
+interface DownloadState {
+  downloads: Map<string, DownloadProgress>;
+  /**
+   * One service per API provider. Downloads track their AbortControllers inside
+   * the service, so a single long-lived instance is what makes cancel reach the
+   * in-flight request.
+   */
+  service: DownloadService | null;
+  serviceApi: BYOS3ApiProvider | null;
+
+  getService: (api: BYOS3ApiProvider) => DownloadService;
+  setProgress: (progress: DownloadProgress) => void;
+  removeDownload: (fileId: string) => void;
+  startDownload: (
+    api: BYOS3ApiProvider,
+    file: FileItem,
+    handlers?: { onError?: (fileId: string, error: string) => void }
+  ) => Promise<void>;
+  cancelDownload: (fileId: string) => void;
+  getAllDownloads: () => DownloadProgress[];
+  isDownloading: (fileId: string) => boolean;
+}
+
+export const useDownloadStore = create<DownloadState>((set, get) => ({
+  downloads: new Map(),
+  service: null,
+  serviceApi: null,
+
+  getService: (api) => {
+    const { service, serviceApi } = get();
+    // Rebuild only when the credentials behind the provider actually change
+    // (login/logout), otherwise reuse so in-flight controllers stay reachable.
+    if (service && serviceApi === api) return service;
+
+    const next = createDownloadService(api);
+    set({ service: next, serviceApi: api });
+    return next;
+  },
+
+  setProgress: (progress) =>
+    set((state) => {
+      const downloads = new Map(state.downloads);
+      downloads.set(progress.fileId, progress);
+      return { downloads };
+    }),
+
+  removeDownload: (fileId) =>
+    set((state) => {
+      if (!state.downloads.has(fileId)) return state;
+      const downloads = new Map(state.downloads);
+      downloads.delete(fileId);
+      return { downloads };
+    }),
+
+  startDownload: async (api, file, handlers) => {
+    const { getService, setProgress, removeDownload } = get();
+
+    await getService(api).downloadFile(file, {
+      onProgress: (progress) => {
+        setProgress(progress);
+        if (progress.status === 'cancelled') {
+          setTimeout(() => removeDownload(file.id), CANCELLED_LINGER_MS);
+        }
+      },
+      onComplete: (fileId) => {
+        setTimeout(() => removeDownload(fileId), COMPLETED_LINGER_MS);
+      },
+      onError: handlers?.onError,
+    });
+  },
+
+  cancelDownload: (fileId) => {
+    // The service emits the 'cancelled' progress update itself when the abort
+    // unwinds, which is also what schedules the row's removal.
+    get().service?.cancelDownload(fileId);
+  },
+
+  getAllDownloads: () => Array.from(get().downloads.values()),
+
+  isDownloading: (fileId) => {
+    const status = get().downloads.get(fileId)?.status;
+    return status === 'downloading' || status === 'pending' || status === 'queued';
+  },
+}));

--- a/frontend/src/features/upload/components/operations-modal.tsx
+++ b/frontend/src/features/upload/components/operations-modal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { useUploadStore } from '@/features/upload/stores/use-upload-store';
-import { useDownload } from '@/features/dashboard/hooks/use-download';
+import { useDownloadList } from '@/features/dashboard/hooks/use-download';
 import { HiOutlineXMark, HiOutlineChevronUp, HiOutlineChevronDown } from 'react-icons/hi2';
 import { FileIcon } from '@/shared/components/icons/file-icons';
 import { FolderIcon } from '@/shared/components/icons/folder-icons';
@@ -84,7 +84,7 @@ export const OperationsModal: React.FC = () => {
     duplicateDialog,
     hideDuplicateDialog,
   } = useUploadStore();
-  const { getAllDownloads, cancelDownload } = useDownload();
+  const { getAllDownloads, cancelDownload } = useDownloadList();
   const downloads = getAllDownloads();
   const [isExpanded, setIsExpanded] = useState(true);
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
@@ -95,11 +95,9 @@ export const OperationsModal: React.FC = () => {
   // Check if pause/resume is supported in current mode
   const supportsPauseResume = uploadMode === 'multipart';
 
-  if (!uploadManager) {
-    return 'Loading...';
-  }
-
-  // Simulate speed tracking for active uploads (demo purposes) - moved to top to fix hook order
+  // Simulate speed tracking for active uploads (demo purposes).
+  // Must stay above the uploadManager guard below: hooks cannot sit after an
+  // early return, or the hook count changes once the manager resolves.
   React.useEffect(() => {
     const interval = setInterval(() => {
       // Check if there are any uploading operations
@@ -116,6 +114,10 @@ export const OperationsModal: React.FC = () => {
 
     return () => clearInterval(interval);
   }, [uploads]); // Depend on uploads object
+
+  if (!uploadManager) {
+    return 'Loading...';
+  }
 
   // Helper function to cancel operations (upload, delete, and download)
   const cancelOperation = (

--- a/s3-api/package.json
+++ b/s3-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opndrive/s3-api",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "AWS S3 helper for the opndrive project",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/s3-api/src/core/types.ts
+++ b/s3-api/src/core/types.ts
@@ -46,6 +46,12 @@ export interface SignedUrlParams {
   expiryInSeconds: number;
   isPreview: boolean;
   responseContentType?: string;
+  /**
+   * Name the browser should save the file as. Only honoured when `isPreview` is
+   * false; sets `Content-Disposition: attachment` on the presigned response so
+   * the name survives the cross-origin hop that makes `<a download>` a no-op.
+   */
+  downloadFilename?: string;
 }
 
 export interface DownloadFileParams {

--- a/s3-api/src/index.ts
+++ b/s3-api/src/index.ts
@@ -19,6 +19,7 @@ import {
   userTypes,
 } from './core/types.js';
 import { forEachWithConcurrency } from './utils/concurrency.js';
+import { buildAttachmentDisposition } from './utils/content-disposition.js';
 import {
   ListObjectsV2Command,
   ListObjectsV2CommandInput,
@@ -165,7 +166,13 @@ export class BYOS3ApiProvider extends BaseS3ApiProvider {
         ResponseContentType: params.responseContentType,
       });
     } else {
-      cmd = new GetObjectCommand({ Bucket: this.credentials.bucketName, Key: params.key });
+      cmd = new GetObjectCommand({
+        Bucket: this.credentials.bucketName,
+        Key: params.key,
+        ResponseContentDisposition: params.downloadFilename
+          ? buildAttachmentDisposition(params.downloadFilename)
+          : undefined,
+      });
     }
     return getSignedUrl(this.s3, cmd, { expiresIn: params.expiryInSeconds });
   }

--- a/s3-api/src/tests/contentDisposition.test.ts
+++ b/s3-api/src/tests/contentDisposition.test.ts
@@ -1,0 +1,126 @@
+import { BYOS3ApiProvider } from '../../dist/index';
+import type { Credentials, SignedUrlParams } from '../../dist/index';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Presigning is computed locally (HMAC over the request), so these need no
+ * network and no real bucket - unlike the credential-gated suites in
+ * byoS3.test.ts. Fake credentials produce a real, inspectable URL.
+ */
+const fakeCreds: Credentials = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  bucketName: 'test-bucket',
+  prefix: '',
+  region: 'us-east-1',
+};
+
+function dispositionOf(url: string): string | null {
+  return new URL(url).searchParams.get('response-content-disposition');
+}
+
+const baseParams: SignedUrlParams = {
+  key: 'folder/abc123hash',
+  expiryInSeconds: 900,
+  isPreview: false,
+};
+
+describe('getSignedUrl content disposition', () => {
+  it('forces an attachment filename for downloads', async () => {
+    const api = new BYOS3ApiProvider(fakeCreds, 'BYO');
+
+    const url = await api.getSignedUrl({ ...baseParams, downloadFilename: 'quarterly report.pdf' });
+
+    // Without this the browser names the file after the key ("abc123hash"),
+    // because <a download> is ignored cross-origin.
+    expect(dispositionOf(url)).toBe(
+      `attachment; filename="quarterly report.pdf"; filename*=UTF-8''quarterly%20report.pdf`
+    );
+  });
+
+  it('omits the header when no filename is requested', async () => {
+    const api = new BYOS3ApiProvider(fakeCreds, 'BYO');
+
+    const url = await api.getSignedUrl(baseParams);
+
+    expect(dispositionOf(url)).toBeNull();
+  });
+
+  it('keeps preview URLs inline', async () => {
+    const api = new BYOS3ApiProvider(fakeCreds, 'BYO');
+
+    const url = await api.getSignedUrl({
+      ...baseParams,
+      isPreview: true,
+      downloadFilename: 'ignored.pdf',
+    });
+
+    expect(dispositionOf(url)).toBe('inline');
+  });
+
+  it('encodes non-ascii names and still supplies an ascii fallback', async () => {
+    const api = new BYOS3ApiProvider(fakeCreds, 'BYO');
+
+    const url = await api.getSignedUrl({ ...baseParams, downloadFilename: '文档.pdf' });
+    const disposition = dispositionOf(url);
+
+    // The quoted-string form cannot carry non-ascii, so it degrades to a
+    // neutral stem - keeping the extension - while filename* carries the truth.
+    expect(disposition).toBe(
+      `attachment; filename="download.pdf"; filename*=UTF-8''%E6%96%87%E6%A1%A3.pdf`
+    );
+  });
+
+  it('transliterates accents in the ascii fallback rather than dropping them', async () => {
+    const api = new BYOS3ApiProvider(fakeCreds, 'BYO');
+
+    const url = await api.getSignedUrl({ ...baseParams, downloadFilename: 'café résumé.pdf' });
+
+    // "caf rsum.pdf" would be a confusing name to land on disk.
+    expect(dispositionOf(url)).toBe(
+      `attachment; filename="cafe resume.pdf"; filename*=UTF-8''caf%C3%A9%20r%C3%A9sum%C3%A9.pdf`
+    );
+  });
+
+  it('emits a header S3 can carry for emoji names', async () => {
+    const api = new BYOS3ApiProvider(fakeCreds, 'BYO');
+
+    const url = await api.getSignedUrl({ ...baseParams, downloadFilename: '📄 report.xlsx' });
+    const disposition = dispositionOf(url)!;
+
+    // Header values must be ascii; the emoji only survives percent-encoded.
+    expect(disposition).toMatch(/^[\x20-\x7e]*$/);
+    expect(disposition).toContain(`filename*=UTF-8''%F0%9F%93%84%20report.xlsx`);
+    expect(disposition).toContain('filename="report.xlsx"');
+  });
+
+  it('strips quotes and control characters that would break out of the header', async () => {
+    const api = new BYOS3ApiProvider(fakeCreds, 'BYO');
+
+    const url = await api.getSignedUrl({
+      ...baseParams,
+      downloadFilename: 'ev"il\r\nX-Injected: 1.txt',
+    });
+    const disposition = dispositionOf(url)!;
+
+    // CR/LF are what make header injection possible; the remaining text is
+    // inert inside a balanced quoted-string.
+    expect(disposition).not.toMatch(/[\r\n]/);
+    expect(disposition).not.toContain('ev"il');
+    // Exactly one quoted-string, so nothing escaped the filename parameter.
+    expect(disposition.match(/"/g)).toHaveLength(2);
+  });
+
+  it('drops any directory component from the suggested name', async () => {
+    const api = new BYOS3ApiProvider(fakeCreds, 'BYO');
+
+    const url = await api.getSignedUrl({
+      ...baseParams,
+      downloadFilename: 'nested/path/report.pdf',
+    });
+
+    expect(dispositionOf(url)).toBe(
+      `attachment; filename="report.pdf"; filename*=UTF-8''report.pdf`
+    );
+  });
+});

--- a/s3-api/src/utils/content-disposition.ts
+++ b/s3-api/src/utils/content-disposition.ts
@@ -1,0 +1,76 @@
+/**
+ * Builds an RFC 6266 `Content-Disposition` value that forces a download under a
+ * chosen filename.
+ *
+ * Browsers ignore the `download` attribute on an anchor whose href points at
+ * another origin, and a presigned S3 URL is always cross-origin. Without this
+ * header S3 serves the object with no filename hint and the browser falls back
+ * to the key's basename, so downloads land as hashed or otherwise wrong names.
+ *
+ * Two filename forms are emitted, per RFC 6266 §4.3:
+ *   - `filename=` carries an ASCII-only fallback for legacy agents.
+ *   - `filename*=` carries the exact UTF-8 name for agents that support RFC 5987.
+ * Agents that understand `filename*` must prefer it, so non-ASCII names survive.
+ */
+
+/** Characters that would terminate or escape the quoted-string, plus C0/C1 controls. */
+// eslint-disable-next-line no-control-regex
+const UNSAFE_QUOTED = /[\u0000-\u001f\u007f-\u009f"\\]/g;
+const NON_ASCII = /[^\x20-\x7e]/g;
+/** Nonspacing combining marks, left over after NFD decomposition. */
+const COMBINING_MARKS = /\p{Mn}/gu;
+
+/**
+ * Strips path separators so a key like `a/b/evil.txt` cannot smuggle a
+ * directory component into the suggested name.
+ */
+function basename(name: string): string {
+  const parts = name.split(/[\\/]/);
+  return parts[parts.length - 1] ?? '';
+}
+
+/**
+ * Percent-encodes per RFC 5987 `attr-char`. `encodeURIComponent` already covers
+ * UTF-8 multibyte sequences; the extra replacements cover ASCII punctuation it
+ * leaves untouched but which is not valid in an `attr-char` production.
+ */
+function encodeRfc5987(value: string): string {
+  return encodeURIComponent(value).replace(
+    /['()*!]/g,
+    (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase()
+  );
+}
+
+/**
+ * @param filename - Desired name for the saved file. Any directory component is
+ *   dropped and header-breaking characters are removed.
+ * @returns A `Content-Disposition` value, or `undefined` when `filename`
+ *   contains nothing usable (callers should then omit the header entirely
+ *   rather than send an empty filename).
+ */
+export function buildAttachmentDisposition(filename: string): string | undefined {
+  const name = basename(filename).trim();
+  if (!name) return undefined;
+
+  // Quoted-string form: drop anything non-ASCII and anything that would break
+  // out of the quotes. This is only the fallback; `filename*` carries the truth.
+  // Stripping non-ASCII also removes CR/LF, so the value cannot inject a header.
+  //
+  // Decomposing first turns accented letters into base letter + combining mark,
+  // so "café" degrades to "cafe" rather than "caf".
+  const ascii = name
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    .replace(NON_ASCII, '')
+    .replace(UNSAFE_QUOTED, '')
+    .trim();
+
+  // A name that is entirely non-ASCII ("文档.pdf") leaves behind only its
+  // extension, or nothing at all. Keep the extension so the OS still opens the
+  // file correctly, but give it a real stem instead of emitting ".pdf" or "".
+  const extension = /\.[^.\s]+$/.exec(ascii)?.[0] ?? '';
+  const stem = ascii.slice(0, ascii.length - extension.length).trim();
+  const fallback = stem ? ascii : `download${extension}`;
+
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${encodeRfc5987(name)}`;
+}


### PR DESCRIPTION
Closes #84

Downloads were broken in three ways, and a fourth bug made the first three invisible.

## What was wrong

**Filenames.** `getSignedUrl` built a bare `GetObjectCommand` for the download branch, so the response carried no filename hint — and `<a download>` is ignored on a cross-origin presigned URL. Every file saved under the S3 key basename.

**Progress.** The bar was `Math.random() * 10` on a 200ms interval, capped at 90%, then a hardcoded 1s timer jumped to 100% and fired `onComplete` whether or not a single byte had arrived.

**Cancel.** The `AbortController` was created, stored, and never passed to anything. `link.click()` hands the transfer to the browser's download manager, which JS cannot cancel by design.

**Not in the issue — the progress UI was wired to dead state.** `useDownload` held `useState` plus its own service instance *per component*. The components that start downloads and the ones that display them are disjoint sets:

| Starts downloads | Displays them |
|---|---|
| overflow menu, preview header, preview content, multi-select actions | progress manager, operations modal |

So the display components read a map that was never written to — `downloads.length === 0` returned `null` forever — and their Cancel button addressed a service instance that never owned the download. Cancel was dead twice over, and fixing the AbortController alone would not have made it work.

Worth noting: `BYOS3ApiProvider.downloadFile()` already implemented correct streaming byte progress and was called from nowhere.

## What changed

- **`s3-api`** — new RFC 6266 builder sets `ResponseContentDisposition` on download URLs: ASCII fallback plus `filename*=UTF-8''`, path components stripped, quotes and CR/LF removed so the value cannot break the header.
- **`download-service`** — `fetch` with the signal wired in; real byte progress off the stream reader; saves through a same-origin `blob:` URL where `download` *is* honoured; `AbortError` maps to `cancelled`, not `error`.
- **`use-download-store`** (new) — one shared map and one long-lived service, matching the existing upload-store idiom.
- **`use-download`** — split into three hooks so the overflow menu (which mounts once per file row) subscribes to a single boolean rather than the whole map.

## Edge cases handled

- Files over 2 GB skip streaming and hand off to the browser — buffering them into a Blob risks killing the tab. Filename stays correct via `Content-Disposition`.
- Multi-select downloads run 3 at a time. An unbounded fan-out would allocate every selected file in memory at once.
- Cancelling during the (non-abortable) signing step no longer triggers the irreversible large-file hand-off.
- Progress is coalesced to ~1 update per whole percent; a 1 GB body arrives in ~16k chunks and forwarding each would re-render every subscriber.
- Non-ASCII names: `café résumé.pdf` → `filename="cafe resume.pdf"` + `filename*=UTF-8''caf%C3%A9%20r%C3%A9sum%C3%A9.pdf`. Emoji and CJK verified to produce pure-ASCII, URL-round-trip-safe headers.

## Drive-by fixes

Three Rules-of-Hooks / stale-memo bugs in files this PR touches, surfaced by the pre-commit `--max-warnings=0` ratchet:

- `use-download` early-returned above its `useCallback`s — the hook count changed once `apiS3` resolved.
- `operations-modal` had the same bug; its `useEffect` sat below an early return.
- `file-overflow-menu` built its menu in a hoisted helper whose live reads were invisible to the memo deps, so `disabled` states stayed stale until an unrelated prop changed.

## Testing

19 new tests (13 frontend + 6 s3-api). Two were written before the code and caught real bugs:

- Capping progress at 99% *before* throttling froze the byte counter at 990/1000 — the last chunks were swallowed. Now throttles on the uncapped percent.
- `isAbortError` gated on `instanceof Error`, but `DOMException` does not extend `Error` in every runtime, so a real cancel could be reported as a failure. Now matches on `.name`.

Abort cleanliness is asserted with a `process.on('unhandledRejection')` guard rather than assumed.

`pnpm typecheck`, `pnpm test` (27 frontend / 8 s3-api), `pnpm build`, and `pnpm lint` all pass. Verified by set-diff against the base tree that this adds zero new lint warnings and zero prettier regressions.

## Dependency note

Requires `@opndrive/s3-api` 2.8.0, published to npm; `frontend` bumped to `^2.8.0`. That bump also aligns `@aws-sdk/s3-request-presigner` with the frontend's `client-s3 ^3.1095.0`, deduplicating a stale `@aws-sdk 3.862.0` subtree — which is most of the lockfile diff.

## Follow-ups not in scope

- The `queued` status and "Queued (position N)" UI already exist unused; with the concurrency cap, selecting 20 files now shows 3 cards at a time. Wiring the queue UI would be a natural next step.
- `pnpm build` rewrites the tracked `frontend/next-env.d.ts` to add a triple-slash reference, which eslint then errors on. CI is unaffected (the quality job never builds), but it bites contributors who build before linting. Deliberately left out to keep this diff focused.
