### PR TITLE
feat(s3-api)!: rename partSizeMB to partSizeBytes

### DIFF
--- a/s3-api/package.json
+++ b/s3-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opndrive/s3-api",
-  "version": "2.8.0",
+  "version": "3.0.0",
   "description": "AWS S3 helper for the opndrive project",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/s3-api/src/core/types.ts
+++ b/s3-api/src/core/types.ts
@@ -28,7 +28,17 @@ export type userTypes = 'BYO';
 export interface MultipartUploadParams {
   key: string;
   fileName: string;
-  partSizeMB: number;
+  /**
+   * Size of each upload part, in BYTES. Values below the 5 MiB S3 minimum are
+   * clamped up to it.
+   *
+   * Named `partSizeMB` until 3.0.0, where it was already compared against a
+   * byte threshold - so passing `10` for "10 MB" failed the check and silently
+   * fell back to 5 MiB parts. Renamed rather than reinterpreted, because
+   * changing the unit would have quietly altered behaviour for callers already
+   * passing bytes.
+   */
+  partSizeBytes: number;
   concurrency: number;
 }
 
@@ -37,7 +47,8 @@ export interface MultipartUploadConfig extends MultipartUploadParams {
   bucket: string;
   key: string;
   fileName: string;
-  partSizeMB: number;
+  /** Size of each upload part, in BYTES. See MultipartUploadParams. */
+  partSizeBytes: number;
   concurrency: number;
 }
 
@@ -185,7 +196,8 @@ export type UploadManagerConfig = {
   bucket: string;
   prefix: string; // Base prefix for all uploads
   maxConcurrency?: number;
-  partSizeMB?: number; // Default part size for all uploads
+  /** Default part size for all uploads, in MEGABYTES. Converted to bytes before reaching MultipartUploader. */
+  partSizeMB?: number;
 };
 
 // For the event emitter

--- a/s3-api/src/index.multipart.test.ts
+++ b/s3-api/src/index.multipart.test.ts
@@ -62,7 +62,7 @@ describe('uploadMultipartParallely', () => {
     const uploader = makeApi().uploadMultipartParallely({
       key: 'users/alice/big.bin',
       fileName: 'big.bin',
-      partSizeMB: 5 * MB,
+      partSizeBytes: 5 * MB,
       concurrency: 4,
     });
 
@@ -79,7 +79,7 @@ describe('uploadMultipartParallely', () => {
     const uploader = makeApi().uploadMultipartParallely({
       key: 'users/alice/big.bin',
       fileName: 'big.bin',
-      partSizeMB: 5 * MB,
+      partSizeBytes: 5 * MB,
       concurrency: 1,
     });
     await uploader.start(new File(['hello'], 'big.bin'));
@@ -104,7 +104,7 @@ describe('uploadMultipartParallely', () => {
     const uploader = makeApi().uploadMultipartParallely({
       key: 'k',
       fileName: 'f',
-      partSizeMB: 5 * MB,
+      partSizeBytes: 5 * MB,
       concurrency: 1,
     });
     await uploader.start(new File(['hello'], 'f'));
@@ -122,7 +122,7 @@ describe('uploadMultipartParallely', () => {
     makeApi().uploadMultipartParallely({
       key: 'users/alice/big.bin',
       fileName: 'big.bin',
-      partSizeMB: 5 * MB,
+      partSizeBytes: 5 * MB,
       concurrency: 4,
     });
 
@@ -148,7 +148,7 @@ describe('uploadMultipartParallely', () => {
     const uploader = makeApi().uploadMultipartParallely({
       key: 'k',
       fileName: 'f',
-      partSizeMB: 5 * MB,
+      partSizeBytes: 5 * MB,
       concurrency: 0,
     });
     await uploader.start(new File(['x'.repeat(30 * MB)], 'f'));
@@ -172,7 +172,7 @@ describe('uploadMultipartParallely', () => {
     const uploader = makeApi().uploadMultipartParallely({
       key: 'k',
       fileName: 'f',
-      partSizeMB: 5 * MB,
+      partSizeBytes: 5 * MB,
       concurrency: 2,
     });
     await uploader.start(new File(['x'.repeat(30 * MB)], 'f'));
@@ -189,7 +189,7 @@ describe('uploadMultipartParallely', () => {
     const uploader = makeApi().uploadMultipartParallely({
       key: 'k',
       fileName: 'f',
-      partSizeMB: 5 * MB,
+      partSizeBytes: 5 * MB,
       concurrency: 1,
     });
     await uploader.start(new File(['x'.repeat(15 * MB)], 'f'), (p) => progress.push(p));
@@ -199,28 +199,23 @@ describe('uploadMultipartParallely', () => {
     expect(progress).toEqual([(1 / 3) * 100, (2 / 3) * 100, 100]);
   });
 
-  it('KNOWN BUG: partSizeMB is compared against bytes, so real MB values are ignored', async () => {
+  it('passes the part size through in bytes', async () => {
     s3Mock.on(CreateMultipartUploadCommand).resolves({ UploadId: 'u' });
     s3Mock.on(UploadPartCommand).resolves({ ETag: '"e"' });
     s3Mock.on(CompleteMultipartUploadCommand).resolves({});
 
-    // The field is named partSizeMB, but MultipartUploader guards it with
-    // `partSizeMB >= 5 * 1024 * 1024` - a BYTE threshold. So a caller passing
-    // the documented unit (10, meaning 10 MB) fails the check and silently
-    // gets the 5 MB default instead of 10 MB parts.
     const uploader = makeApi().uploadMultipartParallely({
       key: 'k',
       fileName: 'f',
-      partSizeMB: 10,
+      partSizeBytes: 10 * MB,
       concurrency: 1,
     });
     await uploader.start(new File(['x'.repeat(10 * MB)], 'f'));
 
-    // 10 MB at the intended 10 MB part size would be ONE part; at the silently
-    // substituted 5 MB default it is two. Pinned, not endorsed - fixing the
-    // unit should make this test fail.
-    const parts = s3Mock.commandCalls(UploadPartCommand);
-    expect(parts).toHaveLength(2);
+    // 10 MB of data at a 10 MiB part size is a single part. Before the rename
+    // this field was called partSizeMB, so `10` meant 10 bytes, failed the
+    // 5 MiB floor, and silently produced two 5 MiB parts instead.
+    expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(1);
   });
 
   it('clamps any part size below 5MB up to the 5MB minimum', async () => {
@@ -231,7 +226,7 @@ describe('uploadMultipartParallely', () => {
     const uploader = makeApi().uploadMultipartParallely({
       key: 'k',
       fileName: 'f',
-      partSizeMB: 1024, // far below the byte threshold
+      partSizeBytes: 1024, // far below the 5 MiB floor
       concurrency: 1,
     });
     await uploader.start(new File(['x'.repeat(12 * MB)], 'f'));
@@ -255,7 +250,7 @@ describe('uploadMultipartParallely', () => {
     const uploader = makeApi().uploadMultipartParallely({
       key: 'k',
       fileName: 'f',
-      partSizeMB: 1,
+      partSizeBytes: 1,
       concurrency: 1,
     });
 

--- a/s3-api/src/index.ts
+++ b/s3-api/src/index.ts
@@ -138,7 +138,7 @@ export class BYOS3ApiProvider extends BaseS3ApiProvider {
       key: params.key,
       fileName: params.fileName,
       concurrency: params.concurrency,
-      partSizeMB: params.partSizeMB,
+      partSizeBytes: params.partSizeBytes,
     };
 
     const uploader = new MultipartUploader(config);

--- a/s3-api/src/utils/multipartUploader.test.ts
+++ b/s3-api/src/utils/multipartUploader.test.ts
@@ -37,13 +37,13 @@ function installLocalStorage() {
   });
 }
 
-function makeUploader(overrides: { partSizeMB?: number; concurrency?: number } = {}) {
+function makeUploader(overrides: { partSizeBytes?: number; concurrency?: number } = {}) {
   return new MultipartUploader({
     s3: new S3Client({ region: 'us-east-1' }),
     bucket: 'test-bucket',
     key: 'users/alice/big.bin',
     fileName: 'big.bin',
-    partSizeMB: overrides.partSizeMB ?? 5 * MB,
+    partSizeBytes: overrides.partSizeBytes ?? 5 * MB,
     concurrency: overrides.concurrency ?? 1,
   });
 }
@@ -89,24 +89,23 @@ describe('construction', () => {
     expect(store.has(STATE_KEY)).toBe(false);
   });
 
-  it('KNOWN BUG: partSizeMB is compared against BYTES, so real MB values are ignored', async () => {
+  it('takes the part size in bytes', async () => {
     stubHappyPath();
 
-    // multipartUploader.ts guards with `partSizeMB >= 5 * 1024 * 1024` - a byte
-    // threshold on a field named MB. A caller passing the documented unit (10,
-    // meaning 10 MB) fails that check and silently falls back to the 5 MB
-    // default instead of getting 10 MB parts.
-    await makeUploader({ partSizeMB: 10 }).start(makeFile(10 * MB));
+    // The field was called partSizeMB but has always been compared against a
+    // byte threshold, so `10` meaning "10 MB" silently became the 5 MiB
+    // default. Renaming it is the fix; the unit itself never changed.
+    await makeUploader({ partSizeBytes: 10 * MB }).start(makeFile(20 * MB));
 
-    // At the intended 10 MB this is ONE part; at the substituted 5 MB it is two.
-    // Fixing the unit should make this assertion fail.
     expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(2);
   });
 
-  it('honours a part size expressed in bytes above the 5MB floor', async () => {
+  it('clamps a part size below the 5MB minimum', async () => {
     stubHappyPath();
 
-    await makeUploader({ partSizeMB: 10 * MB }).start(makeFile(20 * MB));
+    // 10 bytes is nonsense, and pre-rename this is exactly what `10` meaning
+    // "10 MB" resolved to.
+    await makeUploader({ partSizeBytes: 10 }).start(makeFile(10 * MB));
 
     expect(s3Mock.commandCalls(UploadPartCommand)).toHaveLength(2);
   });

--- a/s3-api/src/utils/multipartUploader.ts
+++ b/s3-api/src/utils/multipartUploader.ts
@@ -30,9 +30,10 @@ export class MultipartUploader {
     this.key = config.key;
     this.fileName = config.fileName;
     this.concurrency = config.concurrency && config.concurrency > 0 ? config.concurrency : 3;
+    // S3 rejects a multipart upload whose non-final parts are under 5 MiB.
     this.partSize =
-      config.partSizeMB && config.partSizeMB >= 5 * 1024 * 1024
-        ? config.partSizeMB
+      config.partSizeBytes && config.partSizeBytes >= 5 * 1024 * 1024
+        ? config.partSizeBytes
         : 5 * 1024 * 1024;
     localStorage.removeItem(`upload:${this.fileName}:${this.key}`);
   }

--- a/s3-api/src/utils/uploadManager.ts
+++ b/s3-api/src/utils/uploadManager.ts
@@ -130,7 +130,7 @@ export class UploadManager {
       bucket: this.bucket,
       key: config.key,
       fileName: file.name,
-      partSizeMB: this.partSize,
+      partSizeBytes: this.partSize,
       concurrency: this.partConcurrency,
     });
 


### PR DESCRIPTION
`partSizeMB` was never megabytes. `MultipartUploader` has always compared it
against `5 * 1024 * 1024`, a byte threshold, so passing `10` for "10 MB" failed
the check and silently fell back to 5 MiB parts.

Renamed to `partSizeBytes` instead of changing the unit. Reinterpreting the
value would have quietly changed behaviour for anyone already passing bytes,
which is the harder failure to notice.

`UploadManagerConfig.partSizeMB` genuinely is megabytes and is untouched, so
the frontend needs no change. That path converts to bytes before reaching the
uploader, which is why nothing was broken in the app today. The bug only bit
external callers of `uploadMultipartParallely`.

Breaking type change, so s3-api goes to 3.0.0.

Tests: 273 pass, coverage gate green. Frontend typechecks and tests pass.
