### PR TITLE
test(s3-api): achieve 97% test coverage and enforce CI ratchet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,9 @@
 # Default owner for everything not matched below
 * @yash-sangwan
+
+# Coverage ratchet. The thresholds in this file are the only thing stopping
+# covered behaviour from being quietly dropped, and CI will faithfully enforce
+# whatever number is committed - including a lowered one. Requiring a second
+# maintainer here makes the ratchet one-way in practice, not just on paper.
+# Later rules win in CODEOWNERS, so this must stay below the `*` entry.
+/s3-api/vitest.config.ts @yash-sangwan @Rakesh-46-VR

--- a/.github/scripts/coverage-summary.mjs
+++ b/.github/scripts/coverage-summary.mjs
@@ -1,0 +1,75 @@
+/**
+ * Publishes the s3-api coverage table to the GitHub Actions run summary page.
+ *
+ * Run from the s3-api package directory, after `pnpm test:coverage` has written
+ * coverage/coverage-summary.json. Outside CI it just prints to stdout, so it
+ * can be checked locally without faking GitHub's environment.
+ *
+ * This is deliberately a file rather than an inline `node -e` in the workflow:
+ * quoting a multi-line script inside YAML is fragile and impossible to test.
+ */
+
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+// Imported explicitly rather than relied on as a global: this file sits
+// outside the lint config's Node-environment globs.
+import process from 'node:process';
+
+const REPORT = 'coverage/coverage-summary.json';
+const CONFIG = 'vitest.config.ts';
+const METRICS = ['statements', 'branches', 'functions', 'lines'];
+
+function publish(markdown) {
+  const target = process.env.GITHUB_STEP_SUMMARY;
+  if (target) appendFileSync(target, `${markdown}\n`);
+  else process.stdout.write(`${markdown}\n`);
+}
+
+/**
+ * Reads the enforced thresholds out of vitest.config.ts rather than hardcoding
+ * them here. Duplicating the numbers would let this table advertise a limit
+ * that is not the one CI actually enforces - the exact drift the CODEOWNERS
+ * rule on that file exists to prevent.
+ */
+function readThresholds() {
+  try {
+    const block = /thresholds:\s*\{([^}]*)\}/.exec(readFileSync(CONFIG, 'utf8'))?.[1] ?? '';
+    return Object.fromEntries(
+      METRICS.map((metric) => [
+        metric,
+        Number(new RegExp(`${metric}:\\s*(\\d+(?:\\.\\d+)?)`).exec(block)?.[1]),
+      ])
+    );
+  } catch {
+    return {};
+  }
+}
+
+if (!existsSync(REPORT)) {
+  // The gate step runs with `if: always()`, so this is reachable whenever the
+  // suite dies before coverage is written. Say so plainly instead of crashing
+  // and masking the real failure.
+  publish('### s3-api coverage\n\nNo coverage report was produced — the test run failed early.');
+  process.exit(0);
+}
+
+const { total } = JSON.parse(readFileSync(REPORT, 'utf8'));
+const limits = readThresholds();
+
+const rows = METRICS.map((metric) => {
+  const { pct, covered, total: count } = total[metric];
+  const limit = limits[metric];
+  const known = Number.isFinite(limit);
+  const status = known ? (pct >= limit ? '✅' : '❌') : '–';
+  const label = metric[0].toUpperCase() + metric.slice(1);
+  return `| ${label} | ${pct.toFixed(2)}% | ${covered}/${count} | ${known ? `${limit}%` : '–'} | ${status} |`;
+});
+
+publish(
+  [
+    '### s3-api coverage',
+    '',
+    '| Metric | Covered | Ratio | Threshold | Status |',
+    '| --- | ---: | ---: | ---: | :-: |',
+    ...rows,
+  ].join('\n')
+);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  NODE_VERSION: '22'
+  # Node version is NOT pinned here - every job reads .nvmrc via
+  # setup-node's node-version-file, so contributors' local `nvm use` and CI
+  # can never drift apart.
   PNPM_VERSION: '10.7.0'
 
 jobs:
@@ -40,6 +42,7 @@ jobs:
               - 'eslint.config.mjs'
               - 'prettier.config.js'
               - '.prettierignore'
+              - '.nvmrc'
               - '.github/workflows/ci.yml'
 
   quality:
@@ -56,7 +59,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -90,7 +93,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 
@@ -115,7 +118,7 @@ jobs:
           NEXT_PUBLIC_ENABLE_BLOG: 'false'
 
   s3-api:
-    name: s3-api (typecheck, build)
+    name: s3-api (typecheck, test, build)
     needs: changes
     if: needs.changes.outputs.s3api == 'true'
     runs-on: ubuntu-latest
@@ -131,7 +134,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: pnpm
           cache-dependency-path: s3-api/pnpm-lock.yaml
 
@@ -139,6 +142,14 @@ jobs:
 
       - name: Typecheck
         run: pnpm typecheck
+
+      # Runs the full suite AND enforces the coverage thresholds in
+      # vitest.config.ts (95/90/95/95), so this single step both catches
+      # regressions and fails the build if covered behaviour is removed.
+      # No AWS credentials are needed: the suite mocks the SDK, and the
+      # credential-gated integration tests in src/tests/ skip themselves.
+      - name: Test & coverage gate
+        run: pnpm test:coverage
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,13 @@ jobs:
       - name: Test & coverage gate
         run: pnpm test:coverage
 
+      # Puts the gate's numbers on the run summary page instead of leaving them
+      # buried in the job log. Runs even when the gate fails, which is exactly
+      # when you want to see which metric dropped and by how much.
+      - name: Publish coverage summary
+        if: always()
+        run: node ../.github/scripts/coverage-summary.mjs
+
       - name: Build
         run: pnpm build
 

--- a/docs/content/development/repository-structure.md
+++ b/docs/content/development/repository-structure.md
@@ -123,13 +123,22 @@ s3-api/
 │   │   ├── signedUrlUploader.ts
 │   │   ├── multipartUploader.ts
 │   │   └── concurrency.ts
-│   ├── tests/byoS3.test.ts
-│   └── index.ts               # Public exports
+│   ├── tests/                  # Credential-gated integration suite (skips by default)
+│   ├── index.ts                # Public exports
+│   ├── index.listing.test.ts   # Listing + metadata coverage
+│   ├── index.objects.test.ts   # Single-object operation coverage
+│   └── vitest.d.ts             # Types for the aws-sdk-client-mock matchers
 ├── CHANGELOG.MD
 ├── package.json                # Published as @opndrive/s3-api
-├── tsconfig.json
-└── vitest.config.ts
+├── tsconfig.json               # Type-checking (includes test files)
+├── tsconfig.build.json         # Build only (excludes test files from dist/)
+├── vitest.config.ts
+└── vitest.setup.ts             # Registers the AWS mock matchers
 ```
+
+Unit tests are collocated with the code they cover; `src/tests/` predates that
+convention and now holds only the integration suite. See
+[Testing](./testing.md).
 
 See [S3 API Layer](./s3-api.md) for what each of these actually does.
 

--- a/docs/content/development/s3-api.md
+++ b/docs/content/development/s3-api.md
@@ -99,3 +99,15 @@ See [Connecting Storage](../guides/connecting-storage.md) for how `credentials`
 gets built from the `/connect` form, and
 [Release Process](../maintainers/release-process.md) for how this package gets
 versioned and published.
+
+## Testing It
+
+The listing, metadata, and single-object methods above
+(`fetchDirectoryStructure`, `fetchMetadata`, `listFromPrefix`, `search`,
+`uploadWithPreSignedUrl`, `getSignedUrl`, `downloadFile`, `deleteFile`,
+`deleteBatch`, `createFolder`) are covered by unit tests that mock the AWS SDK,
+so `pnpm test` in `s3-api/` needs no credentials and makes no network calls.
+
+The rename/move family, `uploadMultipartParallely`, the accessors, and the
+upload managers are not covered yet. See [Testing](./testing.md) for the mock
+patterns and conventions.

--- a/docs/content/development/setup.md
+++ b/docs/content/development/setup.md
@@ -115,11 +115,13 @@ pnpm test
 # From s3-api/
 pnpm test
 pnpm test:watch
+pnpm test:coverage
 ```
 
-Both packages use [Vitest](https://vitest.dev/). There is no end-to-end test
-suite in this repository today. See [Testing](./testing.md) for what's actually
-covered and how to add to it.
+Both packages use [Vitest](https://vitest.dev/). The `s3-api` suite mocks the
+AWS SDK, so it needs no credentials and makes no network calls. There is no
+end-to-end test suite in this repository today. See [Testing](./testing.md) for
+what's actually covered and how to add to it.
 
 ## Working with Features
 
@@ -217,16 +219,17 @@ These are the scripts that actually exist in `package.json` today:
 | `pnpm typecheck`     | root, `frontend/`, or `s3-api/` | Type-check (root runs both packages)                 |
 | `pnpm test`          | `frontend/` or `s3-api/`        | Run the Vitest suite                                 |
 | `pnpm test:watch`    | `s3-api/`                       | Run tests in watch mode                              |
+| `pnpm test:coverage` | `s3-api/`                       | Run tests with a v8 coverage report                  |
 | `pnpm lint`          | root                            | Lint both `frontend/` and `s3-api/`                  |
 | `pnpm lint:frontend` | root                            | Lint only `frontend/`                                |
 | `pnpm format`        | root                            | Format the whole repo with Prettier                  |
 | `pnpm format:check`  | root                            | Check formatting without writing                     |
 | `pnpm check`         | root                            | `lint` + `format:check` (what CI's quality job runs) |
 
-There's no `type-check` (hyphenated), `check-all`, `test:coverage`, `clean`, or
+There's no `type-check` (hyphenated), `check-all`, `clean`, or
 environment-specific build script (`build:dev`/`build:staging`/`build:prod`) in
-this repo. If you've seen those referenced elsewhere, that's stale
-documentation - please open an issue.
+this repo, and no `test:coverage` in `frontend/`. If you've seen those
+referenced elsewhere, that's stale documentation - please open an issue.
 
 ---
 

--- a/docs/content/development/testing.md
+++ b/docs/content/development/testing.md
@@ -1,80 +1,161 @@
 # Testing
 
-An honest picture of test coverage today, not an aspirational one: it's thin,
-it's Vitest-only, and there's no end-to-end suite. That's fine to build on, but
-don't assume more coverage exists than actually does.
+An honest picture of test coverage today, not an aspirational one. The frontend
+is still thin. `s3-api` is mid-way through a push to full coverage: every S3
+operation is now exercised against a mocked AWS client, but the upload managers
+and the multipart uploader are still untested.
 
 ## The Stack
 
 - **[Vitest](https://vitest.dev/)** for both packages.
 - **[React Testing Library](https://testing-library.com/react)** for the
   frontend's component/hook tests.
+- **[`aws-sdk-client-mock`](https://github.com/m-radzikowski/aws-sdk-client-mock)**
+  plus its
+  **[Vitest matchers](https://github.com/stschulte/aws-sdk-client-mock-vitest)**
+  for `s3-api`.
 - No Jest, no Playwright, no Cypress.
 
 ## Running Tests
 
 ```bash
 cd frontend && pnpm test
-cd s3-api && pnpm test          # or: pnpm test:watch
+cd s3-api && pnpm test            # or: pnpm test:watch
+cd s3-api && pnpm test:coverage   # text summary + HTML report in coverage/
 ```
 
-There's no `test:coverage` script and no enforced coverage threshold in either
-`vitest.config.ts`.
+**No AWS credentials are required.** `aws-sdk-client-mock` intercepts the SDK
+below the command layer, so no test makes a network call, and the fake keys in
+the suites are the AWS documentation examples. If a test run asks you for
+credentials or hangs on a socket, something is wired up wrong - say so in the PR
+rather than adding real keys.
+
+The one exception is `s3-api/src/tests/byoS3.test.ts`, an integration suite that
+talks to a real bucket. It **skips itself** unless `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `BUCKET_NAME`, and `AWS_REGION` are all set (see
+`.env.example`). CI never sets them, so it never runs there.
+
+There's no enforced coverage threshold yet; `pnpm test:coverage` reports but
+does not gate.
 
 ## What's Actually Covered
 
-- `frontend/src/context/auth-context.test.tsx`
-- `frontend/src/features/dashboard/hooks/use-search.test.tsx`
-- `s3-api/src/tests/byoS3.test.ts`
+**`s3-api`** — listing, metadata, and single-object operations:
 
-That's the entire test suite. Everything else in the frontend and most of
-`s3-api` is currently untested. If you're looking for "good first issue"
-territory, adding a test for an existing hook or utility function is a safe,
-high-value place to start.
+- `src/index.listing.test.ts` — `fetchDirectoryStructure`, `fetchMetadata`,
+  `listFromPrefix`, `search`
+- `src/index.objects.test.ts` — `uploadWithPreSignedUrl`, `getSignedUrl`,
+  `downloadFile`, `deleteFile`, `deleteBatch`, `createFolder`
+- `src/tests/contentDisposition.test.ts` — the `Content-Disposition` builder, in
+  depth (unicode, header injection, path stripping)
+
+Still untested: `moveFile`, `renameFile`, `renameFolder`,
+`uploadMultipartParallely`, the `getBucketName`/`getPrefix`/`getRegion`/
+`getS3Client` accessors, `MultipartUploader`, `UploadManager`,
+`SignedUrlUploadManager`, `SignedUrlUploader`, and `forEachWithConcurrency`.
+
+**`frontend`** — three files, and nothing else:
+
+- `src/context/auth-context.test.tsx`
+- `src/features/dashboard/hooks/use-search.test.tsx`
+- `src/features/dashboard/services/download-service.test.ts`
+
+If you're looking for "good first issue" territory, a test for an existing hook
+or utility is a safe, high-value place to start.
+
+## Writing an `s3-api` Test
+
+The custom matchers are registered globally in `s3-api/vitest.setup.ts`, so
+individual suites only need `mockClient`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { BYOS3ApiProvider } from './index.js';
+
+const s3Mock = mockClient(S3Client);
+
+beforeEach(() => {
+  s3Mock.reset(); // stubs leak between tests otherwise
+});
+
+it('carries pagination through', async () => {
+  s3Mock.on(ListObjectsV2Command).resolves({
+    Contents: [{ Key: 'a.txt' }],
+    NextContinuationToken: 'token-2',
+  });
+
+  const result = await api.fetchDirectoryStructure('photos/', 50);
+
+  expect(result.nextToken).toBe('token-2');
+  expect(s3Mock).toHaveReceivedCommandWith(ListObjectsV2Command, {
+    Bucket: 'test-bucket',
+    Delimiter: '/',
+  });
+});
+```
+
+Useful stubs: `.resolves(...)` for every call, `.resolvesOnce(...)` chained for
+paginated flows, `.rejects(err)` to drive an error path.
+
+### Conventions
+
+1. **Collocate.** `foo.ts` → `foo.test.ts`, next to the source. Where one source
+   file covers a lot of ground, split by topic rather than by file
+   (`index.listing.test.ts`, `index.objects.test.ts`) - both still sit beside
+   `src/index.ts`. `src/tests/` predates this and is not the pattern to copy.
+2. **Import from source, never from `dist/`.** A `dist/` import silently tests
+   the last build instead of your change, and coverage instruments nothing.
+3. **Test our wrapper, not the AWS SDK.** Which command we build, how we map the
+   response, what we do when it throws. Whether S3 itself paginates correctly is
+   not our problem.
+4. **Mock at the boundary** (`@opndrive/s3-api`, `next/navigation`), not deep
+   inside your own code.
+5. **Before you trust a new test, break the code it covers** and confirm it
+   fails. A test that passes either way isn't testing anything.
+
+### Two Gotchas
+
+`toHaveReceivedCommandWith` does a **partial** match, so it can assert a
+parameter's value but not its absence - `{ Delimiter: undefined }` requires the
+key to be present and undefined, which is not the same as unset. For absence,
+read the input directly:
+
+```typescript
+const input = s3Mock.commandCalls(ListObjectsV2Command)[0].args[0].input;
+expect(input.Delimiter).toBeUndefined();
+```
+
+The positional matchers take the command **first**:
+`toHaveReceivedNthCommandWith(Command, n, input)`.
+
+## Type-checking Tests
+
+`tsconfig.json` includes the collocated `*.test.ts` files, so `pnpm typecheck`
+covers them. `pnpm build` uses `tsconfig.build.json`, which excludes them - test
+files must never end up in `dist/` and get published.
+
+The matcher types come from `src/vitest.d.ts`. `vitest.setup.ts` sits outside
+`rootDir` and so isn't in the type-check program; without that declaration file
+every matcher call would be a type error despite working at runtime.
 
 ## What a Real Test Here Looks Like
 
-The existing tests aren't smoke tests - they're regression tests written against
+The frontend tests aren't smoke tests - they're regression tests written against
 a specific, previously-real bug, and they mount real providers instead of
-asserting against an isolated store:
+asserting against an isolated store. The comment above `auth-context.test.tsx`
+explains _why_ it mounts the full `AuthProvider` rather than testing the store
+in isolation: a store-only test would have passed even with the bug present,
+because the defect was that nothing in the session lifecycle called the store's
+cleanup function - not that the cleanup function itself was broken.
 
-```typescript
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
-import { AuthProvider } from './auth-context';
+That's the bar worth aiming for: a test that would actually fail if the fix were
+reverted.
 
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
-  usePathname: () => '/dashboard',
-}));
-
-vi.mock('@opndrive/s3-api', () => ({
-  BYOS3ApiProvider: class {
-    getS3Client() {
-      return {};
-    }
-    getBucketName() {
-      return 'test-bucket';
-    }
-  },
-  // ...
-}));
-```
-
-The comment above the real version of this test explains _why_ it mounts the
-full `AuthProvider` rather than testing the store in isolation: a store-only
-test would have passed even with the bug present, because the defect was that
-nothing in the session lifecycle called the store's cleanup function - not that
-the cleanup function itself was broken. That's the bar worth aiming for: a test
-that would actually fail if the fix were reverted, not one that happens to pass
-either way.
-
-## Adding a Test
-
-1. Put it next to the code it tests (`foo.ts` → `foo.test.ts`), matching the two
-   existing examples.
-2. Mock at the boundary (`@opndrive/s3-api`, `next/navigation`), not deep inside
-   your own code.
-3. Before you trust a new test, revert the fix it's supposed to guard and
-   confirm the test actually fails. A test that passes both with and without the
-   bug isn't testing anything.
+The same idea shows up in `s3-api` as pinning tests for behaviour that is
+_currently_ surprising. `fetchDirectoryStructure` catches every error and
+returns an empty listing, which makes an `AccessDenied` indistinguishable from
+an empty folder. There's a test asserting exactly that, with a comment saying it
+records the behaviour rather than endorses it - so if someone fixes it, the
+failing test is the prompt to update the callers too.

--- a/s3-api/.gitignore
+++ b/s3-api/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 test-uploads
+coverage
+dist
 
 .env
 *.tgz

--- a/s3-api/Readme.md
+++ b/s3-api/Readme.md
@@ -41,9 +41,18 @@ method list and the reasoning behind the trickier ones (`deleteBatch`,
 
 ```bash
 pnpm install
-pnpm check   # typecheck + test
+pnpm check           # typecheck + test
+pnpm test:coverage   # text summary + HTML report in coverage/
 pnpm build
 ```
+
+Tests mock the AWS SDK with
+[`aws-sdk-client-mock`](https://github.com/m-radzikowski/aws-sdk-client-mock),
+so **no AWS credentials are needed** and nothing hits the network. Test files
+live next to the code they cover (`foo.ts` → `foo.test.ts`) and import from
+source, never from `dist/`. See the
+[Testing guide](../docs/content/development/testing.md) for the mock patterns
+and conventions.
 
 See [Release Process](../docs/content/maintainers/release-process.md) for how
 versions get published.

--- a/s3-api/package.json
+++ b/s3-api/package.json
@@ -9,8 +9,9 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
     "check": "pnpm typecheck && pnpm test",
-    "build": "tsc"
+    "build": "tsc -p tsconfig.build.json"
   },
   "exports": {
     ".": {
@@ -30,6 +31,9 @@
     "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",
+    "@vitest/coverage-v8": "^4.1.10",
+    "aws-sdk-client-mock": "^4.1.0",
+    "aws-sdk-client-mock-vitest": "^7.1.0",
     "eslint": "^9.39.5",
     "tsup": "^8.5.0",
     "tsx": "^4.20.3",

--- a/s3-api/pnpm-lock.yaml
+++ b/s3-api/pnpm-lock.yaml
@@ -30,6 +30,15 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.38.0
         version: 8.65.0(eslint@9.39.5)(typescript@5.9.3)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
+      aws-sdk-client-mock-vitest:
+        specifier: ^7.1.0
+        version: 7.1.0(@smithy/types@4.16.1)(aws-sdk-client-mock@4.1.0)(vitest@4.1.10)
       eslint:
         specifier: ^9.39.5
         version: 9.39.5
@@ -44,7 +53,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(vite@7.0.6(@types/node@26.1.1)(tsx@4.23.1))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.0.6(@types/node@26.1.1)(tsx@4.23.1))
 
 packages:
 
@@ -123,6 +132,27 @@ packages:
   '@aws/lambda-invoke-store@0.3.0':
     resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -788,6 +818,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@11.2.2':
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@sinonjs/samsam@8.0.3':
+    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
+
   '@smithy/core@3.30.0':
     resolution: {integrity: sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==}
     engines: {node: '>=18.0.0'}
@@ -829,6 +871,12 @@ packages:
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -889,6 +937,15 @@ packages:
     resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -944,6 +1001,20 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
+
+  aws-sdk-client-mock-vitest@7.1.0:
+    resolution: {integrity: sha512-Qjl5cHdTysOfsq7ac0UFchQKW/A4NbVL4uhU1FcPmawAQQ8Bt6xsTJA//gWCkZO9+hHQxcCJfpmWbSYm02po1A==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@smithy/types': '>=3.5.0'
+      aws-sdk-client-mock: '>=2.2.0'
+      vitest: '>=3.2.0'
+
+  aws-sdk-client-mock@4.1.0:
+    resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1027,6 +1098,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -1160,6 +1235,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1187,9 +1265,24 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -1203,6 +1296,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1232,6 +1328,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1255,6 +1358,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  nise@6.1.5:
+    resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1287,6 +1393,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1367,6 +1476,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1463,6 +1575,14 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1756,6 +1876,21 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -2142,6 +2277,23 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@11.2.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/fake-timers@15.4.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@8.0.3':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+
   '@smithy/core@3.30.0':
     dependencies:
       '@smithy/types': 4.16.1
@@ -2191,6 +2343,12 @@ snapshots:
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)':
     dependencies:
@@ -2283,6 +2441,20 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.0.6(@types/node@26.1.1)(tsx@4.23.1))
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2347,6 +2519,25 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  aws-sdk-client-mock-vitest@7.1.0(@smithy/types@4.16.1)(aws-sdk-client-mock@4.1.0)(vitest@4.1.10):
+    dependencies:
+      '@smithy/types': 4.16.1
+      '@vitest/expect': 4.1.10
+      aws-sdk-client-mock: 4.1.0
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.0.6(@types/node@26.1.1)(tsx@4.23.1))
+
+  aws-sdk-client-mock@4.1.0:
+    dependencies:
+      '@types/sinon': 17.0.4
+      sinon: 18.0.1
+      tslib: 2.8.1
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -2409,6 +2600,8 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  diff@5.2.2: {}
 
   dotenv@17.4.2: {}
 
@@ -2620,6 +2813,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  html-escaper@2.0.2: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -2639,7 +2834,22 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-yaml@4.3.0:
     dependencies:
@@ -2650,6 +2860,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  just-extend@6.2.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -2675,6 +2887,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   minimatch@10.2.5:
     dependencies:
@@ -2702,6 +2924,13 @@ snapshots:
   nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
+
+  nise@6.1.5:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 15.4.0
+      just-extend: 6.2.0
+      path-to-regexp: 8.4.2
 
   object-assign@4.1.1: {}
 
@@ -2731,6 +2960,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -2809,6 +3040,15 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  sinon@18.0.1:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.3
+      diff: 5.2.2
+      nise: 6.1.5
+      supports-color: 7.2.0
 
   source-map-js@1.2.1: {}
 
@@ -2903,6 +3143,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.0.8: {}
+
+  type-detect@4.1.0: {}
+
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
@@ -2928,7 +3172,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.23.1
 
-  vitest@4.1.10(@types/node@26.1.1)(vite@7.0.6(@types/node@26.1.1)(tsx@4.23.1)):
+  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.0.6(@types/node@26.1.1)(tsx@4.23.1)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.0.6(@types/node@26.1.1)(tsx@4.23.1))
@@ -2952,6 +3196,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/s3-api/src/core/index.test.ts
+++ b/s3-api/src/core/index.test.ts
@@ -1,0 +1,189 @@
+/**
+ * `BaseS3ApiProvider` mechanics: how the S3Client gets configured from
+ * credentials, and the debugLog switch.
+ *
+ * The client config is what decides retry behaviour and addressing style for
+ * every call the package makes, so it is worth pinning explicitly rather than
+ * inferring it from a downstream request. Most v3 config fields resolve to
+ * async providers, hence the awaits.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { BYOS3ApiProvider } from '../index.js';
+import type { Credentials, logTypes } from './types.js';
+
+const creds: Credentials = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  bucketName: 'test-bucket',
+  prefix: 'users/alice/',
+  region: 'eu-west-2',
+};
+
+function makeApi(overrides: Partial<Credentials> = {}) {
+  return new BYOS3ApiProvider({ ...creds, ...overrides }, 'BYO');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('S3Client construction', () => {
+  it('builds the client from the supplied region and credentials', async () => {
+    const config = makeApi().getS3Client().config;
+
+    expect(await config.region()).toBe('eu-west-2');
+    expect(await config.credentials()).toMatchObject({
+      accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    });
+  });
+
+  it('raises maxAttempts to 5 and retries only at this layer', async () => {
+    const config = makeApi().getS3Client().config;
+
+    // Bulk operations (renameFolder, deleteBatch) issue thousands of requests.
+    // The SDK's own strategy already backs off on throttling and 5xx, so this
+    // is the ONLY retry layer - a second one around send() would multiply
+    // attempts and fight the SDK's rate limiter.
+    expect(await config.maxAttempts()).toBe(5);
+  });
+
+  it('computes checksums only when the operation requires them', async () => {
+    const config = makeApi().getS3Client().config;
+
+    // Full-body checksums on every request break some S3-compatible services
+    // and cost throughput on large uploads.
+    expect(await config.requestChecksumCalculation()).toBe('WHEN_REQUIRED');
+    expect(await config.responseChecksumValidation()).toBe('WHEN_REQUIRED');
+  });
+
+  it('uses virtual-host addressing when no custom endpoint is given', () => {
+    const config = makeApi().getS3Client().config;
+
+    // The SDK resolves the unset flag to an explicit false.
+    expect(config.forcePathStyle).toBe(false);
+  });
+
+  it('switches to path-style addressing for a custom endpoint', async () => {
+    const config = makeApi({ endpoint: 'https://minio.example.com:9000' }).getS3Client().config;
+
+    // MinIO and friends rarely support virtual-host buckets, so setting an
+    // endpoint has to flip addressing too or every request 404s.
+    expect(config.forcePathStyle).toBe(true);
+    expect(await config.endpoint!()).toMatchObject({
+      hostname: 'minio.example.com',
+      port: 9000,
+    });
+  });
+
+  it('gives each provider its own client instance', () => {
+    // The upload managers hold onto a client across a session; sharing one
+    // between two providers would let a disposed session's client leak into
+    // the next one.
+    expect(makeApi().getS3Client()).not.toBe(makeApi().getS3Client());
+  });
+});
+
+describe('accessors', () => {
+  it('exposes the credentials the provider was built with', () => {
+    const api = makeApi();
+
+    expect(api.getBucketName()).toBe('test-bucket');
+    expect(api.getPrefix()).toBe('users/alice/');
+    expect(api.getRegion()).toBe('eu-west-2');
+  });
+
+  it('returns the same client instance on every call', () => {
+    const api = makeApi();
+
+    expect(api.getS3Client()).toBe(api.getS3Client());
+  });
+
+  it('reports an empty prefix as empty rather than substituting a default', () => {
+    // The dashboard treats '' as "bucket root"; a silent default would trap
+    // the user inside a prefix they never configured.
+    expect(makeApi({ prefix: '' }).getPrefix()).toBe('');
+  });
+});
+
+describe('debugLog', () => {
+  it('prefixes every entry with an ISO timestamp and the user type', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    makeApi().debugLog('BYO', 'log', 'hello');
+
+    expect(log.mock.calls[0]![0]).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[BYO-S3\]:$/
+    );
+  });
+
+  it('routes "log" to console.log with the message and data', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    makeApi().debugLog('BYO', 'log', 'listing done', null, { count: 3 });
+
+    expect(log).toHaveBeenCalledTimes(2); // header + payload
+    expect(log.mock.calls[1]).toEqual(['listing done', { count: 3 }, '\n']);
+  });
+
+  it('routes "error" to console.error and ignores the message', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const boom = new Error('boom');
+
+    makeApi().debugLog('BYO', 'error', 'this message is not printed', boom);
+
+    expect(error).toHaveBeenCalledExactlyOnceWith(boom, '\n');
+  });
+
+  it('routes "warn" to console.warn', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    makeApi().debugLog('BYO', 'warn', 'slow down');
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith('slow down', '\n');
+  });
+
+  it('routes "table" to console.table with the data', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const table = vi.spyOn(console, 'table').mockImplementation(() => {});
+    const rows = [{ key: 'a.txt' }];
+
+    makeApi().debugLog('BYO', 'table', undefined, undefined, rows);
+
+    expect(table).toHaveBeenCalledExactlyOnceWith(rows);
+    expect(log).toHaveBeenCalledTimes(2); // header + trailing blank line
+  });
+
+  it('routes "dir" to console.dir with unlimited depth', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dir = vi.spyOn(console, 'dir').mockImplementation(() => {});
+    const nested = { a: { b: { c: { d: 1 } } } };
+
+    makeApi().debugLog('BYO', 'dir', undefined, undefined, nested);
+
+    // Node truncates at depth 2 by default, which hides exactly the nested
+    // response shapes this is used to inspect.
+    expect(dir).toHaveBeenCalledExactlyOnceWith(nested, { depth: null });
+  });
+
+  it('prints only the header for an unrecognised log type', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    makeApi().debugLog('BYO', 'nonsense' as logTypes, 'ignored');
+
+    // No switch arm matches, so nothing beyond the header is emitted - and it
+    // must not throw.
+    expect(log).toHaveBeenCalledOnce();
+  });
+
+  it('tolerates being called with no message, error, or data', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => makeApi().debugLog('BYO', 'warn')).not.toThrow();
+    expect(warn).toHaveBeenCalledExactlyOnceWith(undefined, '\n');
+  });
+});

--- a/s3-api/src/index.listing.test.ts
+++ b/s3-api/src/index.listing.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Listing and metadata coverage for `BYOS3ApiProvider`.
+ *
+ * These import the provider from source (`./index.js`), not from `dist/`, so
+ * coverage instruments the real files and a run never depends on a stale build.
+ *
+ * The S3 client is intercepted by `aws-sdk-client-mock`, so nothing here makes a
+ * network call or reads credentials from the environment. What's under test is
+ * our own layer: which command we build, how we map the response, and what we
+ * do when the SDK throws.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  ListObjectsV2Command,
+  HeadObjectCommand,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { BYOS3ApiProvider } from './index.js';
+import type { Credentials } from './core/types.js';
+
+const s3Mock = mockClient(S3Client);
+
+const creds: Credentials = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  bucketName: 'test-bucket',
+  prefix: 'users/alice/',
+  region: 'us-east-1',
+};
+
+function makeApi(overrides: Partial<Credentials> = {}) {
+  return new BYOS3ApiProvider({ ...creds, ...overrides }, 'BYO');
+}
+
+/**
+ * Raw input of the nth ListObjectsV2 call. The `toHaveReceivedCommandWith`
+ * matcher does a partial match and cannot express "this key was never set", so
+ * absence assertions read the input directly.
+ */
+function inputOfCall(n: number) {
+  return s3Mock.commandCalls(ListObjectsV2Command)[n]!.args[0].input;
+}
+
+/** Builds an S3ServiceException with a given HTTP status, as the SDK would throw. */
+function s3Error(name: string, httpStatusCode: number) {
+  return new S3ServiceException({
+    name,
+    $fault: 'client',
+    $metadata: { httpStatusCode },
+    message: name,
+  });
+}
+
+beforeEach(() => {
+  s3Mock.reset();
+});
+
+describe('fetchDirectoryStructure', () => {
+  it('splits a listing into files and folders and carries pagination through', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({
+      Contents: [{ Key: 'users/alice/a.txt' }, { Key: 'users/alice/b.txt' }],
+      CommonPrefixes: [{ Prefix: 'users/alice/photos/' }],
+      NextContinuationToken: 'token-2',
+      IsTruncated: true,
+    });
+
+    const result = await makeApi().fetchDirectoryStructure('users/alice/', 50);
+
+    expect(result).toEqual({
+      files: [{ Key: 'users/alice/a.txt' }, { Key: 'users/alice/b.txt' }],
+      folders: [{ Prefix: 'users/alice/photos/' }],
+      nextToken: 'token-2',
+      isTruncated: true,
+    });
+  });
+
+  it('requests a delimited listing so subfolders collapse into CommonPrefixes', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({});
+
+    await makeApi().fetchDirectoryStructure('photos/', 25, 'token-1');
+
+    // Without Delimiter: '/' S3 returns every key recursively and `folders`
+    // would always come back empty.
+    expect(s3Mock).toHaveReceivedCommandWith(ListObjectsV2Command, {
+      Bucket: 'test-bucket',
+      Prefix: 'photos/',
+      MaxKeys: 25,
+      ContinuationToken: 'token-1',
+      Delimiter: '/',
+    });
+  });
+
+  it('defaults to 50 keys when no page size is given', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({});
+
+    await makeApi().fetchDirectoryStructure('photos/');
+
+    expect(s3Mock).toHaveReceivedCommandWith(ListObjectsV2Command, { MaxKeys: 50 });
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('falls back to the credential prefix when the prefix is %s', async (_label, prefix) => {
+    s3Mock.on(ListObjectsV2Command).resolves({});
+
+    await makeApi().fetchDirectoryStructure(prefix, 10);
+
+    expect(s3Mock).toHaveReceivedCommandWith(ListObjectsV2Command, { Prefix: 'users/alice/' });
+  });
+
+  it('treats an empty prefix as the bucket root, not as "unset"', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({});
+
+    await makeApi().fetchDirectoryStructure('', 10);
+
+    // '' is not nullish, so it must NOT collapse to the credential prefix -
+    // otherwise a caller could never list above their configured prefix.
+    expect(s3Mock).toHaveReceivedCommandWith(ListObjectsV2Command, { Prefix: '' });
+  });
+
+  it('returns empty collections when the bucket page has neither files nor folders', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({});
+
+    const result = await makeApi().fetchDirectoryStructure('empty/', 50);
+
+    expect(result).toEqual({
+      files: [],
+      folders: [],
+      nextToken: undefined,
+      isTruncated: undefined,
+    });
+  });
+
+  it('KNOWN DEBT: reports a denied listing identically to an empty folder', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({});
+    const whenGenuinelyEmpty = await makeApi().fetchDirectoryStructure('users/alice/', 50);
+
+    s3Mock.reset();
+    s3Mock.on(ListObjectsV2Command).rejects(s3Error('AccessDenied', 403));
+    const whenAccessDenied = await makeApi().fetchDirectoryStructure('users/alice/', 50);
+
+    // KNOWN DEBT - `fetchDirectoryStructure` in src/index.ts catches every
+    // error and returns an empty structure, so a permissions failure is
+    // byte-for-byte indistinguishable from a genuinely empty folder and the UI
+    // cannot tell the user why their files vanished.
+    //
+    // This test PINS that behaviour so it cannot change silently. It does NOT
+    // endorse it. When the method learns to surface errors, this test SHOULD
+    // fail - and that failure is the prompt to update every caller that
+    // currently treats an empty result as authoritative.
+    expect(whenAccessDenied).toEqual(whenGenuinelyEmpty);
+    expect(whenAccessDenied).toEqual({
+      files: [],
+      folders: [],
+      nextToken: undefined,
+      isTruncated: undefined,
+    });
+  });
+});
+
+describe('fetchMetadata', () => {
+  it('returns the HeadObject response for an existing key', async () => {
+    const lastModified = new Date('2026-01-15T10:00:00Z');
+    s3Mock.on(HeadObjectCommand).resolves({
+      ContentLength: 2048,
+      ContentType: 'application/pdf',
+      LastModified: lastModified,
+      ETag: '"abc123"',
+    });
+
+    const result = await makeApi().fetchMetadata('users/alice/report.pdf');
+
+    expect(result).toMatchObject({
+      ContentLength: 2048,
+      ContentType: 'application/pdf',
+      LastModified: lastModified,
+      ETag: '"abc123"',
+    });
+    expect(s3Mock).toHaveReceivedCommandWith(HeadObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/report.pdf',
+    });
+  });
+
+  it('returns null for a missing object without logging', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    s3Mock.on(HeadObjectCommand).rejects(s3Error('NotFound', 404));
+
+    const result = await makeApi().fetchMetadata('users/alice/gone.pdf');
+
+    expect(result).toBeNull();
+    // A 404 is how callers probe for existence; logging it would flood the
+    // console during normal use.
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('returns null but warns for failures that are not a missing object', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    s3Mock.on(HeadObjectCommand).rejects(s3Error('AccessDenied', 403));
+
+    const result = await makeApi().fetchMetadata('users/alice/secret.pdf');
+
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it('warns for a non-service error, since it carries no HTTP status to inspect', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    s3Mock.on(HeadObjectCommand).rejects(new Error('socket hang up'));
+
+    const result = await makeApi().fetchMetadata('users/alice/report.pdf');
+
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+});
+
+describe('listFromPrefix', () => {
+  it('follows continuation tokens until the listing is exhausted', async () => {
+    s3Mock
+      .on(ListObjectsV2Command)
+      .resolvesOnce({
+        Contents: [{ Key: 'docs/a.txt' }, { Key: 'docs/b.txt' }],
+        NextContinuationToken: 'page-2',
+      })
+      .resolvesOnce({
+        Contents: [{ Key: 'docs/c.txt' }],
+        NextContinuationToken: 'page-3',
+      })
+      .resolvesOnce({
+        Contents: [{ Key: 'docs/d.txt' }],
+      });
+
+    const keys = await makeApi().listFromPrefix('docs/');
+
+    expect(keys).toEqual(['docs/a.txt', 'docs/b.txt', 'docs/c.txt', 'docs/d.txt']);
+    expect(s3Mock).toHaveReceivedCommandTimes(ListObjectsV2Command, 3);
+  });
+
+  it('passes the previous page token on each follow-up request', async () => {
+    s3Mock
+      .on(ListObjectsV2Command)
+      .resolvesOnce({ Contents: [{ Key: 'docs/a.txt' }], NextContinuationToken: 'page-2' })
+      .resolvesOnce({ Contents: [{ Key: 'docs/b.txt' }] });
+
+    await makeApi().listFromPrefix('docs/');
+
+    // First request must not carry a token; the second must carry the one the
+    // first returned, or the loop would re-read page 1 forever.
+    expect(s3Mock).toHaveReceivedNthCommandWith(ListObjectsV2Command, 1, {
+      Bucket: 'test-bucket',
+      Prefix: 'docs/',
+    });
+    expect(inputOfCall(0).ContinuationToken).toBeUndefined();
+    expect(s3Mock).toHaveReceivedNthCommandWith(ListObjectsV2Command, 2, {
+      ContinuationToken: 'page-2',
+    });
+  });
+
+  it('lists recursively, without a delimiter', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'docs/nested/deep.txt' }] });
+
+    const keys = await makeApi().listFromPrefix('docs/');
+
+    // renameFolder's verification step depends on this seeing every key under
+    // the prefix, including nested ones - a Delimiter would collapse them.
+    expect(inputOfCall(0).Delimiter).toBeUndefined();
+    expect(keys).toEqual(['docs/nested/deep.txt']);
+  });
+
+  it('returns an empty list when the prefix holds nothing', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({});
+
+    await expect(makeApi().listFromPrefix('nothing/')).resolves.toEqual([]);
+  });
+
+  it('propagates a listing failure instead of reporting an empty prefix', async () => {
+    s3Mock.on(ListObjectsV2Command).rejects(s3Error('AccessDenied', 403));
+
+    // Unlike fetchDirectoryStructure, this must throw: renameFolder deletes
+    // based on the result, so a silent empty list would be dangerous.
+    await expect(makeApi().listFromPrefix('docs/')).rejects.toThrow();
+  });
+});
+
+describe('search', () => {
+  const page = {
+    Contents: [
+      { Key: 'docs/report-final.pdf' },
+      { Key: 'docs/Report-Draft.pdf' },
+      { Key: 'docs/notes.txt' },
+      { Key: 'docs/reports/' },
+      { Key: 'docs/archive/' },
+    ],
+  };
+
+  it('matches files and folders case-insensitively', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves(page);
+
+    const result = await makeApi().search({
+      prefix: 'docs/',
+      searchTerm: 'report',
+      nextToken: undefined,
+    });
+
+    expect(result.files).toEqual([
+      { Key: 'docs/report-final.pdf' },
+      { Key: 'docs/Report-Draft.pdf' },
+    ]);
+    expect(result.folders).toEqual([{ Key: 'docs/reports/' }]);
+    expect(result).toMatchObject({ totalFiles: 2, totalFolders: 1, totalKeys: 3 });
+  });
+
+  it('classifies keys as folders purely by their trailing slash', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves(page);
+
+    const result = await makeApi().search({
+      prefix: 'docs/',
+      searchTerm: '',
+      nextToken: undefined,
+    });
+
+    // An empty term matches everything, which makes the split visible.
+    expect(result.files.map((f) => f.Key)).toEqual([
+      'docs/report-final.pdf',
+      'docs/Report-Draft.pdf',
+      'docs/notes.txt',
+    ]);
+    expect(result.folders.map((f) => f.Key)).toEqual(['docs/reports/', 'docs/archive/']);
+  });
+
+  it('matches on the name only, ignoring the directory part of the key', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({
+      Contents: [{ Key: 'invoices/2026/summary.txt' }],
+    });
+
+    const result = await makeApi().search({
+      prefix: '',
+      searchTerm: 'invoices',
+      nextToken: undefined,
+    });
+
+    // 'invoices' appears in the key but not in the filename, so searching for
+    // a folder name must not drag in every file underneath it.
+    expect(result.files).toEqual([]);
+    expect(result.totalKeys).toBe(0);
+  });
+
+  it('strips the trailing slash before matching a folder name', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'docs/archive/' }] });
+
+    const result = await makeApi().search({
+      prefix: 'docs/',
+      searchTerm: 'archive',
+      nextToken: undefined,
+    });
+
+    // Matching against 'archive/' would still succeed here, but a term ending
+    // in the name (like 'archive') has to hit the bare name to be reliable.
+    expect(result.folders).toEqual([{ Key: 'docs/archive/' }]);
+    expect(result.totalFolders).toBe(1);
+  });
+
+  it('scans a full page of 1000 keys and passes the caller token through', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({ Contents: [], NextContinuationToken: 'page-2' });
+
+    const result = await makeApi().search({
+      prefix: 'docs/',
+      searchTerm: 'x',
+      nextToken: 'page-1',
+    });
+
+    // Matching happens client-side over one page, so the page has to be as
+    // large as S3 allows or results silently thin out.
+    expect(s3Mock).toHaveReceivedCommandWith(ListObjectsV2Command, {
+      Bucket: 'test-bucket',
+      Prefix: 'docs/',
+      ContinuationToken: 'page-1',
+      MaxKeys: 1000,
+    });
+    expect(result.nextToken).toBe('page-2');
+  });
+
+  it('reports an empty result set for a page with no contents', async () => {
+    s3Mock.on(ListObjectsV2Command).resolves({});
+
+    const result = await makeApi().search({
+      prefix: 'docs/',
+      searchTerm: 'anything',
+      nextToken: undefined,
+    });
+
+    expect(result).toEqual({
+      files: [],
+      totalFiles: 0,
+      folders: [],
+      totalFolders: 0,
+      totalKeys: 0,
+      nextToken: undefined,
+      isTruncated: undefined,
+    });
+  });
+
+  it('propagates a listing failure', async () => {
+    s3Mock.on(ListObjectsV2Command).rejects(s3Error('AccessDenied', 403));
+
+    await expect(
+      makeApi().search({ prefix: 'docs/', searchTerm: 'x', nextToken: undefined })
+    ).rejects.toThrow();
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/s3-api/src/index.multipart.test.ts
+++ b/s3-api/src/index.multipart.test.ts
@@ -1,0 +1,264 @@
+/**
+ * `uploadMultipartParallely` is a thin factory: it maps the caller's params
+ * onto a `MultipartUploadConfig` and hands back a `MultipartUploader`. The
+ * mapping is what's under test here, verified through the commands the
+ * returned uploader actually issues rather than by reaching into its privates.
+ *
+ * `MultipartUploader`'s constructor touches `localStorage` (it clears any
+ * stale resume state), which does not exist in the node test environment, so
+ * these suites install a memory-backed shim.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  CreateMultipartUploadCommand,
+  UploadPartCommand,
+  CompleteMultipartUploadCommand,
+} from '@aws-sdk/client-s3';
+import { BYOS3ApiProvider, MultipartUploader } from './index.js';
+import type { Credentials } from './core/types.js';
+
+const s3Mock = mockClient(S3Client);
+
+const creds: Credentials = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  bucketName: 'test-bucket',
+  prefix: 'users/alice/',
+  region: 'us-east-1',
+};
+
+const MB = 1024 * 1024;
+
+/** Minimal in-memory localStorage, enough for the uploader's get/set/remove. */
+function installLocalStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  });
+  return store;
+}
+
+function makeApi() {
+  return new BYOS3ApiProvider(creds, 'BYO');
+}
+
+beforeEach(() => {
+  s3Mock.reset();
+  installLocalStorage();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('uploadMultipartParallely', () => {
+  it('returns a MultipartUploader rather than starting an upload', () => {
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'users/alice/big.bin',
+      fileName: 'big.bin',
+      partSizeMB: 5 * MB,
+      concurrency: 4,
+    });
+
+    expect(uploader).toBeInstanceOf(MultipartUploader);
+    // The caller drives it, so nothing should have been sent yet.
+    expect(s3Mock).not.toHaveReceivedAnyCommand();
+  });
+
+  it('binds the uploader to the configured bucket and the requested key', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    s3Mock.on(UploadPartCommand).resolves({ ETag: '"etag-1"' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'users/alice/big.bin',
+      fileName: 'big.bin',
+      partSizeMB: 5 * MB,
+      concurrency: 1,
+    });
+    await uploader.start(new File(['hello'], 'big.bin'));
+
+    expect(s3Mock).toHaveReceivedCommandWith(CreateMultipartUploadCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/big.bin',
+    });
+    expect(s3Mock).toHaveReceivedCommandWith(UploadPartCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/big.bin',
+      UploadId: 'upload-1',
+      PartNumber: 1,
+    });
+  });
+
+  it('completes the upload with the parts it collected', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    s3Mock.on(UploadPartCommand).resolves({ ETag: '"etag-1"' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'k',
+      fileName: 'f',
+      partSizeMB: 5 * MB,
+      concurrency: 1,
+    });
+    await uploader.start(new File(['hello'], 'f'));
+
+    expect(s3Mock).toHaveReceivedCommandWith(CompleteMultipartUploadCommand, {
+      UploadId: 'upload-1',
+      MultipartUpload: { Parts: [{ ETag: '"etag-1"', PartNumber: 1 }] },
+    });
+  });
+
+  it('clears any stale resume state for the same file and key', () => {
+    const store = installLocalStorage();
+    store.set('upload:big.bin:users/alice/big.bin', '{"uploadId":"stale"}');
+
+    makeApi().uploadMultipartParallely({
+      key: 'users/alice/big.bin',
+      fileName: 'big.bin',
+      partSizeMB: 5 * MB,
+      concurrency: 4,
+    });
+
+    // A leftover uploadId from a previous session points at a multipart upload
+    // S3 may have already aborted.
+    expect(store.has('upload:big.bin:users/alice/big.bin')).toBe(false);
+  });
+
+  it('falls back to a concurrency of 3 when given a non-positive value', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'u' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+    let inFlight = 0;
+    let peak = 0;
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+      return { ETag: '"e"' };
+    });
+
+    // 6 parts of 5MB, so there is enough work for the limit to be observable.
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'k',
+      fileName: 'f',
+      partSizeMB: 5 * MB,
+      concurrency: 0,
+    });
+    await uploader.start(new File(['x'.repeat(30 * MB)], 'f'));
+
+    expect(peak).toBe(3);
+  });
+
+  it('honours a caller-supplied concurrency', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'u' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+    let inFlight = 0;
+    let peak = 0;
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+      return { ETag: '"e"' };
+    });
+
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'k',
+      fileName: 'f',
+      partSizeMB: 5 * MB,
+      concurrency: 2,
+    });
+    await uploader.start(new File(['x'.repeat(30 * MB)], 'f'));
+
+    expect(peak).toBe(2);
+  });
+
+  it('reports progress as parts complete', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'u' });
+    s3Mock.on(UploadPartCommand).resolves({ ETag: '"e"' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+    const progress: number[] = [];
+
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'k',
+      fileName: 'f',
+      partSizeMB: 5 * MB,
+      concurrency: 1,
+    });
+    await uploader.start(new File(['x'.repeat(15 * MB)], 'f'), (p) => progress.push(p));
+
+    // Mirrors the uploader's own `(completed / total) * 100` so the comparison
+    // is not at the mercy of float association order.
+    expect(progress).toEqual([(1 / 3) * 100, (2 / 3) * 100, 100]);
+  });
+
+  it('KNOWN BUG: partSizeMB is compared against bytes, so real MB values are ignored', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'u' });
+    s3Mock.on(UploadPartCommand).resolves({ ETag: '"e"' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+
+    // The field is named partSizeMB, but MultipartUploader guards it with
+    // `partSizeMB >= 5 * 1024 * 1024` - a BYTE threshold. So a caller passing
+    // the documented unit (10, meaning 10 MB) fails the check and silently
+    // gets the 5 MB default instead of 10 MB parts.
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'k',
+      fileName: 'f',
+      partSizeMB: 10,
+      concurrency: 1,
+    });
+    await uploader.start(new File(['x'.repeat(10 * MB)], 'f'));
+
+    // 10 MB at the intended 10 MB part size would be ONE part; at the silently
+    // substituted 5 MB default it is two. Pinned, not endorsed - fixing the
+    // unit should make this test fail.
+    const parts = s3Mock.commandCalls(UploadPartCommand);
+    expect(parts).toHaveLength(2);
+  });
+
+  it('clamps any part size below 5MB up to the 5MB minimum', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'u' });
+    s3Mock.on(UploadPartCommand).resolves({ ETag: '"e"' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'k',
+      fileName: 'f',
+      partSizeMB: 1024, // far below the byte threshold
+      concurrency: 1,
+    });
+    await uploader.start(new File(['x'.repeat(12 * MB)], 'f'));
+
+    // Clamped to 5MB, so 12MB splits into 5 + 5 + 2 rather than into 12288
+    // one-kilobyte parts that S3 would reject.
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(3);
+  });
+
+  it('DEAD CODE: the "non-final part <5MB" guard cannot be reached', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'u' });
+    s3Mock.on(UploadPartCommand).resolves({ ETag: '"e"' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+
+    // The constructor clamps partSize to >= 5MB, and every non-final part is
+    // exactly partSize, so `end - start < 5MB && partNumber !== totalParts` can
+    // never both hold. The throw inside uploadParts is unreachable defensive
+    // code - it will always show as an uncovered branch, and no test can fix
+    // that without changing the source. Recorded here so the gap is explained
+    // rather than mysterious.
+    const uploader = makeApi().uploadMultipartParallely({
+      key: 'k',
+      fileName: 'f',
+      partSizeMB: 1,
+      concurrency: 1,
+    });
+
+    await expect(uploader.start(new File(['x'.repeat(6 * MB)], 'f'))).resolves.toBeUndefined();
+  });
+});

--- a/s3-api/src/index.objects.test.ts
+++ b/s3-api/src/index.objects.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Single-object operation coverage for `BYOS3ApiProvider`: presigned upload,
+ * presigned GET, download, delete, batch delete, and folder-marker creation.
+ *
+ * Presigning is computed locally (an HMAC over the request), so those cases
+ * need no stubbed response and never reach `send` - fake credentials still
+ * produce a real, inspectable URL. Everything else goes through
+ * `aws-sdk-client-mock`.
+ *
+ * The exhaustive `Content-Disposition` cases (unicode, header injection, path
+ * stripping) live in `tests/contentDisposition.test.ts`; what's here is the
+ * parameter mapping around them.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { Readable } from 'stream';
+import { BYOS3ApiProvider } from './index.js';
+import type { Credentials } from './core/types.js';
+
+const s3Mock = mockClient(S3Client);
+
+const creds: Credentials = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  bucketName: 'test-bucket',
+  prefix: 'users/alice/',
+  region: 'us-east-1',
+};
+
+function makeApi(overrides: Partial<Credentials> = {}) {
+  return new BYOS3ApiProvider({ ...creds, ...overrides }, 'BYO');
+}
+
+function s3Error(name: string, httpStatusCode: number) {
+  return new S3ServiceException({
+    name,
+    $fault: 'client',
+    $metadata: { httpStatusCode },
+    message: name,
+  });
+}
+
+/**
+ * Stubs a GetObject body. The SDK types `Body` as its own streaming union;
+ * the code under test branches on the runtime type, which is the whole point
+ * of these cases, so the cast is what lets us drive each branch.
+ */
+function stubBody(body: unknown, contentLength?: number) {
+  s3Mock.on(GetObjectCommand).resolves({
+    Body: body as never,
+    ContentLength: contentLength,
+  });
+}
+
+beforeEach(() => {
+  s3Mock.reset();
+});
+
+describe('uploadWithPreSignedUrl', () => {
+  it('signs a PUT for the requested key in the configured bucket', async () => {
+    const url = new URL(
+      await makeApi().uploadWithPreSignedUrl({
+        key: 'users/alice/photo.jpg',
+        expiresInSeconds: 900,
+      })
+    );
+
+    expect(url.hostname.startsWith('test-bucket.')).toBe(true);
+    expect(url.pathname).toBe('/users/alice/photo.jpg');
+    expect(url.searchParams.has('X-Amz-Signature')).toBe(true);
+    expect(url.searchParams.get('X-Amz-Expires')).toBe('900');
+  });
+
+  it('signs locally without contacting S3', async () => {
+    await makeApi().uploadWithPreSignedUrl({ key: 'a.txt', expiresInSeconds: 60 });
+
+    // A presign that issued a request would need live credentials and would
+    // make the whole flow far slower than it needs to be.
+    expect(s3Mock).not.toHaveReceivedAnyCommand();
+  });
+
+  it('rejects a key with a leading slash', async () => {
+    // S3 would happily create an object whose name begins with '/', producing
+    // a key no part of the UI can navigate back to.
+    await expect(
+      makeApi().uploadWithPreSignedUrl({ key: '/users/alice/photo.jpg', expiresInSeconds: 900 })
+    ).rejects.toThrow('Key starting with /');
+  });
+
+  it('rejects a negative expiry', async () => {
+    await expect(
+      makeApi().uploadWithPreSignedUrl({ key: 'photo.jpg', expiresInSeconds: -1 })
+    ).rejects.toThrow('Negative seconds');
+  });
+
+  it('accepts a zero expiry as the boundary of the validity check', async () => {
+    // Only negatives are rejected; 0 produces an already-expired but
+    // well-formed URL rather than an error.
+    await expect(
+      makeApi().uploadWithPreSignedUrl({ key: 'photo.jpg', expiresInSeconds: 0 })
+    ).resolves.toContain('X-Amz-Signature');
+  });
+});
+
+describe('getSignedUrl', () => {
+  const base = { key: 'users/alice/report.pdf', expiryInSeconds: 900, isPreview: false };
+
+  it('signs a GET for the requested key and expiry', async () => {
+    const url = new URL(await makeApi().getSignedUrl(base));
+
+    expect(url.hostname.startsWith('test-bucket.')).toBe(true);
+    expect(url.pathname).toBe('/users/alice/report.pdf');
+    expect(url.searchParams.get('X-Amz-Expires')).toBe('900');
+    expect(url.searchParams.has('X-Amz-Signature')).toBe(true);
+  });
+
+  it('asks S3 to serve previews inline with the caller content type', async () => {
+    const url = new URL(
+      await makeApi().getSignedUrl({
+        ...base,
+        isPreview: true,
+        responseContentType: 'application/pdf',
+      })
+    );
+
+    // Without an explicit inline disposition the browser downloads the file
+    // instead of rendering it in the preview pane.
+    expect(url.searchParams.get('response-content-disposition')).toBe('inline');
+    expect(url.searchParams.get('response-content-type')).toBe('application/pdf');
+  });
+
+  it('overrides the saved filename for downloads', async () => {
+    const url = new URL(
+      await makeApi().getSignedUrl({ ...base, downloadFilename: 'Q4 report.pdf' })
+    );
+
+    // The key's basename is opaque, so without this the file lands on disk
+    // under the wrong name - <a download> is ignored cross-origin.
+    expect(url.searchParams.get('response-content-disposition')).toBe(
+      `attachment; filename="Q4 report.pdf"; filename*=UTF-8''Q4%20report.pdf`
+    );
+  });
+
+  it('omits the disposition entirely when no filename is requested', async () => {
+    const url = new URL(await makeApi().getSignedUrl(base));
+
+    expect(url.searchParams.has('response-content-disposition')).toBe(false);
+  });
+
+  it('ignores a download filename in preview mode', async () => {
+    const url = new URL(
+      await makeApi().getSignedUrl({ ...base, isPreview: true, downloadFilename: 'ignored.pdf' })
+    );
+
+    expect(url.searchParams.get('response-content-disposition')).toBe('inline');
+  });
+
+  it('does not set a response content type for downloads', async () => {
+    const url = new URL(
+      await makeApi().getSignedUrl({ ...base, responseContentType: 'application/pdf' })
+    );
+
+    // responseContentType is a preview-only knob; a download should inherit
+    // whatever type the object was stored with.
+    expect(url.searchParams.has('response-content-type')).toBe(false);
+  });
+
+  it('rejects a key with a leading slash', async () => {
+    await expect(makeApi().getSignedUrl({ ...base, key: '/x.pdf' })).rejects.toThrow(
+      'Key starting with /'
+    );
+  });
+
+  it('rejects a negative expiry', async () => {
+    await expect(makeApi().getSignedUrl({ ...base, expiryInSeconds: -5 })).rejects.toThrow(
+      'Negative seconds'
+    );
+  });
+
+  it('signs against a custom endpoint using path-style addressing', async () => {
+    const url = new URL(
+      await makeApi({ endpoint: 'https://minio.example.com:9000' }).getSignedUrl(base)
+    );
+
+    // S3-compatible services (MinIO and friends) rarely support virtual-host
+    // buckets, so the bucket has to travel in the path instead.
+    expect(url.hostname).toBe('minio.example.com');
+    expect(url.pathname).toBe('/test-bucket/users/alice/report.pdf');
+  });
+});
+
+describe('downloadFile', () => {
+  it('concatenates a Node stream body into a Buffer', async () => {
+    stubBody(Readable.from([Buffer.from('hello '), Buffer.from('world')]), 11);
+
+    const result = await makeApi().downloadFile({ key: 'users/alice/greeting.txt' });
+
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect((result as Buffer).toString()).toBe('hello world');
+    expect(s3Mock).toHaveReceivedCommandWith(GetObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/greeting.txt',
+    });
+  });
+
+  it('converts non-Buffer chunks from a Node stream', async () => {
+    // Readable.from over typed arrays yields Uint8Array, not Buffer.
+    stubBody(Readable.from([new Uint8Array([104, 105])]), 2);
+
+    const result = await makeApi().downloadFile({ key: 'a.bin' });
+
+    expect((result as Buffer).toString()).toBe('hi');
+  });
+
+  it('reports progress as a Node stream drains', async () => {
+    stubBody(Readable.from([Buffer.from('hello '), Buffer.from('world')]), 11);
+    const progress: Array<[number, number, number]> = [];
+
+    await makeApi().downloadFile({
+      key: 'a.txt',
+      onProgress: (pct, loaded, total) => progress.push([pct, loaded, total]),
+    });
+
+    expect(progress).toEqual([
+      [(6 / 11) * 100, 6, 11],
+      [100, 11, 11],
+    ]);
+  });
+
+  it('collects a web stream body into a Blob', async () => {
+    stubBody(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.enqueue(new Uint8Array([4, 5]));
+          controller.close();
+        },
+      }),
+      5
+    );
+
+    const result = await makeApi().downloadFile({ key: 'a.bin' });
+
+    expect(result).toBeInstanceOf(Blob);
+    expect((result as Blob).size).toBe(5);
+  });
+
+  it('reports progress as a web stream drains', async () => {
+    stubBody(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.enqueue(new Uint8Array([4, 5]));
+          controller.close();
+        },
+      }),
+      5
+    );
+    const progress: Array<[number, number, number]> = [];
+
+    await makeApi().downloadFile({
+      key: 'a.bin',
+      onProgress: (pct, loaded, total) => progress.push([pct, loaded, total]),
+    });
+
+    expect(progress).toEqual([
+      [60, 3, 5],
+      [100, 5, 5],
+    ]);
+  });
+
+  it('passes a Blob body straight through', async () => {
+    const blob = new Blob(['already a blob']);
+    stubBody(blob, 14);
+
+    await expect(makeApi().downloadFile({ key: 'a.txt' })).resolves.toBe(blob);
+  });
+
+  it('stays silent when the response carries no ContentLength', async () => {
+    stubBody(Readable.from([Buffer.from('hello')]));
+    const onProgress = vi.fn();
+
+    await makeApi().downloadFile({ key: 'a.txt', onProgress });
+
+    // Percentages against an unknown total would be meaningless, so the
+    // callback is skipped rather than fired with NaN or Infinity.
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('stays silent for a zero-length object', async () => {
+    stubBody(Readable.from([]), 0);
+    const onProgress = vi.fn();
+
+    await makeApi().downloadFile({ key: 'empty.txt', onProgress });
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('throws when the response has no body', async () => {
+    s3Mock.on(GetObjectCommand).resolves({});
+
+    await expect(makeApi().downloadFile({ key: 'a.txt' })).rejects.toThrow(
+      'No data returned from S3'
+    );
+  });
+
+  it('throws for a body type it cannot stream', async () => {
+    stubBody('a bare string', 13);
+
+    await expect(makeApi().downloadFile({ key: 'a.txt' })).rejects.toThrow(
+      'Unsupported Body type returned from S3'
+    );
+  });
+
+  it('propagates a GetObject failure', async () => {
+    s3Mock.on(GetObjectCommand).rejects(s3Error('NoSuchKey', 404));
+
+    await expect(makeApi().downloadFile({ key: 'gone.txt' })).rejects.toThrow();
+  });
+});
+
+describe('deleteFile', () => {
+  it('deletes the given key from the configured bucket', async () => {
+    s3Mock.on(DeleteObjectCommand).resolves({});
+
+    await makeApi().deleteFile('users/alice/old.txt');
+
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(DeleteObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/old.txt',
+    });
+  });
+
+  it('propagates a delete failure to the caller', async () => {
+    s3Mock.on(DeleteObjectCommand).rejects(s3Error('AccessDenied', 403));
+
+    // Unwrapped and unswallowed: the UI has to be able to tell the user the
+    // file is still there.
+    await expect(makeApi().deleteFile('users/alice/locked.txt')).rejects.toThrow('AccessDenied');
+  });
+});
+
+describe('deleteBatch', () => {
+  const batch = [{ Key: 'a.txt' }, { Key: 'b.txt' }, { Key: 'c.txt' }];
+
+  it('sends the batch in quiet mode and reports every key deleted', async () => {
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    const result = await makeApi().deleteBatch(batch);
+
+    expect(result).toEqual({ requested: 3, deleted: 3, errors: [] });
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(DeleteObjectsCommand, {
+      Bucket: 'test-bucket',
+      Delete: { Objects: batch, Quiet: true },
+    });
+  });
+
+  it('surfaces per-object failures that arrive alongside a 200', async () => {
+    s3Mock.on(DeleteObjectsCommand).resolves({
+      Errors: [
+        { Key: 'b.txt', Code: 'AccessDenied', Message: 'Access Denied', VersionId: 'v1' },
+        { Key: 'c.txt', Code: 'InternalError', Message: 'We encountered an internal error' },
+      ],
+    });
+
+    const result = await makeApi().deleteBatch(batch);
+
+    // DeleteObjects answers 200 even when keys fail; treating the absence of a
+    // thrown error as success would silently lose data (opndrive#73).
+    expect(result).toEqual({
+      requested: 3,
+      deleted: 1,
+      errors: [
+        { key: 'b.txt', versionId: 'v1', code: 'AccessDenied', message: 'Access Denied' },
+        {
+          key: 'c.txt',
+          versionId: undefined,
+          code: 'InternalError',
+          message: 'We encountered an internal error',
+        },
+      ],
+    });
+  });
+
+  it('tolerates an error entry with no key', async () => {
+    s3Mock.on(DeleteObjectsCommand).resolves({ Errors: [{ Code: 'InternalError' }] });
+
+    const result = await makeApi().deleteBatch(batch);
+
+    // Every field on the SDK's _Error type is optional, Key included.
+    expect(result.errors[0]).toEqual({
+      key: '',
+      versionId: undefined,
+      code: 'InternalError',
+      message: undefined,
+    });
+    expect(result.deleted).toBe(2);
+  });
+
+  it('handles an empty batch without a division-by-zero style surprise', async () => {
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    await expect(makeApi().deleteBatch([])).resolves.toEqual({
+      requested: 0,
+      deleted: 0,
+      errors: [],
+    });
+  });
+
+  it('propagates a failure of the request itself', async () => {
+    s3Mock.on(DeleteObjectsCommand).rejects(s3Error('MalformedXML', 400));
+
+    await expect(makeApi().deleteBatch(batch)).rejects.toThrow();
+  });
+});
+
+describe('createFolder', () => {
+  it('writes a zero-byte marker object at the folder key', async () => {
+    s3Mock.on(PutObjectCommand).resolves({});
+
+    await makeApi().createFolder('users/alice/photos/');
+
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(PutObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/photos/',
+      Body: '',
+    });
+  });
+
+  it('appends the trailing slash that makes the key a folder marker', async () => {
+    s3Mock.on(PutObjectCommand).resolves({});
+
+    await makeApi().createFolder('users/alice/photos');
+
+    // Without it S3 stores an ordinary empty object and the listing shows a
+    // file named "photos" rather than a folder.
+    expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, { Key: 'users/alice/photos/' });
+  });
+
+  it('rejects a key with a leading slash', async () => {
+    await expect(makeApi().createFolder('/users/alice/photos')).rejects.toThrow(
+      'Key starts with /'
+    );
+  });
+
+  it('wraps an S3 failure with the key that could not be created', async () => {
+    s3Mock.on(PutObjectCommand).rejects(s3Error('AccessDenied', 403));
+
+    await expect(makeApi().createFolder('users/alice/photos')).rejects.toThrow(
+      /Create folder failed for users\/alice\/photos\/.*AccessDenied/
+    );
+  });
+});

--- a/s3-api/src/index.rename.test.ts
+++ b/s3-api/src/index.rename.test.ts
@@ -1,0 +1,623 @@
+/**
+ * Copy-and-delete operations: `moveFile`, `renameFile`, and `renameFolder`.
+ *
+ * These are the only methods in the package that delete data the user did not
+ * explicitly ask to delete, so the ordering guarantees matter more than the
+ * happy path. The recurring assertion below is "on failure, nothing was
+ * deleted" - `renameFolder` copies everything, verifies it arrived, and only
+ * then removes the originals.
+ *
+ * There is deliberately NO rollback: a failed copy leaves orphaned objects at
+ * the destination rather than trying to undo them. Re-running the same rename
+ * overwrites them, because CopyObject is idempotent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  ListObjectsV2Command,
+  CopyObjectCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { BYOS3ApiProvider } from './index.js';
+import type { Credentials, RenameFolderProgress } from './core/types.js';
+
+const s3Mock = mockClient(S3Client);
+
+const creds: Credentials = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  bucketName: 'test-bucket',
+  prefix: '',
+  region: 'us-east-1',
+};
+
+function makeApi() {
+  return new BYOS3ApiProvider(creds, 'BYO');
+}
+
+function s3Error(name: string, httpStatusCode = 403) {
+  return new S3ServiceException({
+    name,
+    $fault: 'client',
+    $metadata: { httpStatusCode },
+    message: name,
+  });
+}
+
+/** Stubs the listing for a prefix, returning the given keys as one page. */
+function stubListing(prefix: string, keys: string[]) {
+  s3Mock
+    .on(ListObjectsV2Command, { Prefix: prefix })
+    .resolves({ Contents: keys.map((Key) => ({ Key })) });
+}
+
+const copiedKeys = () =>
+  s3Mock.commandCalls(CopyObjectCommand).map((c) => c.args[0].input.Key as string);
+
+const deletedKeys = () =>
+  s3Mock
+    .commandCalls(DeleteObjectsCommand)
+    .flatMap((c) => (c.args[0].input.Delete?.Objects ?? []).map((o) => o.Key as string));
+
+beforeEach(() => {
+  s3Mock.reset();
+});
+
+describe('moveFile', () => {
+  it('copies to the new key and only then deletes the old one', async () => {
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectCommand).resolves({});
+
+    await makeApi().moveFile({ oldKey: 'a/old.txt', newKey: 'b/new.txt' });
+
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(CopyObjectCommand, {
+      Bucket: 'test-bucket',
+      CopySource: 'test-bucket/a%2Fold.txt',
+      Key: 'b/new.txt',
+    });
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(DeleteObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'a/old.txt',
+    });
+  });
+
+  it('url-encodes the copy source so keys with spaces and symbols survive', async () => {
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectCommand).resolves({});
+
+    await makeApi().moveFile({ oldKey: 'a/my file & notes.txt', newKey: 'b/n.txt' });
+
+    // An unencoded CopySource makes S3 read everything after the first '&' as
+    // a query parameter and the copy silently targets the wrong object.
+    expect(s3Mock).toHaveReceivedCommandWith(CopyObjectCommand, {
+      CopySource: 'test-bucket/a%2Fmy%20file%20%26%20notes.txt',
+    });
+  });
+
+  it('does not delete the source when the copy fails', async () => {
+    s3Mock.on(CopyObjectCommand).rejects(s3Error('AccessDenied'));
+
+    await expect(makeApi().moveFile({ oldKey: 'a/old.txt', newKey: 'b/new.txt' })).rejects.toThrow(
+      /Move failed for a\/old.txt → b\/new.txt/
+    );
+
+    // The whole point of copy-then-delete: a failed move must be a no-op, not
+    // a data-loss event.
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteObjectCommand);
+  });
+
+  it('wraps a failed delete, leaving a duplicate rather than losing the file', async () => {
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectCommand).rejects(s3Error('AccessDenied'));
+
+    await expect(makeApi().moveFile({ oldKey: 'a/old.txt', newKey: 'b/new.txt' })).rejects.toThrow(
+      /Move failed/
+    );
+  });
+});
+
+describe('renameFile', () => {
+  beforeEach(() => {
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectCommand).resolves({});
+  });
+
+  it('renames within the base path and reports success', async () => {
+    const result = await makeApi().renameFile({
+      basePath: 'users/alice/',
+      oldName: 'draft.md',
+      newName: 'final.md',
+    });
+
+    expect(result).toBe(true);
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(CopyObjectCommand, {
+      CopySource: 'test-bucket/users%2Falice%2Fdraft.md',
+      Key: 'users/alice/final.md',
+    });
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(DeleteObjectCommand, {
+      Key: 'users/alice/draft.md',
+    });
+  });
+
+  it('appends the missing trailing slash to the base path', async () => {
+    await makeApi().renameFile({
+      basePath: 'users/alice',
+      oldName: 'draft.md',
+      newName: 'final.md',
+    });
+
+    // Without this the rename would target 'users/alicedraft.md'.
+    expect(s3Mock).toHaveReceivedCommandWith(CopyObjectCommand, {
+      Key: 'users/alice/final.md',
+    });
+  });
+
+  it('rejects a base path with a leading slash', async () => {
+    await expect(
+      makeApi().renameFile({ basePath: '/users/alice/', oldName: 'a.md', newName: 'b.md' })
+    ).rejects.toThrow(/Rename failed for a.md → b.md.*Key starting with \//s);
+
+    expect(s3Mock).not.toHaveReceivedCommand(CopyObjectCommand);
+  });
+
+  it('does not delete the original when the copy fails', async () => {
+    s3Mock.on(CopyObjectCommand).rejects(s3Error('AccessDenied'));
+
+    await expect(
+      makeApi().renameFile({ basePath: 'users/alice/', oldName: 'a.md', newName: 'b.md' })
+    ).rejects.toThrow(/Rename failed/);
+
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteObjectCommand);
+  });
+});
+
+describe('renameFolder: guard rails', () => {
+  it('refuses to rename a prefix onto itself', async () => {
+    await expect(
+      makeApi().renameFolder({ oldPrefix: 'docs/', newPrefix: 'docs/' })
+    ).rejects.toThrow('source and destination prefixes are identical');
+
+    expect(s3Mock).not.toHaveReceivedAnyCommand();
+  });
+
+  it('treats a missing trailing slash as the same prefix', async () => {
+    // Normalisation happens before the equality check, so 'docs' and 'docs/'
+    // must not slip through as "different".
+    await expect(makeApi().renameFolder({ oldPrefix: 'docs', newPrefix: 'docs/' })).rejects.toThrow(
+      'identical'
+    );
+  });
+
+  it('refuses to rename a folder into its own descendant', async () => {
+    await expect(
+      makeApi().renameFolder({ oldPrefix: 'docs/', newPrefix: 'docs/archive/' })
+    ).rejects.toThrow(/overlapping prefixes/);
+
+    // The copy phase would write into the key range being listed, and the
+    // delete phase would then remove the freshly-copied objects.
+    expect(s3Mock).not.toHaveReceivedAnyCommand();
+  });
+
+  it('refuses to rename a folder onto its own ancestor', async () => {
+    await expect(
+      makeApi().renameFolder({ oldPrefix: 'docs/archive/', newPrefix: 'docs/' })
+    ).rejects.toThrow(/overlapping prefixes/);
+  });
+
+  it('allows unrelated sibling prefixes that share a name stem', async () => {
+    // 'docs2/' starts with neither 'docs/' nor vice versa once both are
+    // slash-terminated, so it must NOT be caught by the overlap guard.
+    stubListing('docs/', []);
+    stubListing('docs2/', []);
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'docs', newPrefix: 'docs2' });
+
+    expect(result.status).toBe('completed');
+  });
+});
+
+describe('renameFolder: copy phase', () => {
+  it('copies every key under the prefix to the new one', async () => {
+    stubListing('old/', ['old/a.txt', 'old/nested/b.txt']);
+    stubListing('new/', ['new/a.txt', 'new/nested/b.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    expect(copiedKeys().sort()).toEqual(['new/a.txt', 'new/nested/b.txt']);
+    expect(result).toMatchObject({
+      status: 'completed',
+      totalKeys: 2,
+      copiedKeys: 2,
+      deletedKeys: 2,
+      completed: true,
+      errors: [],
+    });
+  });
+
+  it('follows pagination when listing the source prefix', async () => {
+    s3Mock
+      .on(ListObjectsV2Command, { Prefix: 'old/' })
+      .resolvesOnce({ Contents: [{ Key: 'old/a.txt' }], NextContinuationToken: 'p2' })
+      .resolvesOnce({ Contents: [{ Key: 'old/b.txt' }] });
+    stubListing('new/', ['new/a.txt', 'new/b.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    // Missing page 2 would silently leave half the folder behind.
+    expect(result.totalKeys).toBe(2);
+    expect(copiedKeys().sort()).toEqual(['new/a.txt', 'new/b.txt']);
+  });
+
+  it('replaces only the leading prefix, not every occurrence in the key', async () => {
+    stubListing('a/', ['a/x/a/deep.txt']);
+    stubListing('b/', ['b/x/a/deep.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    await makeApi().renameFolder({ oldPrefix: 'a/', newPrefix: 'b/' });
+
+    // String.replace with a string pattern swaps the FIRST match only, which
+    // is what makes a repeated prefix inside the key safe.
+    expect(copiedKeys()).toEqual(['b/x/a/deep.txt']);
+  });
+
+  it('emits copy progress during the copy, not in one burst afterwards', async () => {
+    stubListing('old/', ['old/a.txt', 'old/b.txt']);
+    stubListing('new/', ['new/a.txt', 'new/b.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+    const events: RenameFolderProgress[] = [];
+
+    await makeApi().renameFolder({
+      oldPrefix: 'old/',
+      newPrefix: 'new/',
+      onProgress: (p) => events.push({ ...p }),
+    });
+
+    const copying = events.filter((e) => e.phase === 'copying');
+    expect(copying.map((e) => e.processed)).toEqual([1, 2]);
+    // Both keys are reported, each paired with its destination. Sorted because
+    // the copy phase is concurrent, so completion order is not part of the
+    // contract - but the values are.
+    expect(copying.map((e) => e.currentKey).sort()).toEqual(['old/a.txt', 'old/b.txt']);
+    expect(copying.map((e) => e.newKey).sort()).toEqual(['new/a.txt', 'new/b.txt']);
+    expect(copying.every((e) => e.total === 2)).toBe(true);
+  });
+
+  it('runs through all three phases in order', async () => {
+    stubListing('old/', ['old/a.txt']);
+    stubListing('new/', ['new/a.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+    const phases: string[] = [];
+
+    await makeApi().renameFolder({
+      oldPrefix: 'old/',
+      newPrefix: 'new/',
+      onProgress: (p) => phases.push(p.phase),
+    });
+
+    expect(phases).toEqual(['copying', 'verifying', 'deleting']);
+  });
+
+  it('bounds copy concurrency to 8 in-flight requests', async () => {
+    const keys = Array.from({ length: 30 }, (_, i) => `old/${i}.txt`);
+    stubListing('old/', keys);
+    stubListing(
+      'new/',
+      keys.map((k) => k.replace('old/', 'new/'))
+    );
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    let inFlight = 0;
+    let peak = 0;
+    s3Mock.on(CopyObjectCommand).callsFake(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+      return {};
+    });
+
+    await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    // Unbounded parallelism on a 100k-object folder would open 100k sockets and
+    // trip S3's rate limiter.
+    expect(peak).toBe(8);
+    expect(copiedKeys()).toHaveLength(30);
+  });
+});
+
+describe('renameFolder: copy failure leaves the source intact', () => {
+  it('deletes nothing and reports failure when a copy fails', async () => {
+    stubListing('old/', ['old/a.txt', 'old/b.txt', 'old/c.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(CopyObjectCommand, { Key: 'new/b.txt' }).rejects(s3Error('AccessDenied'));
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      totalKeys: 3,
+      copiedKeys: 2,
+      deletedKeys: 0,
+      completed: false,
+    });
+    // The source prefix is still the only complete copy of this data.
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteObjectsCommand);
+  });
+
+  it('keeps copying after a failure instead of stopping at the first one', async () => {
+    stubListing('old/', ['old/a.txt', 'old/b.txt', 'old/c.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(CopyObjectCommand, { Key: 'new/a.txt' }).rejects(s3Error('AccessDenied'));
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    // One inaccessible object shouldn't hide what else is wrong; nothing is
+    // deleted regardless, so there is no risk in continuing.
+    expect(copiedKeys().sort()).toEqual(['new/a.txt', 'new/b.txt', 'new/c.txt']);
+    expect(result.copiedKeys).toBe(2);
+  });
+
+  it('records the failing key and its error code', async () => {
+    stubListing('old/', ['old/a.txt']);
+    s3Mock.on(CopyObjectCommand).rejects(s3Error('AccessDenied'));
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    expect(result.errors).toEqual([
+      { key: 'old/a.txt', code: 'AccessDenied', message: 'AccessDenied' },
+    ]);
+  });
+
+  it('records a non-service error without a code', async () => {
+    stubListing('old/', ['old/a.txt']);
+    s3Mock.on(CopyObjectCommand).rejects(new Error('socket hang up'));
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    expect(result.errors).toEqual([
+      { key: 'old/a.txt', code: undefined, message: 'socket hang up' },
+    ]);
+  });
+
+  it('caps the reported errors at 10 to keep the payload bounded', async () => {
+    const keys = Array.from({ length: 25 }, (_, i) => `old/${i}.txt`);
+    stubListing('old/', keys);
+    s3Mock.on(CopyObjectCommand).rejects(s3Error('AccessDenied'));
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    // totalKeys still reports the true scale; only the enumeration is capped.
+    expect(result.errors).toHaveLength(10);
+    expect(result.totalKeys).toBe(25);
+    expect(result.copiedKeys).toBe(0);
+  });
+});
+
+describe('renameFolder: verification', () => {
+  it('compares the exact key set, not just a count', async () => {
+    stubListing('old/', ['old/a.txt', 'old/b.txt']);
+    // Destination has the right NUMBER of objects but the wrong ones: 'b.txt'
+    // never arrived and an unrelated pre-existing file makes up the count.
+    stubListing('new/', ['new/a.txt', 'new/unrelated-preexisting.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    // A count-based check passes here and then deletes the originals - the
+    // exact data-loss bug this comparison exists to prevent, and the reason
+    // the "Replace" flow made it reachable in practice.
+    expect(result.status).toBe('failed');
+    expect(result.errors[0]!.key).toBe('new/b.txt');
+    expect(result.errors[0]!.message).toMatch(/not present at the destination/);
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteObjectsCommand);
+  });
+
+  it('succeeds when the destination also holds unrelated pre-existing files', async () => {
+    stubListing('old/', ['old/a.txt']);
+    stubListing('new/', ['new/a.txt', 'new/something-else.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    // Extra objects at the destination are fine - only the absence of an
+    // expected one is fatal.
+    expect(result.status).toBe('completed');
+  });
+
+  it('reports every missing key, capped at 10', async () => {
+    const keys = Array.from({ length: 15 }, (_, i) => `old/${i}.txt`);
+    stubListing('old/', keys);
+    stubListing('new/', []); // nothing arrived
+    s3Mock.on(CopyObjectCommand).resolves({});
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    expect(result.status).toBe('failed');
+    expect(result.errors).toHaveLength(10);
+    expect(result.copiedKeys).toBe(15);
+    expect(result.deletedKeys).toBe(0);
+  });
+
+  it('emits a verifying progress event before deleting anything', async () => {
+    stubListing('old/', ['old/a.txt']);
+    stubListing('new/', ['new/a.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+    const events: RenameFolderProgress[] = [];
+
+    await makeApi().renameFolder({
+      oldPrefix: 'old/',
+      newPrefix: 'new/',
+      onProgress: (p) => events.push({ ...p }),
+    });
+
+    expect(events.find((e) => e.phase === 'verifying')).toMatchObject({
+      total: 1,
+      processed: 0,
+    });
+  });
+});
+
+describe('renameFolder: delete phase', () => {
+  it('deletes the old keys only after verification passes', async () => {
+    stubListing('old/', ['old/a.txt', 'old/b.txt']);
+    stubListing('new/', ['new/a.txt', 'new/b.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    expect(deletedKeys().sort()).toEqual(['old/a.txt', 'old/b.txt']);
+    expect(result.deletedKeys).toBe(2);
+  });
+
+  it('batches deletions at the 1000-object API limit', async () => {
+    const keys = Array.from({ length: 2500 }, (_, i) => `old/${i}.txt`);
+    stubListing('old/', keys);
+    stubListing(
+      'new/',
+      keys.map((k) => k.replace('old/', 'new/'))
+    );
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    // DeleteObjects rejects a request carrying more than 1000 keys outright.
+    const batches = s3Mock.commandCalls(DeleteObjectsCommand);
+    expect(batches).toHaveLength(3);
+    expect(batches.map((b) => b.args[0].input.Delete!.Objects!.length)).toEqual([1000, 1000, 500]);
+    expect(result.deletedKeys).toBe(2500);
+  });
+
+  it('reports a partial cleanup failure as a SUCCESSFUL rename', async () => {
+    stubListing('old/', ['old/a.txt', 'old/b.txt']);
+    stubListing('new/', ['new/a.txt', 'new/b.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({
+      Errors: [{ Key: 'old/b.txt', Code: 'AccessDenied', Message: 'Access Denied' }],
+    });
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    // The data is complete and correct at the new name; a leftover original is
+    // a cleanup problem. Calling this "failed" would tell the user their
+    // rename did not happen, which is actively false.
+    expect(result).toMatchObject({
+      status: 'copied-not-cleaned',
+      completed: false,
+      copiedKeys: 2,
+      deletedKeys: 1,
+    });
+    expect(result.errors).toEqual([
+      { key: 'old/b.txt', code: 'AccessDenied', message: 'Access Denied' },
+    ]);
+  });
+
+  it('emits deleting progress with a running total', async () => {
+    const keys = Array.from({ length: 1500 }, (_, i) => `old/${i}.txt`);
+    stubListing('old/', keys);
+    stubListing(
+      'new/',
+      keys.map((k) => k.replace('old/', 'new/'))
+    );
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+    const events: RenameFolderProgress[] = [];
+
+    await makeApi().renameFolder({
+      oldPrefix: 'old/',
+      newPrefix: 'new/',
+      onProgress: (p) => events.push({ ...p }),
+    });
+
+    expect(events.filter((e) => e.phase === 'deleting').map((e) => e.processed)).toEqual([
+      1000, 1500,
+    ]);
+  });
+});
+
+describe('renameFolder: edge cases', () => {
+  it('completes trivially for an empty folder', async () => {
+    stubListing('old/', []);
+    stubListing('new/', []);
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' });
+
+    expect(result).toEqual({
+      status: 'completed',
+      totalKeys: 0,
+      copiedKeys: 0,
+      deletedKeys: 0,
+      errors: [],
+      completed: true,
+    });
+    expect(s3Mock).not.toHaveReceivedCommand(CopyObjectCommand);
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteObjectsCommand);
+  });
+
+  it('normalises prefixes that arrive without a trailing slash', async () => {
+    stubListing('old/', ['old/a.txt']);
+    stubListing('new/', ['new/a.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    const result = await makeApi().renameFolder({ oldPrefix: 'old', newPrefix: 'new' });
+
+    // Listing 'old' rather than 'old/' would also match a sibling file named
+    // 'oldest.txt' and drag it into the rename.
+    expect(s3Mock).toHaveReceivedCommandWith(ListObjectsV2Command, { Prefix: 'old/' });
+    expect(result.status).toBe('completed');
+  });
+
+  it('works without a progress callback', async () => {
+    stubListing('old/', ['old/a.txt']);
+    stubListing('new/', ['new/a.txt']);
+    s3Mock.on(CopyObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    await expect(
+      makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' })
+    ).resolves.toMatchObject({ status: 'completed' });
+  });
+
+  it('propagates a failure to list the source prefix', async () => {
+    s3Mock.on(ListObjectsV2Command).rejects(s3Error('AccessDenied'));
+
+    // Treating an unreadable prefix as an empty one would report a successful
+    // rename of nothing.
+    await expect(
+      makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' })
+    ).rejects.toThrow();
+    expect(s3Mock).not.toHaveReceivedCommand(CopyObjectCommand);
+  });
+
+  it('propagates a failure to list the destination during verification', async () => {
+    stubListing('old/', ['old/a.txt']);
+    s3Mock.on(ListObjectsV2Command, { Prefix: 'new/' }).rejects(s3Error('AccessDenied'));
+    s3Mock.on(CopyObjectCommand).resolves({});
+
+    await expect(
+      makeApi().renameFolder({ oldPrefix: 'old/', newPrefix: 'new/' })
+    ).rejects.toThrow();
+
+    // Unverifiable means undeletable.
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteObjectsCommand);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/s3-api/src/tests/byoS3.test.ts
+++ b/s3-api/src/tests/byoS3.test.ts
@@ -1,10 +1,12 @@
-import { BYOS3ApiProvider, RenameFolderParams, SearchParams } from '../../dist/index';
-import {
+import { BYOS3ApiProvider } from '../index.js';
+import type {
   Credentials,
   PresignedUploadParams,
   RenameFileParams,
+  RenameFolderParams,
+  SearchParams,
   SignedUrlParams,
-} from '../../dist/index';
+} from '../core/types.js';
 import { describe, it, expect } from 'vitest';
 
 import dotenv from 'dotenv';

--- a/s3-api/src/tests/contentDisposition.test.ts
+++ b/s3-api/src/tests/contentDisposition.test.ts
@@ -1,5 +1,5 @@
-import { BYOS3ApiProvider } from '../../dist/index';
-import type { Credentials, SignedUrlParams } from '../../dist/index';
+import { BYOS3ApiProvider } from '../index.js';
+import type { Credentials, SignedUrlParams } from '../core/types.js';
 import { describe, it, expect } from 'vitest';
 
 /**

--- a/s3-api/src/utils/concurrency.test.ts
+++ b/s3-api/src/utils/concurrency.test.ts
@@ -1,0 +1,148 @@
+/**
+ * `forEachWithConcurrency` is the bounded-parallelism primitive behind
+ * `renameFolder`'s copy phase, where the input can be 100k+ keys. What matters
+ * is that it never exceeds the limit, never skips an item, and never
+ * materialises one promise per item.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { forEachWithConcurrency } from './concurrency.js';
+
+/** A promise plus the handles to settle it from the outside. */
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('forEachWithConcurrency', () => {
+  it('runs the worker exactly once per item', async () => {
+    const seen: number[] = [];
+
+    await forEachWithConcurrency([10, 20, 30, 40], 2, async (item) => {
+      seen.push(item);
+    });
+
+    expect(seen.sort((a, b) => a - b)).toEqual([10, 20, 30, 40]);
+  });
+
+  it('passes each item together with its original index', async () => {
+    const pairs: Array<[string, number]> = [];
+
+    await forEachWithConcurrency(['a', 'b', 'c'], 1, async (item, index) => {
+      pairs.push([item, index]);
+    });
+
+    // Serial (concurrency 1), so the order is deterministic and the index must
+    // track the position in the input, not the completion order.
+    expect(pairs).toEqual([
+      ['a', 0],
+      ['b', 1],
+      ['c', 2],
+    ]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    const gates = Array.from({ length: 10 }, () => deferred());
+    let inFlight = 0;
+    let peak = 0;
+
+    const run = forEachWithConcurrency(gates, 3, async (gate) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await gate.promise;
+      inFlight--;
+    });
+
+    // Let the runners start and park on their gates.
+    await vi.waitFor(() => expect(inFlight).toBe(3));
+    expect(peak).toBe(3);
+
+    gates.forEach((g) => g.resolve());
+    await run;
+
+    expect(peak).toBe(3);
+  });
+
+  it('starts only as many runners as there are items', async () => {
+    const gates = Array.from({ length: 2 }, () => deferred());
+    let inFlight = 0;
+
+    const run = forEachWithConcurrency(gates, 8, async (gate) => {
+      inFlight++;
+      await gate.promise;
+      inFlight--;
+    });
+
+    // Math.min(concurrency, items.length) - asking for 8 runners over 2 items
+    // must not spawn 6 idle promises.
+    await vi.waitFor(() => expect(inFlight).toBe(2));
+
+    gates.forEach((g) => g.resolve());
+    await run;
+  });
+
+  it('pulls from a shared cursor, so a slow item does not stall the others', async () => {
+    const slow = deferred();
+    const order: number[] = [];
+
+    const run = forEachWithConcurrency([0, 1, 2, 3], 2, async (item) => {
+      if (item === 0) await slow.promise;
+      order.push(item);
+    });
+
+    // Runner B works through 1, 2, 3 while runner A is still parked on 0.
+    await vi.waitFor(() => expect(order).toEqual([1, 2, 3]));
+
+    slow.resolve();
+    await run;
+
+    expect(order).toEqual([1, 2, 3, 0]);
+  });
+
+  it('resolves immediately for an empty list without invoking the worker', async () => {
+    const worker = vi.fn();
+
+    await expect(forEachWithConcurrency([], 4, worker)).resolves.toBeUndefined();
+    expect(worker).not.toHaveBeenCalled();
+  });
+
+  it('KNOWN FOOTGUN: a concurrency of 0 silently processes nothing', async () => {
+    const worker = vi.fn();
+
+    await forEachWithConcurrency([1, 2, 3], 0, worker);
+
+    // Math.min(0, 3) spawns zero runners, so the helper resolves successfully
+    // having done no work at all - a caller that computes its concurrency
+    // dynamically would see a silent no-op rather than an error. Pinned, not
+    // endorsed: if this ever starts throwing or clamping to 1, this test SHOULD
+    // fail so the change is a deliberate one.
+    expect(worker).not.toHaveBeenCalled();
+  });
+
+  it('propagates a worker rejection to the caller', async () => {
+    await expect(
+      forEachWithConcurrency([1, 2, 3], 2, async (item) => {
+        if (item === 2) throw new Error('worker exploded');
+      })
+    ).rejects.toThrow('worker exploded');
+  });
+
+  it('abandons remaining items once a worker throws', async () => {
+    const processed: number[] = [];
+
+    // The throwing runner unwinds; Promise.all rejects on its first rejection.
+    // renameFolder relies on this NOT happening, which is exactly why its copy
+    // worker catches internally and accumulates errors instead of throwing.
+    await expect(
+      forEachWithConcurrency([1, 2, 3, 4, 5, 6], 1, async (item) => {
+        if (item === 3) throw new Error('stop');
+        processed.push(item);
+      })
+    ).rejects.toThrow('stop');
+
+    expect(processed).toEqual([1, 2]);
+  });
+});

--- a/s3-api/src/utils/multipartUploader.test.ts
+++ b/s3-api/src/utils/multipartUploader.test.ts
@@ -1,0 +1,655 @@
+/**
+ * `MultipartUploader` drives a real S3 multipart session: create, upload parts
+ * with bounded concurrency, complete. The interesting behaviour is everything
+ * around the unhappy path - pausing mid-flight, resuming against parts S3
+ * already holds, and aborting so no orphaned multipart upload is left accruing
+ * storage charges.
+ *
+ * It persists resume state to `localStorage` (including from its constructor),
+ * which does not exist in the node test environment, so these suites install a
+ * memory-backed shim.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  CreateMultipartUploadCommand,
+  UploadPartCommand,
+  CompleteMultipartUploadCommand,
+  AbortMultipartUploadCommand,
+  ListPartsCommand,
+} from '@aws-sdk/client-s3';
+import { MultipartUploader } from './multipartUploader.js';
+
+const s3Mock = mockClient(S3Client);
+const MB = 1024 * 1024;
+
+let store: Map<string, string>;
+
+function installLocalStorage() {
+  store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  });
+}
+
+function makeUploader(overrides: { partSizeMB?: number; concurrency?: number } = {}) {
+  return new MultipartUploader({
+    s3: new S3Client({ region: 'us-east-1' }),
+    bucket: 'test-bucket',
+    key: 'users/alice/big.bin',
+    fileName: 'big.bin',
+    partSizeMB: overrides.partSizeMB ?? 5 * MB,
+    concurrency: overrides.concurrency ?? 1,
+  });
+}
+
+/** A File of exactly `size` bytes, without allocating a UTF-16 string twice its size. */
+function makeFile(size: number) {
+  return new File([new Uint8Array(size)], 'big.bin');
+}
+
+const STATE_KEY = 'upload:big.bin:users/alice/big.bin';
+
+/** One macrotask tick - drains every pending microtask first. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+/** Private field access, mirroring how UploadManager reads `uploader['uploadId']`. */
+const uploadIdOf = (u: MultipartUploader) => u['uploadId'];
+const controllersOf = (u: MultipartUploader) => u['controllers'];
+
+function stubHappyPath() {
+  s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+  s3Mock.on(UploadPartCommand).resolves({ ETag: '"etag"' });
+  s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+  s3Mock.on(AbortMultipartUploadCommand).resolves({});
+}
+
+beforeEach(() => {
+  s3Mock.reset();
+  installLocalStorage();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('construction', () => {
+  it('clears any stale resume state for the same file and key', () => {
+    installLocalStorage();
+    store.set(STATE_KEY, '{"uploadId":"from-a-previous-session"}');
+
+    makeUploader();
+
+    // That uploadId may point at a multipart upload S3 has already aborted.
+    expect(store.has(STATE_KEY)).toBe(false);
+  });
+
+  it('KNOWN BUG: partSizeMB is compared against BYTES, so real MB values are ignored', async () => {
+    stubHappyPath();
+
+    // multipartUploader.ts guards with `partSizeMB >= 5 * 1024 * 1024` - a byte
+    // threshold on a field named MB. A caller passing the documented unit (10,
+    // meaning 10 MB) fails that check and silently falls back to the 5 MB
+    // default instead of getting 10 MB parts.
+    await makeUploader({ partSizeMB: 10 }).start(makeFile(10 * MB));
+
+    // At the intended 10 MB this is ONE part; at the substituted 5 MB it is two.
+    // Fixing the unit should make this assertion fail.
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(2);
+  });
+
+  it('honours a part size expressed in bytes above the 5MB floor', async () => {
+    stubHappyPath();
+
+    await makeUploader({ partSizeMB: 10 * MB }).start(makeFile(20 * MB));
+
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(2);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -5],
+  ])('falls back to a concurrency of 3 for a %s value', async (_label, concurrency) => {
+    stubHappyPath();
+    let inFlight = 0;
+    let peak = 0;
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+      return { ETag: '"e"' };
+    });
+
+    await makeUploader({ concurrency }).start(makeFile(30 * MB));
+
+    expect(peak).toBe(3);
+  });
+});
+
+describe('start', () => {
+  it('creates a session, uploads the parts, and completes it', async () => {
+    stubHappyPath();
+
+    await makeUploader().start(makeFile(12 * MB));
+
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(CreateMultipartUploadCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/big.bin',
+    });
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(3); // 5 + 5 + 2
+    expect(s3Mock).toHaveReceivedCommandWith(CompleteMultipartUploadCommand, {
+      UploadId: 'upload-1',
+    });
+  });
+
+  it('reuses an existing session instead of creating a second one', async () => {
+    stubHappyPath();
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'resumed-session';
+
+    await uploader.start(makeFile(5 * MB));
+
+    // A second CreateMultipartUpload would orphan the first session.
+    expect(s3Mock).not.toHaveReceivedCommand(CreateMultipartUploadCommand);
+    expect(s3Mock).toHaveReceivedCommandWith(UploadPartCommand, {
+      UploadId: 'resumed-session',
+    });
+  });
+
+  it('passes an abort signal with every part so cancel can interrupt it', async () => {
+    stubHappyPath();
+
+    await makeUploader().start(makeFile(5 * MB));
+
+    // The stub types `args` as a 1-tuple of the command, but `send` is really
+    // called as `send(command, options)` and sinon records both.
+    const args = s3Mock.commandCalls(UploadPartCommand)[0]!.args as unknown as [
+      unknown,
+      { abortSignal?: AbortSignal } | undefined,
+    ];
+    expect(args[1]?.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('releases each part controller once the part settles', async () => {
+    stubHappyPath();
+    const uploader = makeUploader();
+
+    await uploader.start(makeFile(12 * MB));
+
+    // Holding onto them would leak one AbortController per part for the
+    // lifetime of the uploader.
+    expect(controllersOf(uploader)).toEqual([]);
+  });
+
+  it('persists resume state after every part', async () => {
+    stubHappyPath();
+    const setItem = vi.spyOn(globalThis.localStorage, 'setItem');
+
+    await makeUploader().start(makeFile(12 * MB)); // 5 + 5 + 2
+
+    // Written as it goes, not once at the end - a crash mid-upload is only
+    // recoverable from state that was already on disk.
+    expect(setItem).toHaveBeenCalledTimes(3);
+    const [key, value] = setItem.mock.calls[1]!;
+    expect(key).toBe(STATE_KEY);
+    expect(JSON.parse(value)).toEqual({
+      uploadId: 'upload-1',
+      key: 'users/alice/big.bin',
+      fileName: 'big.bin',
+      fileSize: 12 * MB,
+      partSize: 5 * MB,
+      concurrency: 1,
+      completedParts: [
+        { ETag: '"etag"', PartNumber: 1 },
+        { ETag: '"etag"', PartNumber: 2 },
+      ],
+    });
+  });
+
+  it('clears the resume state once the upload completes', async () => {
+    stubHappyPath();
+
+    await makeUploader().start(makeFile(5 * MB));
+
+    expect(store.has(STATE_KEY)).toBe(false);
+  });
+
+  it('completes with parts sorted by number regardless of finish order', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+
+    // Completion order is FORCED with explicit gates rather than staggered
+    // timers: a timing race would make the out-of-order premise merely likely,
+    // and if it ever stopped holding the test would still pass while silently
+    // no longer exercising the sort.
+    const release: Array<() => void> = [];
+    const started: number[] = [];
+    s3Mock.on(UploadPartCommand).callsFake(async (input) => {
+      const part = input.PartNumber as number;
+      started.push(part);
+      await new Promise<void>((resolve) => {
+        release[part] = resolve;
+      });
+      return { ETag: `"etag-${part}"` };
+    });
+
+    const uploader = makeUploader({ concurrency: 3 });
+    const done = uploader.start(makeFile(15 * MB));
+    await vi.waitFor(() => expect(started).toHaveLength(3));
+
+    for (const part of [3, 2, 1]) {
+      release[part]!();
+      await settle();
+    }
+    await done;
+
+    // The premise, asserted rather than assumed.
+    expect(uploader['completedParts'].map((p) => p.PartNumber)).toEqual([3, 2, 1]);
+
+    // S3 rejects CompleteMultipartUpload if the parts are not in ascending order.
+    expect(s3Mock).toHaveReceivedCommandWith(CompleteMultipartUploadCommand, {
+      MultipartUpload: {
+        Parts: [
+          { ETag: '"etag-1"', PartNumber: 1 },
+          { ETag: '"etag-2"', PartNumber: 2 },
+          { ETag: '"etag-3"', PartNumber: 3 },
+        ],
+      },
+    });
+  });
+
+  it('propagates a part failure that is not a pause or cancel', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    s3Mock.on(UploadPartCommand).rejects(new Error('503 slow down'));
+
+    await expect(makeUploader().start(makeFile(5 * MB))).rejects.toThrow('503 slow down');
+
+    // A silently swallowed failure would complete the upload with missing parts.
+    expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
+  });
+
+  it('KNOWN BUG: a session created without an UploadId uploads parts that never complete', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({}); // no UploadId
+    s3Mock.on(UploadPartCommand).resolves({ ETag: '"e"' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+
+    await makeUploader().start(makeFile(5 * MB));
+
+    // `this.uploadId = UploadId!` asserts away the undefined, so the parts go
+    // out with UploadId: undefined and completeUpload's `if (!this.uploadId)`
+    // guard then returns early. The upload silently "succeeds" having written
+    // nothing. Pinned, not endorsed.
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(1);
+    expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
+  });
+});
+
+describe('pause', () => {
+  it('stops after the in-flight part and does not complete the upload', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+    const uploader = makeUploader();
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      uploader.pause();
+      return { ETag: '"etag-1"' };
+    });
+
+    await uploader.start(makeFile(15 * MB));
+
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(1);
+    expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
+  });
+
+  it('keeps the resume state on disk so the upload can be picked back up', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    const uploader = makeUploader();
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      uploader.pause();
+      return { ETag: '"etag-1"' };
+    });
+
+    await uploader.start(makeFile(15 * MB));
+
+    // Unlike the success and cancel paths, pausing must NOT clear this.
+    const state = JSON.parse(store.get(STATE_KEY)!);
+    expect(state).toMatchObject({
+      uploadId: 'upload-1',
+      key: 'users/alice/big.bin',
+      fileSize: 15 * MB,
+      completedParts: [{ ETag: '"etag-1"', PartNumber: 1 }],
+    });
+  });
+
+  it('aborts the controllers of parts still in flight', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    const uploader = makeUploader();
+    let signal: AbortSignal | undefined;
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      signal = controllersOf(uploader)[0]?.signal;
+      uploader.pause();
+      return { ETag: '"e"' };
+    });
+
+    await uploader.start(makeFile(15 * MB));
+
+    expect(signal!.aborted).toBe(true);
+    expect(controllersOf(uploader)).toEqual([]);
+  });
+
+  it('swallows the rejection caused by its own abort', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    const uploader = makeUploader();
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      uploader.pause();
+      // A real aborted request surfaces as a rejection.
+      throw new Error('Request aborted');
+    });
+
+    // Pausing is a user action, not a failure - it must not reject.
+    await expect(uploader.start(makeFile(15 * MB))).resolves.toBeUndefined();
+    expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
+  });
+
+  it('is harmless when nothing is in flight', () => {
+    const uploader = makeUploader();
+
+    expect(() => uploader.pause()).not.toThrow();
+    expect(controllersOf(uploader)).toEqual([]);
+  });
+});
+
+describe('resume', () => {
+  it('refuses to resume an upload that was never started', async () => {
+    await expect(makeUploader().resume(makeFile(5 * MB))).rejects.toThrow(
+      'No uploadId found. Start a new upload.'
+    );
+  });
+
+  it('asks S3 which parts it already holds', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({ Parts: [] });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    await uploader.resume(makeFile(5 * MB));
+
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(ListPartsCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/big.bin',
+      UploadId: 'upload-1',
+    });
+  });
+
+  it('skips re-uploading parts S3 already has', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({
+      Parts: [
+        { ETag: '"remote-1"', PartNumber: 1 },
+        { ETag: '"remote-2"', PartNumber: 2 },
+      ],
+    });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    await uploader.resume(makeFile(15 * MB)); // 3 parts total
+
+    // Re-sending bytes S3 already stored is the entire cost resume exists to avoid.
+    const uploaded = s3Mock.commandCalls(UploadPartCommand).map((c) => c.args[0].input.PartNumber);
+    expect(uploaded).toEqual([3]);
+  });
+
+  it('merges local and remote parts, preferring what S3 reports', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({ Parts: [{ ETag: '"remote-1"', PartNumber: 1 }] });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+    uploader['completedParts'] = [{ ETag: '"stale-local-1"', PartNumber: 1 }];
+
+    await uploader.resume(makeFile(5 * MB));
+
+    // S3 is the authority on what it actually stored; a stale local ETag would
+    // make CompleteMultipartUpload fail with InvalidPart.
+    expect(s3Mock).toHaveReceivedCommandWith(CompleteMultipartUploadCommand, {
+      MultipartUpload: { Parts: [{ ETag: '"remote-1"', PartNumber: 1 }] },
+    });
+  });
+
+  it('keeps local parts that S3 has not listed', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({ Parts: [{ ETag: '"remote-2"', PartNumber: 2 }] });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+    uploader['completedParts'] = [{ ETag: '"local-1"', PartNumber: 1 }];
+
+    await uploader.resume(makeFile(10 * MB));
+
+    expect(s3Mock).toHaveReceivedCommandWith(CompleteMultipartUploadCommand, {
+      MultipartUpload: {
+        Parts: [
+          { ETag: '"local-1"', PartNumber: 1 },
+          { ETag: '"remote-2"', PartNumber: 2 },
+        ],
+      },
+    });
+  });
+
+  it('sorts the merged parts even when S3 lists them out of order', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({
+      Parts: [
+        { ETag: '"remote-3"', PartNumber: 3 },
+        { ETag: '"remote-1"', PartNumber: 1 },
+        { ETag: '"remote-2"', PartNumber: 2 },
+      ],
+    });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    await uploader.resume(makeFile(15 * MB));
+
+    expect(s3Mock).toHaveReceivedCommandWith(CompleteMultipartUploadCommand, {
+      MultipartUpload: {
+        Parts: [
+          { ETag: '"remote-1"', PartNumber: 1 },
+          { ETag: '"remote-2"', PartNumber: 2 },
+          { ETag: '"remote-3"', PartNumber: 3 },
+        ],
+      },
+    });
+  });
+
+  it('ignores a listed part with no part number', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({ Parts: [{ ETag: '"orphan"' }] });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    await uploader.resume(makeFile(5 * MB));
+
+    // Every field on the SDK's Part type is optional; one without a number
+    // cannot be addressed in CompleteMultipartUpload.
+    expect(s3Mock).toHaveReceivedCommandWith(CompleteMultipartUploadCommand, {
+      MultipartUpload: { Parts: [{ ETag: '"etag"', PartNumber: 1 }] },
+    });
+  });
+
+  it('treats a missing Parts array as nothing uploaded yet', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({});
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    await uploader.resume(makeFile(5 * MB));
+
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(1);
+  });
+
+  it('clears the paused flag so the worker loop runs again', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({ Parts: [] });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+    uploader.pause();
+
+    await uploader.resume(makeFile(5 * MB));
+
+    // Without the reset the loop would exit immediately and resume would be a
+    // silent no-op.
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(1);
+    expect(s3Mock).toHaveReceivedCommand(CompleteMultipartUploadCommand);
+  });
+
+  it('clears the resume state once it finishes', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({ Parts: [] });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    await uploader.resume(makeFile(5 * MB));
+
+    expect(store.has(STATE_KEY)).toBe(false);
+  });
+
+  it('does not complete when paused again mid-resume', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    s3Mock.on(ListPartsCommand).resolves({ Parts: [] });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      uploader.pause();
+      return { ETag: '"e"' };
+    });
+
+    await uploader.resume(makeFile(15 * MB));
+
+    expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
+    expect(store.has(STATE_KEY)).toBe(true);
+  });
+
+  it('reports progress across parts it did not have to re-upload', async () => {
+    stubHappyPath();
+    s3Mock.on(ListPartsCommand).resolves({ Parts: [{ ETag: '"remote-1"', PartNumber: 1 }] });
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+    const progress: number[] = [];
+
+    await uploader.resume(makeFile(10 * MB), (p) => progress.push(p));
+
+    // Part 1 was already there, so the first report jumps straight to 100%.
+    expect(progress).toEqual([100]);
+  });
+});
+
+describe('cancel', () => {
+  it('aborts the multipart session so no orphaned parts are billed', async () => {
+    stubHappyPath();
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    await uploader.cancel();
+
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(AbortMultipartUploadCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/big.bin',
+      UploadId: 'upload-1',
+    });
+  });
+
+  it('skips the abort call when no session was ever created', async () => {
+    stubHappyPath();
+
+    await makeUploader().cancel();
+
+    // AbortMultipartUpload without an UploadId is a guaranteed 400.
+    expect(s3Mock).not.toHaveReceivedCommand(AbortMultipartUploadCommand);
+  });
+
+  it('clears the resume state', async () => {
+    stubHappyPath();
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+    store.set(STATE_KEY, '{"uploadId":"upload-1"}');
+
+    await uploader.cancel();
+
+    // Leaving it behind would let a later session try to resume an upload S3
+    // has already discarded.
+    expect(store.has(STATE_KEY)).toBe(false);
+  });
+
+  it('aborts in-flight part controllers and empties the list', async () => {
+    stubHappyPath();
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+    const controller = new AbortController();
+    uploader['controllers'] = [controller];
+
+    await uploader.cancel();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(controllersOf(uploader)).toEqual([]);
+  });
+
+  it('stops the worker loop and never completes the upload', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+    s3Mock.on(AbortMultipartUploadCommand).resolves({});
+    const uploader = makeUploader();
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      await uploader.cancel();
+      return { ETag: '"e"' };
+    });
+
+    await uploader.start(makeFile(15 * MB));
+
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(1);
+    expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
+    expect(s3Mock).toHaveReceivedCommand(AbortMultipartUploadCommand);
+  });
+
+  it('swallows the rejection caused by its own abort', async () => {
+    s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'upload-1' });
+    s3Mock.on(AbortMultipartUploadCommand).resolves({});
+    s3Mock.on(CompleteMultipartUploadCommand).resolves({});
+    const uploader = makeUploader();
+    s3Mock.on(UploadPartCommand).callsFake(async () => {
+      await uploader.cancel();
+      throw new Error('Request aborted');
+    });
+
+    // Cancelling is a user action; surfacing it as an upload error would show
+    // the user a failure they deliberately caused.
+    await expect(uploader.start(makeFile(15 * MB))).resolves.toBeUndefined();
+  });
+
+  it('propagates a failed abort so the caller can report the orphan', async () => {
+    stubHappyPath();
+    s3Mock.on(AbortMultipartUploadCommand).rejects(new Error('AccessDenied'));
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    // UploadManager.cancelAllUploads relies on this rejecting - a silently
+    // failed abort leaves a multipart upload accruing storage charges forever.
+    await expect(uploader.cancel()).rejects.toThrow('AccessDenied');
+  });
+
+  it('leaves the session id set after cancelling', async () => {
+    stubHappyPath();
+    const uploader = makeUploader();
+    uploader['uploadId'] = 'upload-1';
+
+    await uploader.cancel();
+
+    // Pinning current behaviour: the uploader is single-use after cancel, and
+    // calling start() again would resume the aborted session rather than
+    // create a fresh one.
+    expect(uploadIdOf(uploader)).toBe('upload-1');
+  });
+});

--- a/s3-api/src/utils/signedUrlUploadManager.test.ts
+++ b/s3-api/src/utils/signedUrlUploadManager.test.ts
@@ -1,0 +1,438 @@
+/**
+ * `SignedUrlUploadManager` mirrors `UploadManager`'s singleton and teardown
+ * contract, but its uploads cannot be paused or resumed and its `cancel()` is
+ * synchronous - there is no in-flight AbortMultipartUpload for the worker to
+ * race against. Those differences are what this suite concentrates on.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SignedUrlUploadManager } from './signedUrlUploadManager.js';
+import type { BYOS3ApiProvider } from '../index.js';
+import type { EventPayload } from '../core/types.js';
+
+const { MockUploader, uploaderInstances } = vi.hoisted(() => {
+  function deferred() {
+    let resolve!: () => void;
+    let reject!: (e: Error) => void;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  class MockUploader {
+    upload = vi.fn(async (_file: File, onProgress?: (p: number) => void) => {
+      this.onProgress = onProgress;
+      return this.gate.promise;
+    });
+    cancel = vi.fn();
+    gate = deferred();
+    onProgress?: (p: number) => void;
+
+    /** Captured so tests can assert the key the manager derived. */
+    config: { key?: string };
+
+    constructor(config: { key?: string }) {
+      this.config = config;
+      instances.push(this);
+    }
+  }
+
+  const instances: MockUploader[] = [];
+  return { MockUploader, uploaderInstances: instances };
+});
+
+vi.mock('./signedUrlUploader.js', () => ({ SignedUrlUploader: MockUploader }));
+
+const apiProvider = {} as BYOS3ApiProvider;
+const config = { apiProvider };
+
+function makeFile(name = 'a.txt', size = 10) {
+  return new File(['x'.repeat(size)], name);
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(async () => {
+  await SignedUrlUploadManager.disposeInstance();
+  uploaderInstances.length = 0;
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await SignedUrlUploadManager.disposeInstance();
+  vi.restoreAllMocks();
+});
+
+describe('getInstance', () => {
+  it('returns the same instance for repeated calls', () => {
+    expect(SignedUrlUploadManager.getInstance(config)).toBe(
+      SignedUrlUploadManager.getInstance(config)
+    );
+  });
+
+  it('IGNORES the config once an instance exists', () => {
+    const first = SignedUrlUploadManager.getInstance(config);
+    const second = SignedUrlUploadManager.getInstance({
+      apiProvider: {} as BYOS3ApiProvider,
+      maxConcurrency: 99,
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it('builds a fresh instance after disposal', async () => {
+    const first = SignedUrlUploadManager.getInstance(config);
+    await SignedUrlUploadManager.disposeInstance();
+
+    expect(SignedUrlUploadManager.getInstance(config)).not.toBe(first);
+  });
+});
+
+describe('disposeInstance', () => {
+  it('is a no-op when there is no instance', async () => {
+    await expect(SignedUrlUploadManager.disposeInstance()).resolves.toBeUndefined();
+  });
+
+  it('clears the singleton synchronously', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    const disposal = SignedUrlUploadManager.disposeInstance();
+    expect(SignedUrlUploadManager.getInstance(config)).not.toBe(manager);
+    await disposal;
+  });
+
+  it('cancels in-flight and queued uploads', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    const active = manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const queued = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    await SignedUrlUploadManager.disposeInstance();
+
+    expect(manager.getStatus(active)!.status).toBe('cancelled');
+    expect(manager.getStatus(queued)!.status).toBe('cancelled');
+    expect(uploaderInstances[0]!.cancel).toHaveBeenCalledOnce();
+  });
+
+  it('leaves completed uploads alone', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+    uploaderInstances[0]!.gate.resolve();
+    await settle();
+
+    await SignedUrlUploadManager.disposeInstance();
+
+    expect(manager.getStatus(id)!.status).toBe('completed');
+    expect(uploaderInstances[0]!.cancel).not.toHaveBeenCalled();
+  });
+
+  it('does not promote the next queued upload while tearing down', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    await SignedUrlUploadManager.disposeInstance();
+    await settle();
+
+    expect(uploaderInstances[1]!.upload).not.toHaveBeenCalled();
+  });
+
+  it('refuses new uploads on a disposed instance', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    await SignedUrlUploadManager.disposeInstance();
+
+    expect(() => manager.addUpload(makeFile(), { key: 'k' })).toThrow(/disposed.*getInstance/s);
+  });
+});
+
+describe('queue', () => {
+  it('runs at most maxConcurrency uploads at once', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 2 });
+    const ids = ['a', 'b', 'c'].map((k) => manager.addUpload(makeFile(k), { key: k }));
+    await settle();
+
+    expect(
+      ids.map((id) => manager.getStatus(id)!.status).filter((s) => s === 'uploading')
+    ).toHaveLength(2);
+  });
+
+  it('defaults to two concurrent uploads', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const ids = ['a', 'b', 'c'].map((k) => manager.addUpload(makeFile(k), { key: k }));
+    await settle();
+
+    expect(
+      ids.map((id) => manager.getStatus(id)!.status).filter((s) => s === 'uploading')
+    ).toHaveLength(2);
+  });
+
+  it('starts the next upload once one finishes', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const second = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    uploaderInstances[0]!.gate.resolve();
+    await settle();
+
+    expect(manager.getStatus(second)!.status).toBe('uploading');
+  });
+
+  it('marks an upload failed when the uploader throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    uploaderInstances[0]!.gate.reject(new Error('signed url expired'));
+    await settle();
+
+    expect(manager.getStatus(id)).toMatchObject({
+      status: 'failed',
+      progress: 0,
+    });
+  });
+
+  it('does not overwrite a cancelled upload with a failure', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    await manager.cancelUpload(id);
+    // Cancelling aborts the request, which surfaces as a rejection.
+    uploaderInstances[0]!.gate.reject(new Error('aborted'));
+    await settle();
+
+    expect(manager.getStatus(id)!.status).toBe('cancelled');
+  });
+});
+
+describe('cancel', () => {
+  it('cancels an in-flight upload and frees its slot', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    const first = manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const second = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    await manager.cancelUpload(first);
+    await settle();
+
+    expect(manager.getStatus(first)!.status).toBe('cancelled');
+    expect(uploaderInstances[0]!.cancel).toHaveBeenCalledOnce();
+    expect(manager.getStatus(second)!.status).toBe('uploading');
+  });
+
+  it('cancels a queued upload without touching its uploader', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const queued = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    await manager.cancelUpload(queued);
+
+    expect(manager.getStatus(queued)!.status).toBe('cancelled');
+    expect(uploaderInstances[1]!.cancel).not.toHaveBeenCalled();
+  });
+
+  it('ignores a repeated cancel', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    await manager.cancelUpload(id);
+    await manager.cancelUpload(id);
+
+    // A duplicate would emit a second 'cancelled' event and decrement the
+    // active counter twice.
+    expect(uploaderInstances[0]!.cancel).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a cancel for an unknown id', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+
+    await expect(manager.cancelUpload('nope')).resolves.toBeUndefined();
+  });
+});
+
+describe('pause and resume compatibility shims', () => {
+  it('cancels instead of pausing, since a signed-url PUT cannot resume', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    manager.pauseUpload(id);
+    await settle();
+
+    // Kept for API parity with UploadManager; a half-finished PUT has no
+    // resumable state, so pretending otherwise would strand the upload.
+    expect(manager.getStatus(id)!.status).toBe('cancelled');
+  });
+
+  it('ignores a pause for an upload that is not running', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const queued = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    manager.pauseUpload(queued);
+
+    expect(manager.getStatus(queued)!.status).toBe('queued');
+  });
+
+  it('ignores a pause for an unknown id', () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+
+    expect(() => manager.pauseUpload('nope')).not.toThrow();
+  });
+
+  it('resume is an inert no-op', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    await expect(manager.resumeUpload(id)).resolves.toBeUndefined();
+    expect(manager.getStatus(id)!.status).toBe('uploading');
+  });
+});
+
+describe('status reporting', () => {
+  it('returns undefined for an unknown id', () => {
+    expect(SignedUrlUploadManager.getInstance(config).getStatus('nope')).toBeUndefined();
+  });
+
+  it('reports every upload it knows about', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    const a = manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const b = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    expect(manager.getAllStatuses()).toEqual({
+      [a]: { status: 'uploading', progress: 0 },
+      [b]: { status: 'queued', progress: 0 },
+    });
+  });
+});
+
+describe('events', () => {
+  it('emits a status change when an upload is queued', () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const listener = vi.fn();
+    manager.on('statusChange', listener);
+
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ id, status: 'queued', progress: 0 })
+    );
+  });
+
+  it('forwards uploader progress to subscribers', async () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const events: EventPayload[] = [];
+    manager.on('progress', (p) => events.push(p));
+    manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    uploaderInstances[0]!.onProgress!(75);
+
+    expect(events).toEqual([expect.objectContaining({ progress: 75 })]);
+  });
+
+  it('stops delivering to a removed listener', () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const listener = vi.fn();
+    manager.on('statusChange', listener);
+    manager.off('statusChange', listener);
+
+    manager.addUpload(makeFile(), { key: 'k' });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('off is harmless for an event with no listeners', () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+
+    expect(() => manager.off('progress', vi.fn())).not.toThrow();
+  });
+
+  it('isolates listeners so one throwing does not break the others', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const healthy = vi.fn();
+    manager.on('statusChange', () => {
+      throw new Error('listener exploded');
+    });
+    manager.on('statusChange', healthy);
+
+    manager.addUpload(makeFile(), { key: 'k' });
+
+    expect(healthy).toHaveBeenCalled();
+    expect(error).toHaveBeenCalled();
+  });
+});
+
+describe('addFolderUpload', () => {
+  function fileList(files: File[]) {
+    return files as unknown as FileList;
+  }
+
+  function withPath(name: string, path: string, size = 10) {
+    const file = new File(['x'.repeat(size)], name);
+    Object.defineProperty(file, 'webkitRelativePath', { value: path });
+    return file;
+  }
+
+  it('queues one upload per file', () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+
+    const { fileIds } = manager.addFolderUpload(
+      fileList([withPath('a.txt', 'docs/a.txt'), withPath('b.txt', 'docs/sub/b.txt')]),
+      {}
+    );
+
+    expect(fileIds).toHaveLength(2);
+    // The key must be the file's path within the folder, not its bare name -
+    // otherwise a nested folder upload flattens into the destination root.
+    expect(uploaderInstances.map((u) => u.config.key)).toEqual(['docs/a.txt', 'docs/sub/b.txt']);
+  });
+
+  it('prefixes each key when a base prefix is given', () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+
+    const { fileIds } = manager.addFolderUpload(fileList([withPath('a.txt', 'docs/a.txt')]), {
+      basePrefix: 'users/alice/',
+    });
+
+    expect(fileIds).toHaveLength(1);
+    // Asserting the count alone would pass even if basePrefix were ignored
+    // entirely, which is the whole behaviour this test exists to cover.
+    expect(uploaderInstances[0]!.config.key).toBe('users/alice/docs/a.txt');
+  });
+
+  it('returns a folder id that groups the batch', () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+
+    const { folderId } = manager.addFolderUpload(fileList([withPath('a.txt', 'docs/a.txt')]), {});
+
+    expect(folderId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('skips the zero-byte entries browsers emit for directories', () => {
+    const manager = SignedUrlUploadManager.getInstance(config);
+    const directoryEntry = new File([], 'subdir');
+    Object.defineProperty(directoryEntry, 'webkitRelativePath', { value: 'docs/subdir' });
+
+    const { fileIds } = manager.addFolderUpload(
+      fileList([directoryEntry, withPath('a.txt', 'docs/a.txt')]),
+      {}
+    );
+
+    expect(fileIds).toHaveLength(1);
+  });
+});

--- a/s3-api/src/utils/signedUrlUploader.test.ts
+++ b/s3-api/src/utils/signedUrlUploader.test.ts
@@ -1,0 +1,301 @@
+/**
+ * `SignedUrlUploader` PUTs a file straight at a presigned URL over
+ * `XMLHttpRequest` - chosen over fetch because it is the only browser API that
+ * reports upload progress. XHR does not exist in the node test environment, so
+ * these suites install a fake that lets each lifecycle event be fired
+ * deliberately.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SignedUrlUploader } from './signedUrlUploader.js';
+import type { BYOS3ApiProvider } from '../index.js';
+
+type Listener = (event?: unknown) => void;
+
+class FakeXhr {
+  static instances: FakeXhr[] = [];
+
+  status = 200;
+  method?: string;
+  url?: string;
+  headers: Record<string, string> = {};
+  body?: unknown;
+  aborted = false;
+
+  private listeners = new Map<string, Listener[]>();
+  private uploadListeners = new Map<string, Listener[]>();
+
+  upload = {
+    addEventListener: (type: string, cb: Listener) => {
+      this.uploadListeners.set(type, [...(this.uploadListeners.get(type) ?? []), cb]);
+    },
+  };
+
+  constructor() {
+    FakeXhr.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: Listener) {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), cb]);
+  }
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  setRequestHeader(key: string, value: string) {
+    this.headers[key] = value;
+  }
+
+  send(body: unknown) {
+    this.body = body;
+  }
+
+  abort() {
+    this.aborted = true;
+    this.fire('abort');
+  }
+
+  /** Drives a lifecycle event the way a real XHR would. */
+  fire(type: string, event?: unknown) {
+    (this.listeners.get(type) ?? []).forEach((cb) => cb(event));
+  }
+
+  fireProgress(event: { lengthComputable: boolean; loaded: number; total: number }) {
+    (this.uploadListeners.get('progress') ?? []).forEach((cb) => cb(event));
+  }
+}
+
+const uploadWithPreSignedUrl = vi.fn(async () => 'https://signed.example.com/put');
+
+function makeUploader(overrides: { key?: string; expiresInSeconds?: number } = {}) {
+  return new SignedUrlUploader({
+    apiProvider: { uploadWithPreSignedUrl } as unknown as BYOS3ApiProvider,
+    key: overrides.key ?? 'users/alice/a.txt',
+    fileName: 'a.txt',
+    expiresInSeconds: overrides.expiresInSeconds,
+  });
+}
+
+/** Starts an upload and waits for the fake XHR to be created and sent. */
+async function startUpload(uploader: SignedUrlUploader, file: File) {
+  const promise = uploader.upload(file);
+  await vi.waitFor(() => expect(FakeXhr.instances).toHaveLength(1));
+  return { promise, xhr: FakeXhr.instances[0]! };
+}
+
+beforeEach(() => {
+  FakeXhr.instances = [];
+  uploadWithPreSignedUrl.mockClear();
+  vi.stubGlobal('XMLHttpRequest', FakeXhr);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('signing', () => {
+  it('requests a presigned URL for the configured key', async () => {
+    const { promise, xhr } = await startUpload(
+      makeUploader({ key: 'k/a.txt' }),
+      new File([''], 'a')
+    );
+
+    expect(uploadWithPreSignedUrl).toHaveBeenCalledWith({
+      key: 'k/a.txt',
+      expiresInSeconds: 3600,
+    });
+    xhr.fire('load');
+    await promise;
+  });
+
+  it('defaults the URL lifetime to one hour', async () => {
+    const { promise, xhr } = await startUpload(makeUploader(), new File([''], 'a'));
+
+    expect(uploadWithPreSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresInSeconds: 3600 })
+    );
+    xhr.fire('load');
+    await promise;
+  });
+
+  it('honours a caller-supplied lifetime', async () => {
+    const { promise, xhr } = await startUpload(
+      makeUploader({ expiresInSeconds: 60 }),
+      new File([''], 'a')
+    );
+
+    expect(uploadWithPreSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresInSeconds: 60 })
+    );
+    xhr.fire('load');
+    await promise;
+  });
+
+  it('propagates a signing failure without opening a request', async () => {
+    uploadWithPreSignedUrl.mockRejectedValueOnce(new Error('signing refused'));
+
+    await expect(makeUploader().upload(new File([''], 'a'))).rejects.toThrow('signing refused');
+    expect(FakeXhr.instances).toHaveLength(0);
+  });
+});
+
+describe('the request', () => {
+  it('PUTs the file to the signed URL', async () => {
+    const file = new File(['hello'], 'a.txt', { type: 'text/plain' });
+    const { promise, xhr } = await startUpload(makeUploader(), file);
+
+    expect(xhr.method).toBe('PUT');
+    expect(xhr.url).toBe('https://signed.example.com/put');
+    expect(xhr.body).toBe(file);
+    xhr.fire('load');
+    await promise;
+  });
+
+  it("sends the file's own content type", async () => {
+    const { promise, xhr } = await startUpload(
+      makeUploader(),
+      new File(['x'], 'a.pdf', { type: 'application/pdf' })
+    );
+
+    expect(xhr.headers['Content-Type']).toBe('application/pdf');
+    xhr.fire('load');
+    await promise;
+  });
+
+  it('falls back to a binary content type when the file has none', async () => {
+    const { promise, xhr } = await startUpload(makeUploader(), new File(['x'], 'unknown'));
+
+    // An empty Content-Type is signed into the request and S3 stores the object
+    // with no usable type, which breaks previews later.
+    expect(xhr.headers['Content-Type']).toBe('application/octet-stream');
+    xhr.fire('load');
+    await promise;
+  });
+});
+
+describe('completion', () => {
+  it.each([200, 201, 204, 299])('resolves on a %i response', async (status) => {
+    const { promise, xhr } = await startUpload(makeUploader(), new File([''], 'a'));
+
+    xhr.status = status;
+    xhr.fire('load');
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it.each([199, 300, 403, 500])('rejects on a %i response', async (status) => {
+    const { promise, xhr } = await startUpload(makeUploader(), new File([''], 'a'));
+
+    xhr.status = status;
+    xhr.fire('load');
+
+    await expect(promise).rejects.toThrow(`Upload failed with status ${status}`);
+  });
+
+  it('rejects on a network error', async () => {
+    const { promise, xhr } = await startUpload(makeUploader(), new File([''], 'a'));
+
+    xhr.fire('error');
+
+    await expect(promise).rejects.toThrow('Upload failed due to network error');
+  });
+
+  it('rejects when the request is aborted', async () => {
+    const { promise, xhr } = await startUpload(makeUploader(), new File([''], 'a'));
+
+    xhr.fire('abort');
+
+    await expect(promise).rejects.toThrow('Upload cancelled');
+  });
+});
+
+describe('progress', () => {
+  it('reports rounded percentages', async () => {
+    const progress: number[] = [];
+    const uploader = makeUploader();
+    const promise = uploader.upload(new File([''], 'a'), (p) => progress.push(p));
+    await vi.waitFor(() => expect(FakeXhr.instances).toHaveLength(1));
+    const xhr = FakeXhr.instances[0]!;
+
+    xhr.fireProgress({ lengthComputable: true, loaded: 1, total: 3 });
+    xhr.fireProgress({ lengthComputable: true, loaded: 3, total: 3 });
+
+    expect(progress).toEqual([33, 100]);
+    xhr.fire('load');
+    await promise;
+  });
+
+  it('stays silent when the total size is unknown', async () => {
+    const onProgress = vi.fn();
+    const uploader = makeUploader();
+    const promise = uploader.upload(new File([''], 'a'), onProgress);
+    await vi.waitFor(() => expect(FakeXhr.instances).toHaveLength(1));
+    const xhr = FakeXhr.instances[0]!;
+
+    // A percentage against an unknown total would be meaningless.
+    xhr.fireProgress({ lengthComputable: false, loaded: 1, total: 0 });
+
+    expect(onProgress).not.toHaveBeenCalled();
+    xhr.fire('load');
+    await promise;
+  });
+
+  it('tolerates progress events with no callback registered', async () => {
+    const { promise, xhr } = await startUpload(makeUploader(), new File([''], 'a'));
+
+    expect(() => xhr.fireProgress({ lengthComputable: true, loaded: 1, total: 2 })).not.toThrow();
+    xhr.fire('load');
+    await promise;
+  });
+});
+
+describe('cancel', () => {
+  it('aborts the in-flight request and rejects the upload', async () => {
+    const uploader = makeUploader();
+    const { promise, xhr } = await startUpload(uploader, new File([''], 'a'));
+
+    uploader.cancel();
+
+    expect(xhr.aborted).toBe(true);
+    await expect(promise).rejects.toThrow('Upload cancelled');
+  });
+
+  it('is a no-op before an upload has started', () => {
+    expect(() => makeUploader().cancel()).not.toThrow();
+  });
+
+  it('is safe to call twice', async () => {
+    const uploader = makeUploader();
+    const { promise, xhr } = await startUpload(uploader, new File([''], 'a'));
+
+    uploader.cancel();
+    uploader.cancel();
+
+    // The controller is nulled on the first call, so the second cannot abort a
+    // subsequent upload that reused this uploader.
+    expect(xhr.aborted).toBe(true);
+    await expect(promise).rejects.toThrow();
+  });
+});
+
+describe('pause compatibility shim', () => {
+  it('starts unpaused', () => {
+    expect(makeUploader().isPausedState()).toBe(false);
+  });
+
+  it('records the paused flag without stopping the request', async () => {
+    const uploader = makeUploader();
+    const { promise, xhr } = await startUpload(uploader, new File([''], 'a'));
+
+    uploader.pause();
+
+    // Signed-URL uploads genuinely cannot pause; the flag exists only so this
+    // class matches MultipartUploader's shape. The request keeps running.
+    expect(uploader.isPausedState()).toBe(true);
+    expect(xhr.aborted).toBe(false);
+    xhr.fire('load');
+    await promise;
+  });
+});

--- a/s3-api/src/utils/uploadManager.test.ts
+++ b/s3-api/src/utils/uploadManager.test.ts
@@ -1,0 +1,510 @@
+/**
+ * `UploadManager` is an exported singleton whose `getInstance` silently
+ * discards its config once an instance exists. That makes `disposeInstance()`
+ * a correctness requirement rather than a nicety: without it, uploads started
+ * after a session change keep targeting the previous session's bucket and
+ * credentials.
+ *
+ * `MultipartUploader` is mocked at the module boundary - what's under test is
+ * the queue, the state machine, and the teardown, not the S3 wire protocol.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { S3Client } from '@aws-sdk/client-s3';
+import { UploadManager } from './uploadManager.js';
+import type { EventPayload } from '../core/types.js';
+
+/**
+ * Hoisted so the class exists before `vi.mock`'s factory runs - the factory is
+ * evaluated when `uploadManager.js` first imports the uploader, which is before
+ * this module's own top-level bindings are initialised.
+ */
+const { MockUploader, uploaderInstances } = vi.hoisted(() => {
+  /** Resolves only when the test says so, so an upload can be held "in flight". */
+  function deferred() {
+    let resolve!: () => void;
+    let reject!: (e: Error) => void;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  class MockUploader {
+    start = vi.fn(async (_file: File, onProgress?: (p: number) => void) => {
+      this.onProgress = onProgress;
+      return this.gate.promise;
+    });
+    resume = vi.fn(async (_file: File, onProgress?: (p: number) => void) => {
+      this.onProgress = onProgress;
+      return this.gate.promise;
+    });
+    pause = vi.fn();
+    cancel = vi.fn(async () => {});
+    gate = deferred();
+    onProgress?: (p: number) => void;
+    uploadId?: string;
+
+    /** Captured so tests can assert the key the manager derived. */
+    config: { key?: string };
+
+    constructor(config: { key?: string }) {
+      this.config = config;
+      instances.push(this);
+    }
+  }
+
+  const instances: MockUploader[] = [];
+  return { MockUploader, uploaderInstances: instances };
+});
+
+vi.mock('./multipartUploader.js', () => ({ MultipartUploader: MockUploader }));
+
+const config = {
+  s3: {} as S3Client,
+  bucket: 'test-bucket',
+  prefix: 'users/alice/',
+};
+
+function makeFile(name = 'a.txt', size = 10) {
+  return new File(['x'.repeat(size)], name);
+}
+
+/** Waits for the queue's detached worker to pick an item up. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(async () => {
+  await UploadManager.disposeInstance();
+  uploaderInstances.length = 0;
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await UploadManager.disposeInstance();
+  vi.restoreAllMocks();
+});
+
+describe('getInstance', () => {
+  it('returns the same instance for repeated calls', () => {
+    expect(UploadManager.getInstance(config)).toBe(UploadManager.getInstance(config));
+  });
+
+  it('IGNORES the config once an instance exists', () => {
+    const first = UploadManager.getInstance(config);
+    const second = UploadManager.getInstance({ ...config, bucket: 'a-different-bucket' });
+
+    // This is the whole reason disposeInstance() has to be called on logout:
+    // handing getInstance new credentials does nothing at all.
+    expect(second).toBe(first);
+  });
+
+  it('builds a fresh instance after disposal', async () => {
+    const first = UploadManager.getInstance(config);
+    await UploadManager.disposeInstance();
+
+    expect(UploadManager.getInstance(config)).not.toBe(first);
+  });
+});
+
+describe('disposeInstance', () => {
+  it('is a no-op when there is no instance', async () => {
+    await expect(UploadManager.disposeInstance()).resolves.toBeUndefined();
+  });
+
+  it('clears the singleton synchronously, before awaiting cancellation', async () => {
+    const manager = UploadManager.getInstance(config);
+    manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    const disposal = UploadManager.disposeInstance(); // deliberately not awaited
+    const replacement = UploadManager.getInstance(config);
+
+    // A logout handler that cannot await must still be guaranteed that the
+    // next getInstance() gives it a manager bound to the new session.
+    expect(replacement).not.toBe(manager);
+    await disposal;
+  });
+
+  it('cancels an in-flight upload', async () => {
+    const manager = UploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+    expect(manager.getStatus(id)!.status).toBe('uploading');
+
+    await UploadManager.disposeInstance();
+
+    expect(manager.getStatus(id)!.status).toBe('cancelled');
+    expect(uploaderInstances[0]!.cancel).toHaveBeenCalledOnce();
+  });
+
+  it('cancels queued uploads that never started', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    const active = manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const queued = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    await UploadManager.disposeInstance();
+
+    expect(manager.getStatus(active)!.status).toBe('cancelled');
+    expect(manager.getStatus(queued)!.status).toBe('cancelled');
+  });
+
+  it('leaves already-completed uploads alone', async () => {
+    const manager = UploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+    uploaderInstances[0]!.gate.resolve();
+    await settle();
+    expect(manager.getStatus(id)!.status).toBe('completed');
+
+    await UploadManager.disposeInstance();
+
+    // Re-cancelling a terminal item would emit a bogus 'cancelled' event and
+    // double-decrement the active counter.
+    expect(manager.getStatus(id)!.status).toBe('completed');
+    expect(uploaderInstances[0]!.cancel).not.toHaveBeenCalled();
+  });
+
+  it('does not start the next queued upload while tearing down', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    await UploadManager.disposeInstance();
+    await settle();
+
+    // Cancelling the active item calls processQueue(); without the isDisposed
+    // guard that would promote 'b' and upload it to the bucket being torn down.
+    expect(uploaderInstances[1]!.start).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed cancellation instead of throwing out of dispose', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const manager = UploadManager.getInstance(config);
+    manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+    uploaderInstances[0]!.cancel.mockRejectedValueOnce(new Error('abort failed'));
+
+    await expect(UploadManager.disposeInstance()).resolves.toBeUndefined();
+
+    // A failed AbortMultipartUpload orphans a multipart upload that keeps
+    // accruing storage charges, so it must be surfaced, not swallowed silently.
+    expect(error).toHaveBeenCalled();
+    expect(error.mock.calls.flat().join(' ')).toMatch(/orphaned/);
+  });
+
+  it('refuses new uploads on a disposed instance', async () => {
+    const manager = UploadManager.getInstance(config);
+    await UploadManager.disposeInstance();
+
+    expect(() => manager.addUpload(makeFile(), { key: 'k' })).toThrow(/disposed.*getInstance/s);
+  });
+
+  it('ignores a resume request on a disposed instance', async () => {
+    const manager = UploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+    await UploadManager.disposeInstance();
+
+    await expect(manager.resumeUpload(id)).resolves.toBeUndefined();
+    expect(manager.getStatus(id)!.status).toBe('cancelled');
+  });
+});
+
+describe('queue', () => {
+  it('runs at most maxConcurrency uploads at once', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 2 });
+    const ids = ['a', 'b', 'c', 'd'].map((k) => manager.addUpload(makeFile(k), { key: k }));
+    await settle();
+
+    const statuses = ids.map((id) => manager.getStatus(id)!.status);
+    expect(statuses.filter((s) => s === 'uploading')).toHaveLength(2);
+    expect(statuses.filter((s) => s === 'queued')).toHaveLength(2);
+  });
+
+  it('defaults to two concurrent uploads', async () => {
+    const manager = UploadManager.getInstance(config);
+    const ids = ['a', 'b', 'c'].map((k) => manager.addUpload(makeFile(k), { key: k }));
+    await settle();
+
+    expect(
+      ids.map((id) => manager.getStatus(id)!.status).filter((s) => s === 'uploading')
+    ).toHaveLength(2);
+  });
+
+  it('starts the next upload when one completes', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const second = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    uploaderInstances[0]!.gate.resolve();
+    await settle();
+
+    expect(manager.getStatus(second)!.status).toBe('uploading');
+  });
+
+  it('marks an upload failed when the uploader throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const manager = UploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    uploaderInstances[0]!.gate.reject(new Error('network died'));
+    await settle();
+
+    expect(manager.getStatus(id)).toMatchObject({ status: 'failed' });
+  });
+
+  it('resumes an upload that already has an uploadId', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    await settle();
+    // Simulate a part-way upload being requeued.
+    uploaderInstances[0]!.uploadId = 'existing-upload';
+    manager.pauseUpload(Object.keys(manager.getAllStatuses())[0]!);
+    await manager.resumeUpload(Object.keys(manager.getAllStatuses())[0]!);
+    await settle();
+
+    expect(uploaderInstances[0]!.resume).toHaveBeenCalled();
+  });
+});
+
+describe('pause, resume, and cancel', () => {
+  it('pauses an uploading item and frees a concurrency slot', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    const first = manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const second = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    manager.pauseUpload(first);
+    await settle();
+
+    expect(manager.getStatus(first)!.status).toBe('paused');
+    expect(uploaderInstances[0]!.pause).toHaveBeenCalledOnce();
+    expect(manager.getStatus(second)!.status).toBe('uploading');
+  });
+
+  it('ignores a pause for an item that is not uploading', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const queued = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    manager.pauseUpload(queued);
+
+    expect(manager.getStatus(queued)!.status).toBe('queued');
+  });
+
+  it('puts a resumed upload at the FRONT of the queue', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    const first = manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    const last = manager.addUpload(makeFile('c.txt'), { key: 'c' });
+    await settle();
+
+    manager.pauseUpload(first); // frees the slot, so 'b' starts
+    await settle();
+    await manager.resumeUpload(first); // no slot yet - goes to the queue head
+    expect(manager.getStatus(first)!.status).toBe('queued');
+
+    uploaderInstances[1]!.gate.resolve(); // 'b' finishes, freeing the slot
+    await settle();
+
+    // The user just asked for this file specifically; making them wait behind
+    // everything queued since would feel broken.
+    expect(manager.getStatus(first)!.status).toBe('uploading');
+    expect(manager.getStatus(last)!.status).toBe('queued');
+  });
+
+  it('cancels a queued upload without touching the uploader', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const queued = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    await manager.cancelUpload(queued);
+
+    expect(manager.getStatus(queued)!.status).toBe('cancelled');
+    // Never started, so there is no multipart upload to abort.
+    expect(uploaderInstances[1]!.cancel).not.toHaveBeenCalled();
+  });
+
+  it('does not emit a bogus completion for an upload cancelled mid-flight', async () => {
+    const manager = UploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    const cancelling = manager.cancelUpload(id);
+    // The worker unwinds normally while AbortMultipartUpload is in flight.
+    uploaderInstances[0]!.gate.resolve();
+    await cancelling;
+    await settle();
+
+    // Status is marked terminal BEFORE awaiting the uploader precisely so the
+    // resolving worker cannot transition this to 'completed'.
+    expect(manager.getStatus(id)!.status).toBe('cancelled');
+  });
+
+  it('ignores a repeated cancel', async () => {
+    const manager = UploadManager.getInstance(config);
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    await manager.cancelUpload(id);
+    await manager.cancelUpload(id);
+
+    // Re-running the bookkeeping would double-decrement activeUploads and
+    // permanently shrink the effective concurrency.
+    expect(uploaderInstances[0]!.cancel).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a cancel for an unknown id', async () => {
+    const manager = UploadManager.getInstance(config);
+
+    await expect(manager.cancelUpload('does-not-exist')).resolves.toBeUndefined();
+  });
+});
+
+describe('status reporting', () => {
+  it('returns undefined for an unknown id', () => {
+    expect(UploadManager.getInstance(config).getStatus('nope')).toBeUndefined();
+  });
+
+  it('reports every upload it knows about', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
+    const a = manager.addUpload(makeFile('a.txt'), { key: 'a' });
+    const b = manager.addUpload(makeFile('b.txt'), { key: 'b' });
+    await settle();
+
+    expect(manager.getAllStatuses()).toEqual({
+      [a]: { status: 'uploading', progress: 0 },
+      [b]: { status: 'queued', progress: 0 },
+    });
+  });
+});
+
+describe('events', () => {
+  it('emits a status change when an upload is queued', () => {
+    const manager = UploadManager.getInstance(config);
+    const listener = vi.fn();
+    manager.on('statusChange', listener);
+
+    const id = manager.addUpload(makeFile(), { key: 'k' });
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ id, status: 'queued', progress: 0 })
+    );
+  });
+
+  it('forwards uploader progress to subscribers', async () => {
+    const manager = UploadManager.getInstance(config);
+    const events: EventPayload[] = [];
+    manager.on('progress', (p) => events.push(p));
+    manager.addUpload(makeFile(), { key: 'k' });
+    await settle();
+
+    uploaderInstances[0]!.onProgress!(42);
+
+    expect(events).toEqual([expect.objectContaining({ progress: 42 })]);
+  });
+
+  it('stops delivering to a removed listener', async () => {
+    const manager = UploadManager.getInstance(config);
+    const listener = vi.fn();
+    manager.on('statusChange', listener);
+    manager.off('statusChange', listener);
+
+    manager.addUpload(makeFile(), { key: 'k' });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('off is harmless for an event with no listeners', () => {
+    const manager = UploadManager.getInstance(config);
+
+    expect(() => manager.off('progress', vi.fn())).not.toThrow();
+  });
+
+  it('isolates listeners so one throwing does not break the others', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const manager = UploadManager.getInstance(config);
+    const healthy = vi.fn();
+    manager.on('statusChange', () => {
+      throw new Error('listener exploded');
+    });
+    manager.on('statusChange', healthy);
+
+    manager.addUpload(makeFile(), { key: 'k' });
+
+    // During disposeInstance a throwing listener would otherwise propagate up
+    // through updateItemStatus -> cancelUpload and abandon the remaining
+    // uploads mid-teardown.
+    expect(healthy).toHaveBeenCalled();
+    expect(error).toHaveBeenCalled();
+  });
+});
+
+describe('addFolderUpload', () => {
+  function fileList(files: File[]) {
+    return files as unknown as FileList;
+  }
+
+  function withPath(name: string, path: string, size = 10) {
+    const file = new File(['x'.repeat(size)], name);
+    Object.defineProperty(file, 'webkitRelativePath', { value: path });
+    return file;
+  }
+
+  it('queues one upload per file, keyed by its relative path', () => {
+    const manager = UploadManager.getInstance(config);
+
+    const { fileIds } = manager.addFolderUpload(
+      fileList([withPath('a.txt', 'docs/a.txt'), withPath('b.txt', 'docs/sub/b.txt')]),
+      {}
+    );
+
+    expect(fileIds).toHaveLength(2);
+    // The key must be the file's path within the folder, not its bare name -
+    // otherwise a nested folder upload flattens into the destination root.
+    expect(uploaderInstances.map((u) => u.config.key)).toEqual(['docs/a.txt', 'docs/sub/b.txt']);
+    expect(Object.keys(manager.getAllStatuses())).toEqual(fileIds);
+  });
+
+  it('prefixes each key when a base prefix is given', () => {
+    const manager = UploadManager.getInstance(config);
+    const { fileIds } = manager.addFolderUpload(fileList([withPath('a.txt', 'docs/a.txt')]), {
+      basePrefix: 'users/alice/',
+    });
+
+    expect(fileIds).toHaveLength(1);
+    // Asserting the count alone would pass even if basePrefix were ignored
+    // entirely, which is the whole behaviour this test exists to cover.
+    expect(uploaderInstances[0]!.config.key).toBe('users/alice/docs/a.txt');
+  });
+
+  it('returns a folder id that groups the batch', () => {
+    const manager = UploadManager.getInstance(config);
+
+    const { folderId } = manager.addFolderUpload(fileList([withPath('a.txt', 'docs/a.txt')]), {});
+
+    expect(folderId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('skips the zero-byte entries browsers emit for directories', () => {
+    const manager = UploadManager.getInstance(config);
+    const directoryEntry = new File([], 'subdir');
+    Object.defineProperty(directoryEntry, 'webkitRelativePath', { value: 'docs/subdir' });
+
+    const { fileIds } = manager.addFolderUpload(
+      fileList([directoryEntry, withPath('a.txt', 'docs/a.txt')]),
+      {}
+    );
+
+    // Uploading these would create phantom zero-byte objects shadowing real
+    // folder prefixes.
+    expect(fileIds).toHaveLength(1);
+  });
+});

--- a/s3-api/src/vitest.d.ts
+++ b/s3-api/src/vitest.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Makes the `aws-sdk-client-mock-vitest` matchers registered in
+ * `vitest.setup.ts` visible to `tsc`.
+ *
+ * The setup file sits outside `rootDir`, so it is not part of the type-check
+ * program. Without this declaration every `toHaveReceivedCommandWith(...)` call
+ * is a type error even though it works fine at runtime.
+ */
+
+import 'aws-sdk-client-mock-vitest/extend';

--- a/s3-api/tsconfig.build.json
+++ b/s3-api/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  // Build-only view of the sources. `tsconfig.json` deliberately still sees the
+  // collocated `*.test.ts` files so `pnpm typecheck` covers them, but they must
+  // not end up compiled into `dist/` and published to npm.
+  //
+  // `src/vitest.d.ts` is excluded for a different reason: it emits nothing, but
+  // leaving it in drags vitest and aws-sdk-client-mock-vitest types into the
+  // build program, making `pnpm build` fail on a production-only install.
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "src/tests",
+    "src/vitest.d.ts"
+  ]
+}

--- a/s3-api/vitest.config.ts
+++ b/s3-api/vitest.config.ts
@@ -5,7 +5,40 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/tests/**/*.test.ts'],
+    // Tests live next to the code they cover (`foo.ts` -> `foo.test.ts`).
+    // `src/tests/` predates that convention and still holds the
+    // credential-gated integration suite, which this glob also picks up.
+    include: ['src/**/*.test.ts'],
+    setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        // Type-only modules compile to nothing, so they would otherwise show
+        // up as 0% covered files that can never be covered.
+        'src/core/types.ts',
+        // Declaration files emit no executable code. v8 still lists them in
+        // lcov with LF:0/LH:0, which downstream tools (Codecov, Coveralls)
+        // render as a 0%-covered file that can never be fixed.
+        'src/**/*.d.ts',
+      ],
+      // CI gate. Set below the numbers achieved at the end of Phase 1
+      // (97.67 / 92.5 / 99.12 / 98.37) so ordinary refactoring has room to
+      // move, while a genuine drop in covered behaviour fails the build.
+      //
+      // Branches sits lowest on purpose: the remaining gap is unreachable
+      // defensive code that no test can close - see the `DEAD CODE:` and
+      // `KNOWN BUG:` cases in multipartUploader.test.ts. Raising this to match
+      // the others would require deleting source, not adding tests.
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 95,
+        lines: 95,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/s3-api/vitest.config.ts
+++ b/s3-api/vitest.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html', 'lcov'],
+      // json-summary backs the CI step that publishes the coverage table to
+      // the GitHub run summary page; it is not useful locally on its own.
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: [
         'src/**/*.test.ts',

--- a/s3-api/vitest.setup.ts
+++ b/s3-api/vitest.setup.ts
@@ -1,0 +1,17 @@
+/**
+ * Global test setup for the s3-api package.
+ *
+ * Registers the `aws-sdk-client-mock-vitest` matchers so any suite can assert
+ * against a mocked S3 client without wiring matchers up per-file:
+ *
+ *   expect(s3Mock).toHaveReceivedCommandWith(ListObjectsV2Command, { Bucket: 'b' });
+ *
+ * The `/extend` import is type-only at runtime but is what teaches TypeScript
+ * about the added matchers, so it must stay alongside `expect.extend`.
+ */
+
+import { expect } from 'vitest';
+import { allCustomMatcher } from 'aws-sdk-client-mock-vitest';
+import 'aws-sdk-client-mock-vitest/extend';
+
+expect.extend(allCustomMatcher);


### PR DESCRIPTION
Completes Phase 1 of the s3-api testing initiative: 284 tests, coverage from
20.56% to 97.67% statements, and a CI gate that keeps it there.

## The infrastructure was not working

Several things had to be fixed before any of this could hold:

- **CI never ran the s3-api tests.** The job did `typecheck` and `build` only,
  so the entire suite (including everything that existed before this PR) had
  never executed in CI. It now runs `pnpm test:coverage`, which runs the suite
  and enforces the thresholds in one step.
- **Vitest only globbed `src/tests/**`,** so collocated tests would never have
  been picked up.
- **Tests imported from `dist/`,** silently testing the last build rather than
  the working tree, and leaving coverage instrumenting nothing.
- **Collocated tests would have been published to npm.** `pnpm build` now uses
  a separate `tsconfig.build.json`; `pnpm typecheck` still covers test files.
  Verified: `npm pack` is 29 files with zero test artifacts.
- **The matchers did not type-check** (`vitest.setup.ts` sits outside
  `rootDir`), producing 15 type errors despite passing at runtime.
- **CI used a hardcoded Node version.** All jobs now read `.nvmrc`.

## The gate

`vitest.config.ts` enforces 95 statements / 90 branches / 95 functions / 95
lines. Current numbers: **97.67 / 92.5 / 99.12 / 98.37**. Verified in both
directions: it passes at exit 0, and raising a threshold above the actual
value fails the build with a clear message.

Branches sits lowest deliberately. The remaining gap is unreachable defensive
code, marked with `DEAD CODE:` in the tests so nobody later "fixes" it by
deleting source. CODEOWNERS now requires a second maintainer on
`vitest.config.ts`, since CI enforces whatever threshold is committed.

## Notable coverage

`renameFolder`'s copy-verify-delete pipeline gets the most attention, since it
is the only code that deletes data the user did not ask to delete. The
verification test gives the destination the right *number* of objects but the
wrong ones, which is exactly the case a count-based check passes before
deleting the originals.

## Bugs found, pinned not fixed

Each has a test that will fail when the bug is fixed, which is the prompt to
update callers:

1. `partSizeMB` is compared against a **byte** threshold, so a caller passing
   the documented unit (`10` for 10MB) silently gets 5MB parts.
2. A `CreateMultipartUpload` response with no `UploadId` uploads parts that
   are never completed, and reports success having written nothing.
3. `fetchDirectoryStructure` swallows every error, making `AccessDenied`
   indistinguishable from an empty folder.

## Still open

`multipartUploader.ts` has one unreachable branch, and
`content-disposition.ts` sits at 62.5% branch coverage (the RFC 5987
punctuation escape). Neither blocks the gate.
