### PR TITLE
fix: stop hiding listing failures behind an empty folder

### DIFF
--- a/frontend/src/features/dashboard/hooks/use-folder-creation.ts
+++ b/frontend/src/features/dashboard/hooks/use-folder-creation.ts
@@ -9,6 +9,7 @@ import {
   isValidFolderName,
 } from '@/features/upload/utils/sanitize-folder-name';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
+import { folderExists, describeFolderCheckError } from '@/services/folder-existence';
 
 interface UseFolderCreationOptions {
   currentPath: string;
@@ -34,43 +35,33 @@ export function useFolderCreation({ currentPath, onFolderCreated }: UseFolderCre
 
   const { apiS3 } = useAuthGuard();
 
-  if (!apiS3) {
-    return {
-      handleFolderCreation: async () => {
-        throw new Error('S3 API is not available yet.');
-      },
-      duplicateDialog,
-      hideDuplicateDialog: () => {
-        setDuplicateDialog({
-          isOpen: false,
-          folderName: '',
-          onReplace: null,
-          onKeepBoth: null,
-        });
-      },
-    };
-  }
-
-  // Check if folder already exists
+  // Every hook below is declared unconditionally. This used to sit behind an
+  // early `if (!apiS3) return ...`, which made the hook order depend on
+  // whether the session had loaded yet - the thing rules-of-hooks exists to
+  // prevent. The callbacks guard on apiS3 themselves instead, so the
+  // "not ready" behaviour is unchanged: calling them throws.
   const checkFolderExists = useCallback(
     async (folderName: string): Promise<boolean> => {
-      try {
-        // Create a test path to check if folder exists
-        const folderPrefix = generateS3Key(`${folderName}/`, currentPath);
-        const result = await apiS3.fetchDirectoryStructure(folderPrefix, 1);
+      if (!apiS3) throw new Error('S3 API is not available yet.');
 
-        // If we find any objects with this prefix, the folder exists
-        return result.files.length > 0 || result.folders.length > 0;
+      const folderPrefix = generateS3Key(`${folderName}/`, currentPath);
+      try {
+        return await folderExists(apiS3, folderPrefix);
       } catch {
-        return false;
+        // Returning false here would mean "the name is free" and we would
+        // create a folder over one that may already exist. We do not know
+        // either way, so stop and let the user retry.
+        throw new Error(describeFolderCheckError('creating the folder'));
       }
     },
-    [currentPath]
+    [currentPath, apiS3]
   );
 
   // Create folder in S3
   const createFolder = useCallback(
     async (folderName: string): Promise<void> => {
+      if (!apiS3) throw new Error('S3 API is not available yet.');
+
       // Validate and sanitize folder name
       if (!isValidFolderName(folderName)) {
         throw new Error(
@@ -91,12 +82,14 @@ export function useFolderCreation({ currentPath, onFolderCreated }: UseFolderCre
       // Use the sanitized name for the success callback
       onFolderCreated?.(sanitizedName);
     },
-    [currentPath, fetchData, onFolderCreated]
+    [currentPath, fetchData, onFolderCreated, apiS3]
   );
 
   // Handle folder creation with duplicate checking
   const handleFolderCreation = useCallback(
     async (folderName: string): Promise<void> => {
+      if (!apiS3) throw new Error('S3 API is not available yet.');
+
       const exists = await checkFolderExists(folderName);
 
       if (exists) {
@@ -162,7 +155,7 @@ export function useFolderCreation({ currentPath, onFolderCreated }: UseFolderCre
         }
       }
     },
-    [checkFolderExists, createFolder, currentPath, refreshCurrentData]
+    [checkFolderExists, createFolder, currentPath, refreshCurrentData, apiS3]
   );
 
   return {

--- a/frontend/src/features/dashboard/services/rename-service.ts
+++ b/frontend/src/features/dashboard/services/rename-service.ts
@@ -2,6 +2,7 @@ import { FileItem } from '@/features/dashboard/types/file';
 import { Folder } from '@/features/dashboard/types/folder';
 import { generateS3Key } from '@/features/upload/utils/generate-s3-key';
 import { BYOS3ApiProvider } from '@opndrive/s3-api';
+import { folderExists, describeFolderCheckError } from '@/services/folder-existence';
 
 export interface RenameOptions {
   onProgress?: (progress: { status: 'renaming' | 'success' | 'error'; error?: string }) => void;
@@ -260,18 +261,19 @@ class RenameService {
   }
 
   async checkFolderExists(folderName: string, currentPath: string): Promise<boolean> {
-    try {
-      // Normalize currentPath to work with generateS3Key
-      let normalizedPath = currentPath || '';
-      if (normalizedPath.startsWith('/')) {
-        normalizedPath = normalizedPath.slice(1);
-      }
+    // Normalize currentPath to work with generateS3Key
+    let normalizedPath = currentPath || '';
+    if (normalizedPath.startsWith('/')) {
+      normalizedPath = normalizedPath.slice(1);
+    }
 
-      const folderPrefix = generateS3Key(`${folderName}/`, normalizedPath);
-      const result = await this.api.fetchDirectoryStructure(folderPrefix, 1);
-      return result.files.length > 0 || result.folders.length > 0;
+    const folderPrefix = generateS3Key(`${folderName}/`, normalizedPath);
+    try {
+      return await folderExists(this.api, folderPrefix);
     } catch {
-      return false;
+      // "false" would mean the target name is free, and the rename would then
+      // overwrite whatever is actually there.
+      throw new Error(describeFolderCheckError('the rename'));
     }
   }
 

--- a/frontend/src/features/upload/components/upload-operations-card.tsx
+++ b/frontend/src/features/upload/components/upload-operations-card.tsx
@@ -106,6 +106,11 @@ export const UploadOperationsCard: React.FC = () => {
                           ? `Folder • ${upload.fileIds?.length || 0} files`
                           : 'File'}
                       </p>
+                      {upload.error && (
+                        <p className="text-xs text-red-600 dark:text-red-400 mt-0.5">
+                          {upload.error}
+                        </p>
+                      )}
                     </div>
                   </div>
 

--- a/frontend/src/features/upload/stores/use-upload-store.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.ts
@@ -11,6 +11,7 @@ import { ProcessedDragData } from '@/features/upload/types/folder-upload-types';
 import { DragDropTarget } from '@/features/upload/types/drag-drop-types';
 import { generateUniqueFileName, generateUniqueFolderName } from '../utils/unique-filename';
 import { useDriveStore } from '@/context/data-context';
+import { folderExists, describeFolderCheckError } from '@/services/folder-existence';
 
 // Enhanced batch tracking types
 interface UploadBatch {
@@ -86,35 +87,57 @@ const checkForFolderDuplicates = async (
   folderName: string,
   currentPath: string
 ): Promise<boolean> => {
-  try {
-    // Generate the folder prefix that would be used for this folder
-    let folderPrefix = currentPath;
+  // Generate the folder prefix that would be used for this folder
+  let folderPrefix = currentPath;
 
-    // Remove leading slash if present
-    if (folderPrefix.startsWith('/')) {
-      folderPrefix = folderPrefix.slice(1);
-    }
-
-    // If path is empty or just root, don't add any prefix
-    if (!folderPrefix || folderPrefix === '' || folderPrefix === '/') {
-      folderPrefix = `${folderName}/`;
-    } else {
-      // Ensure path ends with slash but doesn't start with one
-      if (!folderPrefix.endsWith('/')) {
-        folderPrefix = `${folderPrefix}/`;
-      }
-      folderPrefix = `${folderPrefix}${folderName}/`;
-    }
-
-    // Use fetchDirectoryStructure to check if any objects exist with this prefix
-    const result = await apiS3.fetchDirectoryStructure(folderPrefix, 1);
-
-    // If we find any objects (files or folders) with this prefix, the folder exists
-    return result.files.length > 0 || result.folders.length > 0;
-  } catch {
-    // If there's an error checking, assume it doesn't exist
-    return false;
+  // Remove leading slash if present
+  if (folderPrefix.startsWith('/')) {
+    folderPrefix = folderPrefix.slice(1);
   }
+
+  // If path is empty or just root, don't add any prefix
+  if (!folderPrefix || folderPrefix === '' || folderPrefix === '/') {
+    folderPrefix = `${folderName}/`;
+  } else {
+    // Ensure path ends with slash but doesn't start with one
+    if (!folderPrefix.endsWith('/')) {
+      folderPrefix = `${folderPrefix}/`;
+    }
+    folderPrefix = `${folderPrefix}${folderName}/`;
+  }
+
+  try {
+    return await folderExists(apiS3, folderPrefix);
+  } catch {
+    // Assuming "does not exist" here would upload straight into an existing
+    // folder without the user ever being asked.
+    throw new Error(describeFolderCheckError('the upload'));
+  }
+};
+
+/**
+ * Records a folder we refused to upload because we could not tell whether the
+ * name was already taken.
+ *
+ * The check used to answer "does not exist" on any error, so a network or
+ * permissions blip meant uploading straight into an existing folder. Skipping
+ * the folder is the safe call, but it must be visible - a silent no-op looks
+ * exactly like a successful upload of nothing.
+ */
+const reportFolderCheckFailure = (
+  addUpload: (id: string, upload: UploadProgress) => void,
+  folderName: string,
+  err: unknown
+): void => {
+  const id = `folder-check-failed-${folderName}-${Date.now()}`;
+  addUpload(id, {
+    id,
+    name: folderName,
+    status: 'failed',
+    progress: 0,
+    type: 'folder',
+    error: err instanceof Error ? err.message : 'Could not check whether that name is taken.',
+  });
 };
 
 interface DuplicateDialogState {
@@ -135,6 +158,8 @@ interface UploadProgress {
   status: UploadStatus;
   progress: number;
   type: 'file' | 'folder';
+  /** Why this entry failed. Shown in the operations card. */
+  error?: string;
   parentFolderId?: string; // For files that belong to a folder
   fileIds?: string[]; // For folders, track their file IDs
 }
@@ -449,11 +474,13 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
       for (const folder of processedData.folderStructures) {
         // Check for folder duplicates if API is available
         if (apiS3) {
-          const isDuplicate = await checkForFolderDuplicates(
-            apiS3,
-            folder.name,
-            currentPrefix || ''
-          );
+          let isDuplicate: boolean;
+          try {
+            isDuplicate = await checkForFolderDuplicates(apiS3, folder.name, currentPrefix || '');
+          } catch (err) {
+            reportFolderCheckFailure(addUpload, folder.name, err);
+            continue;
+          }
 
           if (isDuplicate) {
             // Show duplicate dialog for folder
@@ -705,7 +732,13 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
 
         // Check for folder duplicates if API is available
         if (apiS3) {
-          const isDuplicate = await checkForFolderDuplicates(apiS3, folder.name, targetPath);
+          let isDuplicate: boolean;
+          try {
+            isDuplicate = await checkForFolderDuplicates(apiS3, folder.name, targetPath);
+          } catch (err) {
+            reportFolderCheckFailure(addUpload, folder.name, err);
+            continue;
+          }
 
           if (isDuplicate) {
             // Show duplicate dialog for folder

--- a/frontend/src/features/upload/utils/unique-filename.ts
+++ b/frontend/src/features/upload/utils/unique-filename.ts
@@ -1,5 +1,6 @@
 import { BYOS3ApiProvider } from '@opndrive/s3-api';
 import { generateS3Key } from './generate-s3-key';
+import { folderExists, describeFolderCheckError } from '@/services/folder-existence';
 
 /**
  * Generates a unique filename by checking S3 and adding (1), (2), etc. if needed
@@ -79,15 +80,15 @@ export async function generateUniqueFolderName(
   currentPath: string
 ): Promise<string> {
   const checkFolderExists = async (folderName: string): Promise<boolean> => {
+    // Use the same generateS3Key logic as the hook for consistency
+    const folderPrefix = generateS3Key(`${folderName}/`, currentPath);
     try {
-      // Use the same generateS3Key logic as the hook for consistency
-      const folderPrefix = generateS3Key(`${folderName}/`, currentPath);
-      const result = await apiS3.fetchDirectoryStructure(folderPrefix, 1);
-
-      // If we find any objects (files or folders) with this prefix, the folder exists
-      return result.files.length > 0 || result.folders.length > 0;
+      return await folderExists(apiS3, folderPrefix);
     } catch {
-      return false;
+      // This function picks the name an upload will be written to. Treating a
+      // failed check as "free" is how it would hand back a name that is
+      // already in use and overwrite it.
+      throw new Error(describeFolderCheckError('the upload'));
     }
   };
 

--- a/frontend/src/services/folder-existence.ts
+++ b/frontend/src/services/folder-existence.ts
@@ -1,0 +1,35 @@
+import { BYOS3ApiProvider } from '@opndrive/s3-api';
+
+/**
+ * Checks whether anything is stored under a folder prefix.
+ *
+ * This used to be copy-pasted into four call sites, each of which caught the
+ * error and returned `false` - meaning "the name is free". A listing that
+ * failed for any reason (permissions, throttling, a dropped connection) was
+ * therefore read as "this folder does not exist", and the caller went on to
+ * create, rename, or upload over something that was already there.
+ *
+ * So this deliberately does NOT catch. A caller that cannot determine whether
+ * a name is taken must stop and say so, not guess. Use `describeFolderCheckError`
+ * for the message to show the user.
+ *
+ * @throws whatever the S3 listing threw. Callers must handle it.
+ */
+export async function folderExists(
+  apiS3: BYOS3ApiProvider,
+  folderPrefix: string
+): Promise<boolean> {
+  const result = await apiS3.fetchDirectoryStructure(folderPrefix, 1);
+  return result.files.length > 0 || result.folders.length > 0;
+}
+
+/**
+ * Message for the case where we could not tell whether a name is taken.
+ *
+ * Deliberately does not claim the operation failed - we genuinely do not know
+ * the state of the bucket, and saying "that folder already exists" would be a
+ * guess presented as fact.
+ */
+export function describeFolderCheckError(action: string): string {
+  return `Could not check whether that name is already taken, so ${action} was cancelled. Please try again.`;
+}

--- a/s3-api/src/index.listing.test.ts
+++ b/s3-api/src/index.listing.test.ts
@@ -135,25 +135,22 @@ describe('fetchDirectoryStructure', () => {
     });
   });
 
-  it('KNOWN DEBT: reports a denied listing identically to an empty folder', async () => {
+  it('reports a denied listing as an error, not as an empty folder', async () => {
     s3Mock.on(ListObjectsV2Command).resolves({});
     const whenGenuinelyEmpty = await makeApi().fetchDirectoryStructure('users/alice/', 50);
 
     s3Mock.reset();
     s3Mock.on(ListObjectsV2Command).rejects(s3Error('AccessDenied', 403));
-    const whenAccessDenied = await makeApi().fetchDirectoryStructure('users/alice/', 50);
 
-    // KNOWN DEBT - `fetchDirectoryStructure` in src/index.ts catches every
-    // error and returns an empty structure, so a permissions failure is
-    // byte-for-byte indistinguishable from a genuinely empty folder and the UI
-    // cannot tell the user why their files vanished.
-    //
-    // This test PINS that behaviour so it cannot change silently. It does NOT
-    // endorse it. When the method learns to surface errors, this test SHOULD
-    // fail - and that failure is the prompt to update every caller that
-    // currently treats an empty result as authoritative.
-    expect(whenAccessDenied).toEqual(whenGenuinelyEmpty);
-    expect(whenAccessDenied).toEqual({
+    // A failure must be distinguishable from an empty folder. When this method
+    // swallowed errors, callers asking "does this folder exist?" answered "no"
+    // on a permissions blip and then created or uploaded over what was there.
+    await expect(makeApi().fetchDirectoryStructure('users/alice/', 50)).rejects.toThrow(
+      'AccessDenied'
+    );
+
+    // An genuinely empty folder still reports empty, not an error.
+    expect(whenGenuinelyEmpty).toEqual({
       files: [],
       folders: [],
       nextToken: undefined,

--- a/s3-api/src/index.ts
+++ b/s3-api/src/index.ts
@@ -53,37 +53,37 @@ export class BYOS3ApiProvider extends BaseS3ApiProvider {
     this.userType = userType;
   }
 
+  /**
+   * Lists one page of a directory.
+   *
+   * Throws if the listing fails. It used to swallow every error and return an
+   * empty structure, which made a permissions failure look exactly like an
+   * empty folder - and callers that ask "does this folder exist?" would then
+   * answer "no" and happily create or upload over something that was already
+   * there. Callers must handle the rejection.
+   */
   async fetchDirectoryStructure(
     prefix: string | undefined | null,
     maxKeys: number = 50,
     token?: string
   ): Promise<DirectoryStructure> {
-    try {
-      const input: ListObjectsV2CommandInput = {
-        Bucket: this.credentials.bucketName,
-        Prefix: prefix ?? this.credentials.prefix,
-        MaxKeys: maxKeys,
-        ContinuationToken: token,
-        Delimiter: '/',
-      };
+    const input: ListObjectsV2CommandInput = {
+      Bucket: this.credentials.bucketName,
+      Prefix: prefix ?? this.credentials.prefix,
+      MaxKeys: maxKeys,
+      ContinuationToken: token,
+      Delimiter: '/',
+    };
 
-      const command = new ListObjectsV2Command(input);
-      const response = await this.s3.send(command);
+    const command = new ListObjectsV2Command(input);
+    const response = await this.s3.send(command);
 
-      return {
-        files: response.Contents ?? [],
-        folders: response.CommonPrefixes ?? [],
-        nextToken: response.NextContinuationToken,
-        isTruncated: response.IsTruncated,
-      };
-    } catch (error) {
-      return {
-        files: [],
-        folders: [],
-        nextToken: undefined,
-        isTruncated: undefined,
-      };
-    }
+    return {
+      files: response.Contents ?? [],
+      folders: response.CommonPrefixes ?? [],
+      nextToken: response.NextContinuationToken,
+      isTruncated: response.IsTruncated,
+    };
   }
 
   async fetchMetadata(path: string): Promise<HeadObjectCommandOutput | null> {

--- a/s3-api/src/utils/multipartUploader.test.ts
+++ b/s3-api/src/utils/multipartUploader.test.ts
@@ -274,18 +274,19 @@ describe('start', () => {
     expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
   });
 
-  it('KNOWN BUG: a session created without an UploadId uploads parts that never complete', async () => {
+  it('fails fast when S3 starts a session without returning an UploadId', async () => {
     s3Mock.on(CreateMultipartUploadCommand).resolves({}); // no UploadId
     s3Mock.on(UploadPartCommand).resolves({ ETag: '"e"' });
     s3Mock.on(CompleteMultipartUploadCommand).resolves({});
 
-    await makeUploader().start(makeFile(5 * MB));
+    await expect(makeUploader().start(makeFile(5 * MB))).rejects.toThrow(
+      /did not return an UploadId/
+    );
 
-    // `this.uploadId = UploadId!` asserts away the undefined, so the parts go
-    // out with UploadId: undefined and completeUpload's `if (!this.uploadId)`
-    // guard then returns early. The upload silently "succeeds" having written
-    // nothing. Pinned, not endorsed.
-    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(1);
+    // Nothing may be sent afterwards. Without the guard the parts went out
+    // with UploadId: undefined and completeUpload returned early, so the
+    // upload "succeeded" having stored nothing.
+    expect(s3Mock).not.toHaveReceivedCommand(UploadPartCommand);
     expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
   });
 });

--- a/s3-api/src/utils/multipartUploader.ts
+++ b/s3-api/src/utils/multipartUploader.ts
@@ -58,7 +58,18 @@ export class MultipartUploader {
           Key: this.key,
         })
       );
-      this.uploadId = UploadId!;
+
+      // UploadId is optional on the response type, and some S3-compatible
+      // services do omit it. Without this guard every part goes out with
+      // UploadId: undefined and completeUpload() then returns early, so the
+      // upload finishes "successfully" having stored nothing.
+      if (!UploadId) {
+        throw new Error(
+          `S3 did not return an UploadId when starting the multipart upload for ${this.key}`
+        );
+      }
+
+      this.uploadId = UploadId;
     }
 
     await this.uploadParts(file, onProgress);


### PR DESCRIPTION
Two bugs found while writing the Phase 1 tests.

**Listing errors were swallowed.** `fetchDirectoryStructure` caught everything and
returned an empty result, so a permissions failure looked identical to an empty
folder. It now throws.

That mattered because four places in the frontend asked "does this folder exist?"
and answered `false` when the check itself failed, meaning the app would create,
rename, or upload over something already there. They now share one `folderExists()`
helper that does not swallow. Folder uploads skip the folder and show it as failed
in the operations card with the reason.

**Missing UploadId.** If S3 starts a multipart upload without returning an
UploadId, every part used to go out with an undefined id and the complete call was
silently skipped. It now fails immediately.

The dashboard already had `catch { setStatus('error') }` on both display paths, so
it gets a proper error state for free.

`useFolderCreation` also had its hooks moved out from behind an early return, since
the pre-commit lint gate blocks files with warnings.

Tests: 273 s3-api, 27 frontend, coverage gate green.
