### PR TITLE
test(frontend): cover the state layer and fix two data-safety bugs

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,3 @@
+
+# Test coverage reports
+coverage

--- a/frontend/__mocks__/zustand.ts
+++ b/frontend/__mocks__/zustand.ts
@@ -1,0 +1,87 @@
+/**
+ * Auto-reset wrapper around zustand, applied to every test run.
+ *
+ * Zustand stores are created once at module scope, so a store written to in
+ * one test is still holding that state in the next one. Test order then starts
+ * to matter, and a suite can pass in isolation while failing in a full run (or,
+ * worse, pass in a full run only because an earlier test happened to leave the
+ * right state behind).
+ *
+ * This records the initial state of every store as it is created and restores
+ * all of them after each test. It is the pattern from zustand's own testing
+ * docs; `vi.mock('zustand')` in the setup file is what activates it.
+ */
+
+import { act } from '@testing-library/react';
+import type * as ZustandExportedTypes from 'zustand';
+import { afterEach, vi } from 'vitest';
+
+export * from 'zustand';
+
+const { create: actualCreate, createStore: actualCreateStore } =
+  await vi.importActual<typeof ZustandExportedTypes>('zustand');
+
+/** Reset callbacks, one per store created during the run. */
+export const storeResetFns = new Set<() => void>();
+
+/**
+ * Copies a state object one level deep, cloning the data and keeping the
+ * actions.
+ *
+ * `structuredClone` cannot be used on the whole state: zustand keeps its
+ * actions alongside the data and functions are not cloneable, so it would
+ * throw. Anything it refuses (a class instance, a proxy) keeps its reference
+ * rather than failing the reset.
+ */
+function cloneState<T>(state: T): T {
+  const copy = { ...(state as object) } as Record<string, unknown>;
+  for (const [key, value] of Object.entries(copy)) {
+    if (typeof value === 'function') continue;
+    try {
+      copy[key] = structuredClone(value);
+    } catch {
+      // Not cloneable - leave the original reference in place.
+    }
+  }
+  return copy as T;
+}
+
+function trackReset<T>(store: {
+  getInitialState: () => T;
+  setState: (s: T, replace: true) => void;
+}) {
+  // Snapshot taken at store creation, before any test can touch it, and never
+  // handed out. Each reset installs a FRESH copy of it.
+  //
+  // Restoring the captured object directly is not enough: a test that mutates
+  // a nested value in place (`state.downloads.set(...)` rather than going
+  // through an action) mutates the very object the reset restores, so the
+  // pollution survives every subsequent reset.
+  const pristine = cloneState(store.getInitialState());
+
+  storeResetFns.add(() => {
+    // `replace: true` matters too: a partial set would leave keys added by a
+    // test in place.
+    store.setState(cloneState(pristine), true);
+  });
+  return store;
+}
+
+export const create = (<T>(stateCreator: ZustandExportedTypes.StateCreator<T>) => {
+  // Supports both the curried `create<T>()(fn)` and direct `create(fn)` forms.
+  return typeof stateCreator === 'function'
+    ? trackReset(actualCreate(stateCreator))
+    : (curried: ZustandExportedTypes.StateCreator<T>) => trackReset(actualCreate(curried));
+}) as typeof ZustandExportedTypes.create;
+
+export const createStore = (<T>(stateCreator: ZustandExportedTypes.StateCreator<T>) => {
+  return typeof stateCreator === 'function'
+    ? trackReset(actualCreateStore(stateCreator))
+    : (curried: ZustandExportedTypes.StateCreator<T>) => trackReset(actualCreateStore(curried));
+}) as typeof ZustandExportedTypes.createStore;
+
+afterEach(() => {
+  act(() => {
+    storeResetFns.forEach((reset) => reset());
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "tsc": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1095.0",
@@ -71,6 +73,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4.7.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/frontend/src/features/dashboard/hooks/use-search.test.tsx
+++ b/frontend/src/features/dashboard/hooks/use-search.test.tsx
@@ -53,7 +53,13 @@ const providerB = { id: 'B' } as never;
 describe('useSearch - Rules of Hooks (#82 defect 1)', () => {
   beforeEach(() => {
     mockUseAuthGuard.mockReset();
-    mockedCreateSearchService.mockClear();
+    // mockReset, not mockClear: two tests below install a persistent return
+    // value with mockReturnValue, and mockClear only wipes call history. That
+    // stale value survived into other suites, so both providers received the
+    // same service object and the memoisation assertions silently passed or
+    // failed depending on test order. mockReset also restores the factory
+    // implementation given to vi.fn().
+    mockedCreateSearchService.mockReset();
   });
 
   it('does not throw when apiS3 goes null -> provider on a mounted instance', () => {
@@ -84,7 +90,13 @@ describe('useSearch - Rules of Hooks (#82 defect 1)', () => {
 describe('useSearch - service memoisation (#82 defect 2)', () => {
   beforeEach(() => {
     mockUseAuthGuard.mockReset();
-    mockedCreateSearchService.mockClear();
+    // mockReset, not mockClear: two tests below install a persistent return
+    // value with mockReturnValue, and mockClear only wipes call history. That
+    // stale value survived into other suites, so both providers received the
+    // same service object and the memoisation assertions silently passed or
+    // failed depending on test order. mockReset also restores the factory
+    // implementation given to vi.fn().
+    mockedCreateSearchService.mockReset();
   });
 
   it('builds the search service once across re-renders with an unchanged apiS3', () => {
@@ -128,7 +140,13 @@ describe('useSearch - service memoisation (#82 defect 2)', () => {
 describe('useSearch - readiness and inert behaviour', () => {
   beforeEach(() => {
     mockUseAuthGuard.mockReset();
-    mockedCreateSearchService.mockClear();
+    // mockReset, not mockClear: two tests below install a persistent return
+    // value with mockReturnValue, and mockClear only wipes call history. That
+    // stale value survived into other suites, so both providers received the
+    // same service object and the memoisation assertions silently passed or
+    // failed depending on test order. mockReset also restores the factory
+    // implementation given to vi.fn().
+    mockedCreateSearchService.mockReset();
     useSearchStore.getState().clearCache();
     useSearchStore.getState().setLoading(false);
   });
@@ -177,7 +195,13 @@ describe('useSearch - readiness and inert behaviour', () => {
 describe('useSearch - in-flight search cleanup', () => {
   beforeEach(() => {
     mockUseAuthGuard.mockReset();
-    mockedCreateSearchService.mockClear();
+    // mockReset, not mockClear: two tests below install a persistent return
+    // value with mockReturnValue, and mockClear only wipes call history. That
+    // stale value survived into other suites, so both providers received the
+    // same service object and the memoisation assertions silently passed or
+    // failed depending on test order. mockReset also restores the factory
+    // implementation given to vi.fn().
+    mockedCreateSearchService.mockReset();
     useSearchStore.getState().clearCache();
     useSearchStore.getState().setLoading(false);
   });

--- a/frontend/src/features/dashboard/services/rename-service.test.ts
+++ b/frontend/src/features/dashboard/services/rename-service.test.ts
@@ -138,23 +138,42 @@ describe('renameFile', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('KNOWN GAP: does not short-circuit when the new name equals the old one', async () => {
+  it('never touches S3 when the new name equals the old one', async () => {
+    const api = fakeApi();
+    const h = handlers();
+
+    await createRenameService(api).renameFile(file, 'draft.md', 'docs', h);
+
+    // Without this guard the call becomes a copy of the object onto itself
+    // followed by a delete of that same key. Real S3 refuses the self-copy so
+    // the delete is never reached, but that safety belongs to the backend - an
+    // S3-compatible service that permits the copy would delete the file.
+    expect(api.moveFile).not.toHaveBeenCalled();
+  });
+
+  it('reports a same-name rename as a clean success', async () => {
+    const h = handlers();
+
+    await expect(
+      createRenameService(fakeApi()).renameFile(file, 'draft.md', 'docs', h)
+    ).resolves.toBeUndefined();
+
+    // The user asked for the name it already has, so nothing is wrong - the UI
+    // should close the dialog, not show an error.
+    expect(h.onProgress.mock.calls.map(([p]) => p.status)).toEqual(['renaming', 'success']);
+    expect(h.onComplete).toHaveBeenCalledOnce();
+    expect(h.onError).not.toHaveBeenCalled();
+  });
+
+  it('still renames when only the casing differs', async () => {
     const api = fakeApi();
 
-    await createRenameService(api).renameFile(file, 'draft.md', 'docs');
+    await createRenameService(api).renameFile(file, 'Draft.md', 'docs');
 
-    // There is no equality check, so this issues a copy of the object onto
-    // itself followed by a delete of that same key. Real S3 rejects a self-copy
-    // ("this copy request is illegal"), so the delete is never reached and the
-    // user sees a confusing error rather than losing the file - but the safety
-    // here is S3's, not ours, and S3-compatible backends may not all refuse it.
-    //
-    // Pinned, not endorsed. A `if (oldKey === newKey) return;` guard would make
-    // this test fail, which is the prompt to also stop the UI offering a rename
-    // that changes nothing.
+    // S3 keys are case-sensitive, so this is a real rename, not a no-op.
     expect(api.moveFile).toHaveBeenCalledExactlyOnceWith({
       oldKey: 'docs/draft.md',
-      newKey: 'docs/draft.md',
+      newKey: 'docs/Draft.md',
     });
   });
 });

--- a/frontend/src/features/dashboard/services/rename-service.test.ts
+++ b/frontend/src/features/dashboard/services/rename-service.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Rename service: the layer between the rename UI and `@opndrive/s3-api`.
+ *
+ * The api provider is injected, so it is faked here rather than mocked through
+ * the module registry - same effect, less indirection. s3-api's own behaviour
+ * is covered by its suite; what matters here is how this layer maps results and
+ * failures onto the callbacks the UI renders.
+ *
+ * The interesting case is `copied-not-cleaned`: the rename SUCCEEDED and only
+ * cleanup of the old copies fell short. Reporting that as an error would tell
+ * the user their rename failed while their files sit correctly at the new name.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BYOS3ApiProvider } from '@opndrive/s3-api';
+import { createRenameService } from './rename-service';
+import type { FileItem } from '../types/file';
+import type { Folder } from '../types/folder';
+
+function fakeApi(overrides: Record<string, unknown> = {}) {
+  return {
+    moveFile: vi.fn(async () => {}),
+    renameFolder: vi.fn(async () => ({
+      status: 'completed',
+      totalKeys: 3,
+      copiedKeys: 3,
+      deletedKeys: 3,
+      errors: [],
+      completed: true,
+    })),
+    fetchMetadata: vi.fn(async () => null),
+    fetchDirectoryStructure: vi.fn(async () => ({ files: [], folders: [] })),
+    ...overrides,
+  } as unknown as BYOS3ApiProvider;
+}
+
+const file = { Key: 'docs/draft.md', name: 'draft.md' } as FileItem;
+const folder = { name: 'photos', Prefix: 'docs/photos/' } as Folder;
+
+/** Collects every callback the service can fire. */
+function handlers() {
+  return {
+    onProgress: vi.fn(),
+    onComplete: vi.fn(),
+    onError: vi.fn(),
+    onPartialCleanup: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('renameFile', () => {
+  it('moves the object to the new name in the same folder', async () => {
+    const api = fakeApi();
+
+    await createRenameService(api).renameFile(file, 'final.md', 'docs');
+
+    expect(api.moveFile).toHaveBeenCalledExactlyOnceWith({
+      oldKey: 'docs/draft.md',
+      newKey: 'docs/final.md',
+    });
+  });
+
+  it('renames using the object key, not a reconstructed path', async () => {
+    const api = fakeApi();
+    const nested = { Key: 'a/b/c/report.pdf', name: 'report.pdf' } as FileItem;
+
+    await createRenameService(api).renameFile(nested, 'summary.pdf', 'ignored/path');
+
+    // The key is authoritative; rebuilding it from currentPath would break for
+    // anything the UI navigated to indirectly.
+    expect(api.moveFile).toHaveBeenCalledWith({
+      oldKey: 'a/b/c/report.pdf',
+      newKey: 'a/b/c/summary.pdf',
+    });
+  });
+
+  it('reports progress then completion', async () => {
+    const h = handlers();
+
+    await createRenameService(fakeApi()).renameFile(file, 'final.md', 'docs', h);
+
+    expect(h.onProgress.mock.calls.map(([p]) => p.status)).toEqual(['renaming', 'success']);
+    expect(h.onComplete).toHaveBeenCalledOnce();
+    expect(h.onError).not.toHaveBeenCalled();
+  });
+
+  it('rejects a file with no key', async () => {
+    const h = handlers();
+    const keyless = { name: 'ghost.md' } as FileItem;
+
+    await expect(
+      createRenameService(fakeApi()).renameFile(keyless, 'x.md', 'docs', h)
+    ).rejects.toThrow('File key is missing');
+
+    expect(h.onError).toHaveBeenCalledExactlyOnceWith('File key is missing');
+  });
+
+  it('surfaces a move failure through every error channel', async () => {
+    const api = fakeApi({
+      moveFile: vi.fn(async () => {
+        throw new Error('AccessDenied');
+      }),
+    });
+    const h = handlers();
+
+    await expect(createRenameService(api).renameFile(file, 'final.md', 'docs', h)).rejects.toThrow(
+      'AccessDenied'
+    );
+
+    expect(h.onProgress).toHaveBeenLastCalledWith({ status: 'error', error: 'AccessDenied' });
+    expect(h.onError).toHaveBeenCalledExactlyOnceWith('AccessDenied');
+    expect(h.onComplete).not.toHaveBeenCalled();
+  });
+
+  it('describes a non-Error rejection', async () => {
+    const api = fakeApi({
+      moveFile: vi.fn(async () => {
+        throw 'just a string';
+      }),
+    });
+    const h = handlers();
+
+    await expect(
+      createRenameService(api).renameFile(file, 'x.md', 'docs', h)
+    ).rejects.toBeDefined();
+
+    expect(h.onError).toHaveBeenCalledExactlyOnceWith('Failed to rename file');
+  });
+
+  it('works without any callbacks', async () => {
+    await expect(
+      createRenameService(fakeApi()).renameFile(file, 'final.md', 'docs')
+    ).resolves.toBeUndefined();
+  });
+
+  it('KNOWN GAP: does not short-circuit when the new name equals the old one', async () => {
+    const api = fakeApi();
+
+    await createRenameService(api).renameFile(file, 'draft.md', 'docs');
+
+    // There is no equality check, so this issues a copy of the object onto
+    // itself followed by a delete of that same key. Real S3 rejects a self-copy
+    // ("this copy request is illegal"), so the delete is never reached and the
+    // user sees a confusing error rather than losing the file - but the safety
+    // here is S3's, not ours, and S3-compatible backends may not all refuse it.
+    //
+    // Pinned, not endorsed. A `if (oldKey === newKey) return;` guard would make
+    // this test fail, which is the prompt to also stop the UI offering a rename
+    // that changes nothing.
+    expect(api.moveFile).toHaveBeenCalledExactlyOnceWith({
+      oldKey: 'docs/draft.md',
+      newKey: 'docs/draft.md',
+    });
+  });
+});
+
+describe('renameFolder', () => {
+  it('renames from the folder prefix to the new one', async () => {
+    const api = fakeApi();
+
+    await createRenameService(api).renameFolder(folder, 'pictures', 'docs/');
+
+    expect(api.renameFolder).toHaveBeenCalledExactlyOnceWith({
+      oldPrefix: 'docs/photos/',
+      newPrefix: 'docs/pictures/',
+    });
+  });
+
+  it('strips a leading slash from the current path', async () => {
+    const api = fakeApi();
+
+    await createRenameService(api).renameFolder(folder, 'pictures', '/docs/');
+
+    // S3 keys never begin with '/'; leaving it on creates an unreachable prefix.
+    expect(api.renameFolder).toHaveBeenCalledWith(
+      expect.objectContaining({ newPrefix: 'docs/pictures/' })
+    );
+  });
+
+  it('renames at the bucket root', async () => {
+    const api = fakeApi();
+    const rootFolder = { name: 'photos', Prefix: 'photos/' } as Folder;
+
+    await createRenameService(api).renameFolder(rootFolder, 'pictures', '');
+
+    expect(api.renameFolder).toHaveBeenCalledWith({
+      oldPrefix: 'photos/',
+      newPrefix: 'pictures/',
+    });
+  });
+
+  it('reports success when the rename completes', async () => {
+    const h = handlers();
+
+    await createRenameService(fakeApi()).renameFolder(folder, 'pictures', 'docs/', h);
+
+    expect(h.onProgress.mock.calls.map(([p]) => p.status)).toEqual(['renaming', 'success']);
+    expect(h.onComplete).toHaveBeenCalledOnce();
+    expect(h.onPartialCleanup).not.toHaveBeenCalled();
+  });
+
+  it('treats a partial cleanup as SUCCESS, not failure', async () => {
+    const api = fakeApi({
+      renameFolder: vi.fn(async () => ({
+        status: 'copied-not-cleaned',
+        totalKeys: 5,
+        copiedKeys: 5,
+        deletedKeys: 3,
+        errors: [{ key: 'docs/photos/a.jpg', code: 'AccessDenied', message: 'Access Denied' }],
+        completed: false,
+      })),
+    });
+    const h = handlers();
+
+    await expect(
+      createRenameService(api).renameFolder(folder, 'pictures', 'docs/', h)
+    ).resolves.toBeUndefined();
+
+    // The data is complete and correct at the new name. Calling this a failed
+    // rename would be actively false.
+    expect(h.onProgress).toHaveBeenLastCalledWith({ status: 'success' });
+    expect(h.onError).not.toHaveBeenCalled();
+    expect(h.onPartialCleanup).toHaveBeenCalledOnce();
+  });
+
+  it('names the leftover files in the partial-cleanup message', async () => {
+    const api = fakeApi({
+      renameFolder: vi.fn(async () => ({
+        status: 'copied-not-cleaned',
+        totalKeys: 5,
+        copiedKeys: 5,
+        deletedKeys: 4,
+        errors: [{ key: 'docs/photos/a.jpg', code: 'AccessDenied', message: 'Access Denied' }],
+        completed: false,
+      })),
+    });
+    const h = handlers();
+
+    await createRenameService(api).renameFolder(folder, 'pictures', 'docs/', h);
+
+    const message = h.onPartialCleanup.mock.calls[0]![0] as string;
+    expect(message).toContain('pictures');
+    expect(message).toContain('5');
+    expect(message).toContain('docs/photos/a.jpg');
+  });
+
+  it('throws when the copy phase failed', async () => {
+    const api = fakeApi({
+      renameFolder: vi.fn(async () => ({
+        status: 'failed',
+        totalKeys: 5,
+        copiedKeys: 2,
+        deletedKeys: 0,
+        errors: [{ key: 'docs/photos/b.jpg', code: 'AccessDenied', message: 'Access Denied' }],
+        completed: false,
+      })),
+    });
+    const h = handlers();
+
+    await expect(
+      createRenameService(api).renameFolder(folder, 'pictures', 'docs/', h)
+    ).rejects.toThrow(/nothing was changed/);
+
+    expect(h.onError).toHaveBeenCalledOnce();
+    expect(h.onComplete).not.toHaveBeenCalled();
+  });
+
+  it('tells the user retrying is safe and mentions the orphaned copies', async () => {
+    const api = fakeApi({
+      renameFolder: vi.fn(async () => ({
+        status: 'failed',
+        totalKeys: 5,
+        copiedKeys: 2,
+        deletedKeys: 0,
+        errors: [{ key: 'docs/photos/b.jpg', message: 'Access Denied' }],
+        completed: false,
+      })),
+    });
+    const h = handlers();
+
+    await expect(
+      createRenameService(api).renameFolder(folder, 'pictures', 'docs/', h)
+    ).rejects.toThrow();
+
+    const message = h.onError.mock.calls[0]![0] as string;
+    // The source is untouched, so the honest advice is "try again".
+    expect(message).toMatch(/original folder is intact/);
+    expect(message).toContain('2 partial copy');
+  });
+
+  it('still explains the leftovers when the delete failed without an error code', async () => {
+    const api = fakeApi({
+      renameFolder: vi.fn(async () => ({
+        status: 'copied-not-cleaned',
+        totalKeys: 3,
+        copiedKeys: 3,
+        deletedKeys: 2,
+        // A dropped connection surfaces with no S3 error code at all.
+        errors: [{ key: 'docs/photos/c.jpg', message: 'socket hang up' }],
+        completed: false,
+      })),
+    });
+    const h = handlers();
+
+    await createRenameService(api).renameFolder(folder, 'pictures', 'docs/', h);
+
+    const message = h.onPartialCleanup.mock.calls[0]![0] as string;
+    // The wording must not depend on the failure being a permissions error -
+    // the user needs to know their files copied and the old ones remain.
+    expect(message).toMatch(/safely at the\s+new location/);
+    expect(message).toMatch(/could not be removed/);
+    expect(message).toContain('socket hang up');
+    expect(h.onError).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a thrown api failure', async () => {
+    const api = fakeApi({
+      renameFolder: vi.fn(async () => {
+        throw new Error('overlapping prefixes');
+      }),
+    });
+    const h = handlers();
+
+    await expect(
+      createRenameService(api).renameFolder(folder, 'pictures', 'docs/', h)
+    ).rejects.toThrow('overlapping prefixes');
+
+    expect(h.onError).toHaveBeenCalledExactlyOnceWith('overlapping prefixes');
+  });
+
+  describe('legacy s3-api result shape', () => {
+    it('reads a fully processed legacy result as success', async () => {
+      const api = fakeApi({
+        renameFolder: vi.fn(async () => ({ total: 4, processed: 4 })),
+      });
+      const h = handlers();
+
+      await createRenameService(api).renameFolder(folder, 'pictures', 'docs/', h);
+
+      expect(h.onComplete).toHaveBeenCalledOnce();
+    });
+
+    it('reads a partially processed legacy result as failure', async () => {
+      const api = fakeApi({
+        renameFolder: vi.fn(async () => ({ total: 4, processed: 2 })),
+      });
+
+      await expect(
+        createRenameService(api).renameFolder(folder, 'pictures', 'docs/')
+      ).rejects.toThrow();
+    });
+
+    it('warns once about the outdated package, not per rename', async () => {
+      const api = fakeApi({
+        renameFolder: vi.fn(async () => ({ total: 1, processed: 1 })),
+      });
+      const service = createRenameService(api);
+
+      await service.renameFolder(folder, 'a', 'docs/');
+      await service.renameFolder(folder, 'b', 'docs/');
+
+      // Warning per rename would drown the console during bulk operations.
+      const warnings = vi
+        .mocked(console.warn)
+        .mock.calls.filter(([m]) => String(m).includes('predates 2.7.0'));
+      expect(warnings.length).toBeLessThanOrEqual(1);
+    });
+  });
+});
+
+describe('unique name generation', () => {
+  it('appends a counter before the extension', () => {
+    const service = createRenameService(fakeApi());
+
+    expect(service.generateUniqueFileName('report.pdf', 1)).toBe('report (1).pdf');
+    expect(service.generateUniqueFileName('report.pdf', 7)).toBe('report (7).pdf');
+  });
+
+  it('does not stack counters on an already numbered name', () => {
+    const service = createRenameService(fakeApi());
+
+    // Without this, retrying produces "report (1) (2).pdf".
+    expect(service.generateUniqueFileName('report (1).pdf', 2)).toBe('report (2).pdf');
+  });
+
+  it('handles a name with no extension', () => {
+    const service = createRenameService(fakeApi());
+
+    expect(service.generateUniqueFileName('README', 1)).toBe('README (1)');
+  });
+
+  it('treats a leading dot as part of the name, not an extension', () => {
+    const service = createRenameService(fakeApi());
+
+    expect(service.generateUniqueFileName('.gitignore', 1)).toBe('.gitignore (1)');
+  });
+
+  it('appends a counter to a folder name', () => {
+    const service = createRenameService(fakeApi());
+
+    expect(service.generateUniqueFolderName('photos', 1)).toBe('photos (1)');
+  });
+});
+
+describe('existence checks', () => {
+  it('reports a file as existing when metadata comes back', async () => {
+    const api = fakeApi({ fetchMetadata: vi.fn(async () => ({ ContentLength: 10 })) });
+
+    await expect(createRenameService(api).checkFileExists('a.md', 'docs')).resolves.toBe(true);
+  });
+
+  it('reports a file as missing when metadata is null', async () => {
+    const api = fakeApi({ fetchMetadata: vi.fn(async () => null) });
+
+    await expect(createRenameService(api).checkFileExists('a.md', 'docs')).resolves.toBe(false);
+  });
+
+  it('reports a folder as existing when the prefix holds anything', async () => {
+    const api = fakeApi({
+      fetchDirectoryStructure: vi.fn(async () => ({
+        files: [{ Key: 'docs/photos/a' }],
+        folders: [],
+      })),
+    });
+
+    await expect(createRenameService(api).checkFolderExists('photos', 'docs')).resolves.toBe(true);
+  });
+
+  it('reports an empty prefix as no folder', async () => {
+    const api = fakeApi();
+
+    await expect(createRenameService(api).checkFolderExists('photos', 'docs')).resolves.toBe(false);
+  });
+});
+
+describe('findUniqueFileName', () => {
+  it('starts numbering at (1) rather than offering the bare name', async () => {
+    const api = fakeApi({ fetchMetadata: vi.fn(async () => null) });
+
+    // This is the "Keep both" path, so the caller already knows the original is
+    // taken. Returning it unchanged would overwrite the file the user chose to
+    // keep.
+    await expect(createRenameService(api).findUniqueFileName('report.pdf', 'docs')).resolves.toBe(
+      'report (1).pdf'
+    );
+  });
+
+  it('walks the counter past every taken name', async () => {
+    const taken = new Set(['docs/report (1).pdf', 'docs/report (2).pdf']);
+    const api = fakeApi({
+      fetchMetadata: vi.fn(async (key: string) => (taken.has(key) ? { ContentLength: 1 } : null)),
+    });
+
+    await expect(createRenameService(api).findUniqueFileName('report.pdf', 'docs')).resolves.toBe(
+      'report (3).pdf'
+    );
+  });
+
+  it('falls back to a timestamp once 100 numbers are taken', async () => {
+    const api = fakeApi({ fetchMetadata: vi.fn(async () => ({ ContentLength: 1 })) });
+
+    const name = await createRenameService(api).findUniqueFileName('report.pdf', 'docs');
+
+    // Better a long name than an unbounded loop or an overwrite.
+    expect(name).toMatch(/^report \(\d{13}\)\.pdf$/);
+  });
+
+  it('numbers folders from (1) too', async () => {
+    const api = fakeApi();
+
+    await expect(createRenameService(api).findUniqueFolderName('photos', 'docs')).resolves.toBe(
+      'photos (1)'
+    );
+  });
+
+  it('falls back to a timestamp for folders as well', async () => {
+    const api = fakeApi({
+      fetchDirectoryStructure: vi.fn(async () => ({ files: [{ Key: 'x' }], folders: [] })),
+    });
+
+    const name = await createRenameService(api).findUniqueFolderName('photos', 'docs');
+
+    expect(name).toMatch(/^photos \(\d{13}\)$/);
+  });
+});

--- a/frontend/src/features/dashboard/services/rename-service.ts
+++ b/frontend/src/features/dashboard/services/rename-service.ts
@@ -158,6 +158,17 @@ class RenameService {
       pathParts[pathParts.length - 1] = newName; // Replace the last part (filename) with new name
       const newKey = pathParts.join('/');
 
+      // Renaming a file to the name it already has is a no-op, and must not
+      // reach S3. moveFile copies the object onto itself and then DELETES that
+      // same key - real S3 refuses the self-copy so the delete is never
+      // reached, but that safety belongs to the backend, not to us. On an
+      // S3-compatible service that permits the copy, this deletes the file.
+      if (oldKey === newKey) {
+        onProgress?.({ status: 'success' });
+        onComplete?.();
+        return;
+      }
+
       // Use moveFile method which handles the copy/delete operations
       await this.api.moveFile({
         oldKey,

--- a/frontend/src/features/dashboard/services/search-service.test.ts
+++ b/frontend/src/features/dashboard/services/search-service.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Search service: a breadth-first walk over prefixes, stopping early and
+ * handing back a resume token.
+ *
+ * The provider is injected, so it is faked rather than mocked through the
+ * module registry. s3-api's `search` already returns files and folders
+ * segregated and filtered; what this layer adds is the traversal, the 50-result
+ * batch limit, deduplication, and the opaque continuation token.
+ *
+ * `isTruncated` reads backwards here and is easy to misremember: the service
+ * paginates while it is `true` and stops when it is `false`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BYOS3ApiProvider, SearchResult } from '@opndrive/s3-api';
+import { createSearchService } from './search-service';
+
+type Page = Partial<SearchResult>;
+
+/** Builds a provider whose `search` returns the given pages in order. */
+function apiReturning(...pages: Page[]) {
+  const search = vi.fn(async () => {
+    const page = pages.shift() ?? {};
+    return {
+      files: [],
+      folders: [],
+      totalFiles: 0,
+      totalFolders: 0,
+      totalKeys: 0,
+      isTruncated: false,
+      ...page,
+    } as SearchResult;
+  });
+  return { search } as unknown as BYOS3ApiProvider & { search: typeof search };
+}
+
+const file = (Key: string) => ({ Key });
+const folderKey = (Key: string) => ({ Key });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('searching', () => {
+  it('asks the provider for the query at the given prefix', async () => {
+    const api = apiReturning({ files: [file('docs/a.txt')] });
+
+    await createSearchService(api).search('report', 'docs/');
+
+    expect(api.search).toHaveBeenCalledWith({
+      prefix: 'docs/',
+      searchTerm: 'report',
+      nextToken: undefined,
+    });
+  });
+
+  it('normalises a root prefix of "/" to empty', async () => {
+    const api = apiReturning({});
+
+    await createSearchService(api).search('report', '/');
+
+    expect(api.search).toHaveBeenCalledWith(expect.objectContaining({ prefix: '' }));
+  });
+
+  it('defaults to the bucket root', async () => {
+    const api = apiReturning({});
+
+    await createSearchService(api).search('report');
+
+    expect(api.search).toHaveBeenCalledWith(expect.objectContaining({ prefix: '' }));
+  });
+
+  it('returns the matched files and folders', async () => {
+    const api = apiReturning({
+      files: [file('docs/a.txt'), file('docs/b.txt')],
+      folders: [folderKey('docs/reports/')],
+    });
+
+    const result = await createSearchService(api).search('report', 'docs/');
+
+    expect(result.files.map((f) => f.Key)).toEqual(['docs/a.txt', 'docs/b.txt']);
+    expect(result.folders.map((f) => f.Key)).toEqual(['docs/reports/']);
+    expect(result).toMatchObject({ totalFiles: 2, totalFolders: 1, totalKeys: 3 });
+  });
+
+  it('reports an empty search cleanly', async () => {
+    const result = await createSearchService(apiReturning({})).search('nothing', 'docs/');
+
+    expect(result).toMatchObject({
+      files: [],
+      folders: [],
+      totalFiles: 0,
+      totalKeys: 0,
+      nextToken: undefined,
+      isTruncated: false,
+    });
+  });
+});
+
+describe('recursive traversal', () => {
+  it('queues matched folders and searches inside them', async () => {
+    // isTruncated must be left undefined here: `false` breaks the whole walk
+    // (see the test below), and `true` + a token keeps paginating this prefix
+    // instead of moving on to the queued folder.
+    const api = apiReturning(
+      { folders: [folderKey('docs/reports/')], totalKeys: 1, isTruncated: undefined },
+      { files: [file('docs/reports/q4.pdf')], totalKeys: 1 }
+    );
+
+    const result = await createSearchService(api).search('q4', 'docs/');
+
+    // A match nested one level down is only found if the folder is followed.
+    expect(api.search).toHaveBeenCalledTimes(2);
+    expect(api.search).toHaveBeenLastCalledWith(
+      expect.objectContaining({ prefix: 'docs/reports/' })
+    );
+    expect(result.files.map((f) => f.Key)).toEqual(['docs/reports/q4.pdf']);
+  });
+
+  it('paginates a prefix while the page says there is more', async () => {
+    const api = apiReturning(
+      { files: [file('a.txt')], nextToken: 'page-2', isTruncated: true, totalKeys: 1 },
+      { files: [file('b.txt')], isTruncated: false, totalKeys: 1 }
+    );
+
+    const result = await createSearchService(api).search('x', 'docs/');
+
+    expect(api.search).toHaveBeenLastCalledWith(expect.objectContaining({ nextToken: 'page-2' }));
+    expect(result.files.map((f) => f.Key)).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('KNOWN BUG: a complete first page abandons folders already queued for search', async () => {
+    const api = apiReturning(
+      { files: [file('a.txt')], folders: [folderKey('sub/')], isTruncated: false, totalKeys: 2 },
+      { files: [file('sub/b.txt')] }
+    );
+
+    const result = await createSearchService(api).search('x', 'docs/');
+
+    // `isTruncated: false` from s3-api means "this prefix's listing is
+    // complete" - it says nothing about the folders this walk has queued. The
+    // service treats it as "stop everything" and `break`s out of the loop, so
+    // sub/ is never searched and sub/b.txt is silently missing from a search
+    // that reports itself finished and not truncated.
+    //
+    // Pinned, not endorsed. Replacing the `break` with `current = undefined`
+    // (move on to the next queued prefix) would make this fail, which is the
+    // prompt to confirm the intended traversal semantics.
+    expect(api.search).toHaveBeenCalledOnce();
+    expect(result.files.map((f) => f.Key)).toEqual(['a.txt']);
+    expect(result.isTruncated).toBe(false);
+  });
+
+  it('removes duplicate keys from the results', async () => {
+    const api = apiReturning({
+      files: [file('a.txt'), file('a.txt'), file('b.txt')],
+      totalKeys: 3,
+    });
+
+    const result = await createSearchService(api).search('x', 'docs/');
+
+    // The same object can surface under two prefixes during a walk.
+    expect(result.files.map((f) => f.Key)).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('drops entries with no key when deduplicating', async () => {
+    const api = apiReturning({ files: [file('a.txt'), { Key: undefined }], totalKeys: 2 });
+
+    const result = await createSearchService(api).search('x', 'docs/');
+
+    expect(result.files.map((f) => f.Key)).toEqual(['a.txt']);
+  });
+
+  it('KNOWN BUG: totalFiles counts duplicates that were removed from files', async () => {
+    const api = apiReturning({ files: [file('a.txt'), file('a.txt')], totalKeys: 2 });
+
+    const result = await createSearchService(api).search('x', 'docs/');
+
+    // `files` is deduplicated but `totalFiles` is taken from the raw array, so
+    // the UI reports a count higher than the number of rows it can show.
+    //
+    // Pinned, not endorsed: counting after the dedupe would make this fail.
+    expect(result.files).toHaveLength(1);
+    expect(result.totalFiles).toBe(2);
+  });
+});
+
+describe('batch limit and resuming', () => {
+  const fiftyFiles = Array.from({ length: 50 }, (_, i) => file(`f${i}.txt`));
+
+  it('stops once 50 results are collected and offers a resume token', async () => {
+    const api = apiReturning({ files: fiftyFiles, totalKeys: 50, nextToken: 'more' });
+
+    const result = await createSearchService(api).search('x', 'docs/');
+
+    expect(result.files).toHaveLength(50);
+    expect(result.isTruncated).toBe(true);
+    expect(result.nextToken).toBeTruthy();
+  });
+
+  it('resumes from where it stopped', async () => {
+    const first = apiReturning({ files: fiftyFiles, totalKeys: 50, nextToken: 'page-2' });
+    const initial = await createSearchService(first).search('x', 'docs/');
+
+    const second = apiReturning({ files: [file('later.txt')], totalKeys: 1 });
+    const resumed = await createSearchService(second).search('x', 'docs/', initial.nextToken);
+
+    // The token has to carry the page cursor, or "Load more" restarts the walk.
+    expect(second.search).toHaveBeenCalledWith(
+      expect.objectContaining({ prefix: 'docs/', nextToken: 'page-2' })
+    );
+    expect(resumed.files.map((f) => f.Key)).toEqual(['later.txt']);
+  });
+
+  it('KNOWN BUG: a corrupt resume token returns nothing instead of restarting', async () => {
+    const api = apiReturning({ files: [file('a.txt')], totalKeys: 1 });
+
+    const result = await createSearchService(api).search('x', 'docs/', 'not-a-real-token');
+
+    // decodeResumeToken swallows the failure and returns `{ queue: [] }`. An
+    // empty array is not nullish, so it wins over the `?? [rootPrefix]`
+    // fallback and the walk has nowhere to start - the provider is never even
+    // called and "Load more" silently reports no results rather than an error.
+    //
+    // Pinned, not endorsed: returning `{ queue: [rootPrefix] }` from the catch
+    // would make this fail, which is the prompt to decide whether a bad token
+    // should restart or surface.
+    expect(api.search).not.toHaveBeenCalled();
+    expect(result.files).toEqual([]);
+    expect(result.isTruncated).toBe(false);
+  });
+
+  it('reports no more results once the walk finishes', async () => {
+    const api = apiReturning({ files: [file('a.txt')], totalKeys: 1 });
+
+    const result = await createSearchService(api).search('x', 'docs/');
+
+    expect(result.nextToken).toBeUndefined();
+    expect(result.isTruncated).toBe(false);
+  });
+});
+
+describe('progress callbacks', () => {
+  it('reports searching then success', async () => {
+    const onProgress = vi.fn();
+    const onComplete = vi.fn();
+
+    await createSearchService(apiReturning({})).search('x', 'docs/', undefined, {
+      onProgress,
+      onComplete,
+    });
+
+    expect(onProgress.mock.calls.map(([p]) => p.status)).toEqual(['searching', 'success']);
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it('streams partial results as pages arrive', async () => {
+    const onResultsUpdate = vi.fn();
+    const api = apiReturning(
+      { files: [file('a.txt')], nextToken: 'p2', isTruncated: true, totalKeys: 1 },
+      { files: [file('b.txt')], isTruncated: false, totalKeys: 1 }
+    );
+
+    await createSearchService(api).search('x', 'docs/', undefined, { onResultsUpdate });
+
+    // The UI fills in as the walk proceeds instead of waiting for the end.
+    expect(onResultsUpdate).toHaveBeenCalledTimes(2);
+    expect(onResultsUpdate.mock.calls[0]![0].files.map((f: { Key: string }) => f.Key)).toEqual([
+      'a.txt',
+    ]);
+    expect(onResultsUpdate.mock.calls[1]![0].files.map((f: { Key: string }) => f.Key)).toEqual([
+      'a.txt',
+      'b.txt',
+    ]);
+  });
+
+  it('does not stream a page that matched nothing', async () => {
+    const onResultsUpdate = vi.fn();
+
+    await createSearchService(apiReturning({ totalKeys: 10 })).search('x', 'docs/', undefined, {
+      onResultsUpdate,
+    });
+
+    expect(onResultsUpdate).not.toHaveBeenCalled();
+  });
+
+  it('never exposes a resume token in a partial update', async () => {
+    const onResultsUpdate = vi.fn();
+    const api = apiReturning({ files: [file('a.txt')], totalKeys: 1, nextToken: 'p2' });
+
+    await createSearchService(api).search('x', 'docs/', undefined, { onResultsUpdate });
+
+    // Only the settled result carries a token the caller may resume from.
+    expect(onResultsUpdate.mock.calls[0]![0].nextToken).toBeUndefined();
+  });
+
+  it('reports how many requests the walk has made', async () => {
+    const onRequestCountUpdate = vi.fn();
+    const api = apiReturning(
+      { folders: [folderKey('sub/')], totalKeys: 1, isTruncated: undefined },
+      { files: [file('sub/a.txt')], totalKeys: 1 }
+    );
+
+    await createSearchService(api).search('x', 'docs/', undefined, { onRequestCountUpdate });
+
+    // Drives the "searched N folders" indicator.
+    expect(onRequestCountUpdate.mock.calls.map(([n]) => n)).toEqual([1, 2]);
+  });
+});
+
+describe('cancellation', () => {
+  it('refuses to start when the signal is already aborted', async () => {
+    const api = apiReturning({});
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      createSearchService(api).search('x', 'docs/', undefined, { signal: controller.signal })
+    ).rejects.toThrow('Search cancelled');
+
+    expect(api.search).not.toHaveBeenCalled();
+  });
+
+  it('stops between pages once aborted', async () => {
+    const controller = new AbortController();
+    const api = apiReturning(
+      { files: [file('a.txt')], nextToken: 'p2', isTruncated: true, totalKeys: 1 },
+      { files: [file('b.txt')], totalKeys: 1 }
+    );
+    vi.mocked(api.search).mockImplementationOnce(async () => {
+      controller.abort();
+      return {
+        files: [file('a.txt')],
+        folders: [],
+        totalFiles: 1,
+        totalFolders: 0,
+        totalKeys: 1,
+        nextToken: 'p2',
+        isTruncated: true,
+      } as SearchResult;
+    });
+
+    await expect(
+      createSearchService(api).search('x', 'docs/', undefined, { signal: controller.signal })
+    ).rejects.toThrow('Search cancelled');
+
+    expect(api.search).toHaveBeenCalledOnce();
+  });
+
+  it('does not route a cancellation through the error callbacks', async () => {
+    const onError = vi.fn();
+    const onProgress = vi.fn();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      createSearchService(apiReturning({})).search('x', 'docs/', undefined, {
+        signal: controller.signal,
+        onError,
+        onProgress,
+      })
+    ).rejects.toThrow('Search cancelled');
+
+    // The user cancelled on purpose; showing them an error toast would be wrong.
+    expect(onError).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'error' }));
+  });
+});
+
+describe('failures', () => {
+  it('surfaces a provider error through every channel', async () => {
+    const api = { search: vi.fn(async () => Promise.reject(new Error('AccessDenied'))) };
+    const onProgress = vi.fn();
+    const onError = vi.fn();
+
+    await expect(
+      createSearchService(api as unknown as BYOS3ApiProvider).search('x', 'docs/', undefined, {
+        onProgress,
+        onError,
+      })
+    ).rejects.toThrow('AccessDenied');
+
+    expect(onProgress).toHaveBeenLastCalledWith({ status: 'error', error: 'AccessDenied' });
+    expect(onError).toHaveBeenCalledExactlyOnceWith('AccessDenied');
+  });
+
+  it('describes a non-Error rejection', async () => {
+    const api = { search: vi.fn(async () => Promise.reject('just a string')) };
+    const onError = vi.fn();
+
+    await expect(
+      createSearchService(api as unknown as BYOS3ApiProvider).search('x', 'docs/', undefined, {
+        onError,
+      })
+    ).rejects.toBeDefined();
+
+    expect(onError).toHaveBeenCalledExactlyOnceWith('Failed to search files');
+  });
+
+  it('works with no options at all', async () => {
+    await expect(createSearchService(apiReturning({})).search('x', 'docs/')).resolves.toBeDefined();
+  });
+});

--- a/frontend/src/features/dashboard/stores/use-download-store.test.ts
+++ b/frontend/src/features/dashboard/stores/use-download-store.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Download store: the shared map of in-flight downloads.
+ *
+ * The download *service* is mocked at the module boundary. It already has its
+ * own suite covering streaming, progress and cancellation; what matters here is
+ * that the store wires callbacks to state correctly, reuses one service per
+ * provider, and clears finished rows on the right schedule.
+ *
+ * Store state is reset between tests by `__mocks__/zustand.ts` - see
+ * src/tests/setup.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { BYOS3ApiProvider } from '@opndrive/s3-api';
+import { useDownloadStore } from './use-download-store';
+import { createDownloadService, type DownloadProgress } from '../services/download-service';
+import type { FileItem } from '../types/file';
+
+vi.mock('../services/download-service', () => ({
+  createDownloadService: vi.fn(),
+}));
+
+const createDownloadServiceMock = vi.mocked(createDownloadService);
+
+/** The callback bag the store hands to the service. */
+interface DownloadHandlers {
+  onProgress: (progress: DownloadProgress) => void;
+  onComplete: (fileId: string) => void;
+  onError?: (fileId: string, error: string) => void;
+}
+
+/**
+ * A stand-in service whose callbacks the test drives by hand. Typed with the
+ * real signature so mockImplementation stays type-checked rather than needing
+ * casts at every call site.
+ */
+function fakeService() {
+  return {
+    downloadFile: vi.fn(async (_file: FileItem, _handlers: DownloadHandlers) => {}),
+    cancelDownload: vi.fn((_fileId: string) => {}),
+  };
+}
+
+/** Two distinct provider identities; the store keys its service cache on these. */
+const apiA = { id: 'a' } as unknown as BYOS3ApiProvider;
+const apiB = { id: 'b' } as unknown as BYOS3ApiProvider;
+
+const file = { id: 'file-1', name: 'report.pdf' } as FileItem;
+
+function progress(overrides: Partial<DownloadProgress> = {}): DownloadProgress {
+  return {
+    fileId: 'file-1',
+    fileName: 'report.pdf',
+    progress: 0,
+    status: 'downloading',
+    ...overrides,
+  };
+}
+
+const store = () => useDownloadStore.getState();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createDownloadServiceMock.mockImplementation(() => fakeService() as never);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('getService', () => {
+  it('builds a service on first use', () => {
+    const service = store().getService(apiA);
+
+    expect(createDownloadServiceMock).toHaveBeenCalledExactlyOnceWith(apiA);
+    expect(store().service).toBe(service);
+    expect(store().serviceApi).toBe(apiA);
+  });
+
+  it('reuses the same service for the same provider', () => {
+    const first = store().getService(apiA);
+    const second = store().getService(apiA);
+
+    // Downloads keep their AbortControllers inside the service, so rebuilding
+    // it would leave cancel() addressing an instance that owns nothing.
+    expect(second).toBe(first);
+    expect(createDownloadServiceMock).toHaveBeenCalledOnce();
+  });
+
+  it('rebuilds when the provider changes', () => {
+    const first = store().getService(apiA);
+    const second = store().getService(apiB);
+
+    // A new provider means new credentials (login/logout, bucket switch).
+    expect(second).not.toBe(first);
+    expect(createDownloadServiceMock).toHaveBeenCalledTimes(2);
+    expect(store().serviceApi).toBe(apiB);
+  });
+});
+
+describe('setProgress', () => {
+  it('records a download by its file id', () => {
+    store().setProgress(progress({ progress: 42 }));
+
+    expect(store().downloads.get('file-1')).toEqual(progress({ progress: 42 }));
+  });
+
+  it('overwrites the previous entry for the same file', () => {
+    store().setProgress(progress({ progress: 10 }));
+    store().setProgress(progress({ progress: 90 }));
+
+    expect(store().downloads.size).toBe(1);
+    expect(store().downloads.get('file-1')!.progress).toBe(90);
+  });
+
+  it('replaces the map rather than mutating it', () => {
+    const before = store().downloads;
+    store().setProgress(progress());
+
+    // Mutating in place would leave subscribed components rendering stale rows,
+    // because the reference they compare against never changes.
+    expect(store().downloads).not.toBe(before);
+  });
+
+  it('keeps unrelated downloads', () => {
+    store().setProgress(progress({ fileId: 'a' }));
+    store().setProgress(progress({ fileId: 'b' }));
+
+    expect([...store().downloads.keys()]).toEqual(['a', 'b']);
+  });
+});
+
+describe('removeDownload', () => {
+  it('drops the download', () => {
+    store().setProgress(progress());
+    store().removeDownload('file-1');
+
+    expect(store().downloads.has('file-1')).toBe(false);
+  });
+
+  it('leaves the state object untouched for an unknown id', () => {
+    store().setProgress(progress());
+    const before = store().downloads;
+
+    store().removeDownload('never-existed');
+
+    // Returning a fresh map here would re-render every subscriber for nothing.
+    expect(store().downloads).toBe(before);
+  });
+});
+
+describe('startDownload', () => {
+  it('hands the file to the service', async () => {
+    const service = fakeService();
+    createDownloadServiceMock.mockReturnValue(service as never);
+
+    await store().startDownload(apiA, file);
+
+    expect(service.downloadFile).toHaveBeenCalledOnce();
+    expect(service.downloadFile.mock.calls[0]![0]).toBe(file);
+  });
+
+  it('writes service progress into the store', async () => {
+    const service = fakeService();
+    service.downloadFile.mockImplementation(async (_f, opts) => {
+      opts.onProgress(progress({ progress: 25 }));
+    });
+    createDownloadServiceMock.mockReturnValue(service as never);
+
+    await store().startDownload(apiA, file);
+
+    expect(store().downloads.get('file-1')!.progress).toBe(25);
+  });
+
+  it('clears a completed download after the linger delay', async () => {
+    vi.useFakeTimers();
+    const service = fakeService();
+    service.downloadFile.mockImplementation(async (_f, opts) => {
+      opts.onComplete('file-1');
+    });
+    createDownloadServiceMock.mockReturnValue(service as never);
+
+    store().setProgress(progress({ status: 'completed', progress: 100 }));
+    await store().startDownload(apiA, file);
+
+    // The row stays briefly so the user sees it finish.
+    expect(store().downloads.has('file-1')).toBe(true);
+    vi.advanceTimersByTime(3000);
+    expect(store().downloads.has('file-1')).toBe(false);
+  });
+
+  it('clears a cancelled download sooner than a completed one', async () => {
+    vi.useFakeTimers();
+    const service = fakeService();
+    service.downloadFile.mockImplementation(async (_f, opts) => {
+      opts.onProgress(progress({ status: 'cancelled' }));
+    });
+    createDownloadServiceMock.mockReturnValue(service as never);
+
+    await store().startDownload(apiA, file);
+
+    expect(store().downloads.has('file-1')).toBe(true);
+    vi.advanceTimersByTime(2000);
+    expect(store().downloads.has('file-1')).toBe(false);
+  });
+
+  it('does not schedule removal for ordinary progress updates', async () => {
+    vi.useFakeTimers();
+    const service = fakeService();
+    service.downloadFile.mockImplementation(async (_f, opts) => {
+      opts.onProgress(progress({ status: 'downloading', progress: 50 }));
+    });
+    createDownloadServiceMock.mockReturnValue(service as never);
+
+    await store().startDownload(apiA, file);
+    vi.advanceTimersByTime(10_000);
+
+    // An in-flight download must never disappear from the list on a timer.
+    expect(store().downloads.has('file-1')).toBe(true);
+  });
+
+  it('forwards the caller error handler to the service', async () => {
+    const onError = vi.fn();
+    const service = fakeService();
+    service.downloadFile.mockImplementation(async (_f, opts) => {
+      opts.onError?.('file-1', 'boom');
+    });
+    createDownloadServiceMock.mockReturnValue(service as never);
+
+    await store().startDownload(apiA, file, { onError });
+
+    expect(onError).toHaveBeenCalledExactlyOnceWith('file-1', 'boom');
+  });
+
+  it('works without any handlers', async () => {
+    const service = fakeService();
+    service.downloadFile.mockImplementation(async (_f, opts) => {
+      opts.onError?.('file-1', 'boom');
+    });
+    createDownloadServiceMock.mockReturnValue(service as never);
+
+    await expect(store().startDownload(apiA, file)).resolves.toBeUndefined();
+  });
+
+  it('propagates a failure from the service', async () => {
+    const service = fakeService();
+    service.downloadFile.mockRejectedValue(new Error('signing failed'));
+    createDownloadServiceMock.mockReturnValue(service as never);
+
+    await expect(store().startDownload(apiA, file)).rejects.toThrow('signing failed');
+  });
+});
+
+describe('cancelDownload', () => {
+  it('asks the service to cancel', async () => {
+    const service = fakeService();
+    createDownloadServiceMock.mockReturnValue(service as never);
+    await store().startDownload(apiA, file);
+
+    store().cancelDownload('file-1');
+
+    expect(service.cancelDownload).toHaveBeenCalledExactlyOnceWith('file-1');
+  });
+
+  it('is a no-op before any download has started', () => {
+    // No service exists yet, so this must not throw on a stray cancel click.
+    expect(() => store().cancelDownload('file-1')).not.toThrow();
+  });
+
+  it('does not remove the row itself', async () => {
+    const service = fakeService();
+    createDownloadServiceMock.mockReturnValue(service as never);
+    await store().startDownload(apiA, file);
+    store().setProgress(progress());
+
+    store().cancelDownload('file-1');
+
+    // The service emits the 'cancelled' update, which is what schedules removal.
+    // Removing here too would drop the row before the user sees it was cancelled.
+    expect(store().downloads.has('file-1')).toBe(true);
+  });
+});
+
+describe('derived state', () => {
+  it('lists every download', () => {
+    store().setProgress(progress({ fileId: 'a' }));
+    store().setProgress(progress({ fileId: 'b' }));
+
+    expect(
+      store()
+        .getAllDownloads()
+        .map((d) => d.fileId)
+    ).toEqual(['a', 'b']);
+  });
+
+  it('lists nothing when idle', () => {
+    expect(store().getAllDownloads()).toEqual([]);
+  });
+
+  it.each(['downloading', 'pending', 'queued'] as const)('reports %s as in progress', (status) => {
+    store().setProgress(progress({ status }));
+
+    expect(store().isDownloading('file-1')).toBe(true);
+  });
+
+  it.each(['completed', 'error', 'cancelled'] as const)('reports %s as finished', (status) => {
+    store().setProgress(progress({ status }));
+
+    expect(store().isDownloading('file-1')).toBe(false);
+  });
+
+  it('reports an unknown file as not downloading', () => {
+    expect(store().isDownloading('never-seen')).toBe(false);
+  });
+});

--- a/frontend/src/features/dashboard/stores/use-multi-select-store.test.ts
+++ b/frontend/src/features/dashboard/stores/use-multi-select-store.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Multi-select store: the click/ctrl/shift selection state machine.
+ *
+ * Almost all the behaviour lives in one `selectItem` call whose meaning changes
+ * with the modifier keys, so the cases below are grouped by modifier rather
+ * than by action name.
+ *
+ * Identity is by S3 key: files carry `Key`, folders carry `Prefix`. Two
+ * different objects describing the same key are the same selection.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { useMultiSelectStore } from './use-multi-select-store';
+import type { FileItem } from '../types/file';
+import type { Folder } from '../types/folder';
+
+const store = () => useMultiSelectStore.getState();
+
+const file = (key: string) => ({ Key: key, name: key }) as FileItem;
+const folder = (prefix: string) => ({ Prefix: prefix, name: prefix }) as Folder;
+
+/** Five files, so range selections have room to move in both directions. */
+const files = [file('a.txt'), file('b.txt'), file('c.txt'), file('d.txt'), file('e.txt')];
+
+/** Mirrors the store's own getItemKey: files carry Key, folders carry Prefix. */
+const keysOf = () =>
+  store().selectedItems.map((item) => {
+    const record = item as unknown as { Key?: string; Prefix?: string };
+    return record.Key ?? record.Prefix ?? '';
+  });
+
+describe('plain click', () => {
+  it('selects exactly one item', () => {
+    store().selectItem(files[1]!, 'file', 1, false, false, files);
+
+    expect(keysOf()).toEqual(['b.txt']);
+    expect(store().selectedType).toBe('file');
+    expect(store().lastSelectedIndex).toBe(1);
+  });
+
+  it('replaces an existing selection', () => {
+    store().selectItem(files[0]!, 'file', 0, true, false, files);
+    store().selectItem(files[1]!, 'file', 1, true, false, files);
+
+    store().selectItem(files[3]!, 'file', 3, false, false, files);
+
+    expect(keysOf()).toEqual(['d.txt']);
+  });
+});
+
+describe('ctrl+click', () => {
+  it('adds to the selection', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[2]!, 'file', 2, true, false, files);
+
+    expect(keysOf()).toEqual(['a.txt', 'c.txt']);
+  });
+
+  it('removes an item that is already selected', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[1]!, 'file', 1, true, false, files);
+
+    store().selectItem(files[0]!, 'file', 0, true, false, files);
+
+    expect(keysOf()).toEqual(['b.txt']);
+  });
+
+  it('matches by key, not by object identity', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+
+    // A re-render hands the UI a fresh object for the same S3 key.
+    store().selectItem(file('a.txt'), 'file', 0, true, false, files);
+
+    expect(keysOf()).toEqual([]);
+  });
+
+  it('drops the type once the last item is deselected', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+
+    store().selectItem(files[0]!, 'file', 0, true, false, files);
+
+    // A lingering type would keep blocking folder selection.
+    expect(store().selectedItems).toEqual([]);
+    expect(store().selectedType).toBeNull();
+  });
+
+  it('keeps the type while anything is still selected', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[1]!, 'file', 1, true, false, files);
+
+    store().selectItem(files[0]!, 'file', 0, true, false, files);
+
+    expect(store().selectedType).toBe('file');
+  });
+
+  it('starts a selection from nothing', () => {
+    store().selectItem(files[2]!, 'file', 2, true, false, files);
+
+    expect(keysOf()).toEqual(['c.txt']);
+    expect(store().selectedType).toBe('file');
+  });
+});
+
+describe('shift+click range', () => {
+  it('selects downwards from the anchor', () => {
+    store().selectItem(files[1]!, 'file', 1, false, false, files);
+
+    store().selectItem(files[3]!, 'file', 3, false, true, files);
+
+    expect(keysOf()).toEqual(['b.txt', 'c.txt', 'd.txt']);
+  });
+
+  it('selects upwards from the anchor', () => {
+    store().selectItem(files[3]!, 'file', 3, false, false, files);
+
+    store().selectItem(files[1]!, 'file', 1, false, true, files);
+
+    // Range is min..max, so direction does not matter.
+    expect(keysOf()).toEqual(['b.txt', 'c.txt', 'd.txt']);
+  });
+
+  it('selects a single item when the range collapses', () => {
+    store().selectItem(files[2]!, 'file', 2, false, false, files);
+
+    store().selectItem(files[2]!, 'file', 2, false, true, files);
+
+    expect(keysOf()).toEqual(['c.txt']);
+  });
+
+  it('covers the whole list at the boundaries', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+
+    store().selectItem(files[4]!, 'file', 4, false, true, files);
+
+    expect(keysOf()).toEqual(['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt']);
+  });
+
+  it('keeps the anchor fixed so the range can be resized', () => {
+    store().selectItem(files[1]!, 'file', 1, false, false, files);
+    store().selectItem(files[4]!, 'file', 4, false, true, files);
+
+    // Shrinking the range must measure from the original anchor, not from the
+    // end of the previous range.
+    store().selectItem(files[2]!, 'file', 2, false, true, files);
+
+    expect(store().lastSelectedIndex).toBe(1);
+    expect(keysOf()).toEqual(['b.txt', 'c.txt']);
+  });
+
+  it('replaces the previous selection rather than adding to it', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[4]!, 'file', 4, true, false, files); // ctrl-add, anchor moves to 4
+
+    store().selectItem(files[3]!, 'file', 3, false, true, files);
+
+    expect(keysOf()).toEqual(['d.txt', 'e.txt']);
+  });
+
+  it('falls back to a single selection with no anchor', () => {
+    // Shift-clicking as the very first interaction has nothing to range from.
+    store().selectItem(files[2]!, 'file', 2, false, true, files);
+
+    expect(keysOf()).toEqual(['c.txt']);
+    expect(store().lastSelectedIndex).toBe(2);
+  });
+});
+
+describe('mixing files and folders', () => {
+  const folders = [folder('one/'), folder('two/')];
+
+  it('discards a file selection when a folder is clicked', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[1]!, 'file', 1, true, false, files);
+
+    store().selectItem(folders[0]!, 'folder', 0, false, false, folders);
+
+    // Bulk actions differ for files and folders, so the two cannot mix.
+    expect(keysOf()).toEqual(['one/']);
+    expect(store().selectedType).toBe('folder');
+  });
+
+  it('discards the old type even when ctrl is held', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+
+    store().selectItem(folders[0]!, 'folder', 0, true, false, folders);
+
+    expect(keysOf()).toEqual(['one/']);
+  });
+
+  it('discards the old type even when shift is held', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+
+    store().selectItem(folders[1]!, 'folder', 1, false, true, folders);
+
+    // The type check runs before the range branch, so no cross-type range is
+    // ever built.
+    expect(keysOf()).toEqual(['two/']);
+  });
+
+  it('identifies folders by prefix', () => {
+    store().selectItem(folders[0]!, 'folder', 0, false, false, folders);
+
+    expect(store().isSelected(folder('one/'))).toBe(true);
+    expect(store().isSelected(folder('two/'))).toBe(false);
+  });
+});
+
+describe('queries and clearing', () => {
+  it('reports whether an item is selected', () => {
+    store().selectItem(files[1]!, 'file', 1, false, false, files);
+
+    expect(store().isSelected(files[1]!)).toBe(true);
+    expect(store().isSelected(files[0]!)).toBe(false);
+  });
+
+  it('treats an item with neither key nor prefix as unselected', () => {
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+
+    // getItemKey returns '' for these, which must not match a real key.
+    expect(store().isSelected({ name: 'orphan' } as unknown as FileItem)).toBe(false);
+  });
+
+  it('counts the selection', () => {
+    expect(store().getSelectionCount()).toBe(0);
+
+    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[1]!, 'file', 1, true, false, files);
+
+    expect(store().getSelectionCount()).toBe(2);
+  });
+
+  it('resets everything, including the anchor', () => {
+    store().selectItem(files[2]!, 'file', 2, false, false, files);
+
+    store().clearSelection();
+
+    expect(store().selectedItems).toEqual([]);
+    expect(store().selectedType).toBeNull();
+    // Leaving the anchor behind would let the next shift-click build a range
+    // from a row the user last touched minutes ago.
+    expect(store().lastSelectedIndex).toBeNull();
+  });
+});

--- a/frontend/src/features/dashboard/stores/use-search-store.test.ts
+++ b/frontend/src/features/dashboard/stores/use-search-store.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Search store: a TTL cache of search results keyed by query + prefix.
+ *
+ * Two things drive most of the behaviour and both are easy to get wrong:
+ *
+ *  - The cache key is normalised. `  Report ` and `report` are the same query,
+ *    and prefix `/` means the same place as `''`. Without that, the same search
+ *    typed slightly differently re-hits S3.
+ *  - Entries expire after 5 minutes, and reads are what evict them.
+ *
+ * Time is faked throughout so the TTL is exercised deterministically rather
+ * than by waiting.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { SearchResult } from '@opndrive/s3-api';
+import { useSearchStore, CACHE_CONFIG } from './use-search-store';
+
+const store = () => useSearchStore.getState();
+
+function results(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    files: [],
+    folders: [],
+    totalFiles: 0,
+    totalFolders: 0,
+    totalKeys: 0,
+    isTruncated: false,
+    ...overrides,
+  } as SearchResult;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(Date.UTC(2026, 0, 1));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('storing and reading results', () => {
+  it('round-trips a result', () => {
+    const payload = results({ totalFiles: 3 });
+
+    store().setSearchResults('report', 'docs/', payload);
+
+    expect(store().getCachedOrNull('report', 'docs/')).toBe(payload);
+  });
+
+  it('returns null for a query it has never seen', () => {
+    expect(store().getCachedOrNull('nothing', 'docs/')).toBeNull();
+    expect(store().getSearchResults('nothing', 'docs/')).toBeNull();
+  });
+
+  it('records the query and prefix alongside the results', () => {
+    store().setSearchResults('  Report  ', 'docs/', results());
+
+    const entry = store().getSearchResults('report', 'docs/')!;
+    // The stored query is trimmed but keeps its original casing for display.
+    expect(entry).toMatchObject({ query: 'Report', prefix: 'docs/', requestCount: 0 });
+    expect(entry.timestamp).toBe(Date.now());
+  });
+
+  it('overwrites the entry for a repeated search', () => {
+    store().setSearchResults('report', 'docs/', results({ totalFiles: 1 }));
+    store().setSearchResults('report', 'docs/', results({ totalFiles: 9 }));
+
+    expect(store().searchCache.size).toBe(1);
+    expect(store().getCachedOrNull('report', 'docs/')!.totalFiles).toBe(9);
+  });
+});
+
+describe('cache key normalisation', () => {
+  it('ignores surrounding whitespace and casing', () => {
+    store().setSearchResults('Report', 'docs/', results({ totalFiles: 4 }));
+
+    // Retyping the same search slightly differently must not re-hit S3.
+    expect(store().getCachedOrNull('  report  ', 'docs/')!.totalFiles).toBe(4);
+    expect(store().getCachedOrNull('REPORT', 'docs/')!.totalFiles).toBe(4);
+  });
+
+  it('treats a root prefix of "/" the same as empty', () => {
+    store().setSearchResults('report', '/', results({ totalFiles: 2 }));
+
+    expect(store().getCachedOrNull('report', '')!.totalFiles).toBe(2);
+  });
+
+  it('keeps different prefixes apart', () => {
+    store().setSearchResults('report', 'docs/', results({ totalFiles: 1 }));
+    store().setSearchResults('report', 'photos/', results({ totalFiles: 7 }));
+
+    expect(store().searchCache.size).toBe(2);
+    expect(store().getCachedOrNull('report', 'docs/')!.totalFiles).toBe(1);
+    expect(store().getCachedOrNull('report', 'photos/')!.totalFiles).toBe(7);
+  });
+
+  it('does not confuse queries that differ only inside the string', () => {
+    store().setSearchResults('re port', 'docs/', results({ totalFiles: 1 }));
+
+    expect(store().getCachedOrNull('report', 'docs/')).toBeNull();
+  });
+});
+
+describe('expiry', () => {
+  it('serves an entry that is still inside the TTL', () => {
+    store().setSearchResults('report', 'docs/', results({ totalFiles: 5 }));
+
+    vi.advanceTimersByTime(CACHE_CONFIG.TTL_MS - 1);
+
+    expect(store().getCachedOrNull('report', 'docs/')!.totalFiles).toBe(5);
+  });
+
+  it('discards an entry once the TTL has passed', () => {
+    store().setSearchResults('report', 'docs/', results());
+
+    vi.advanceTimersByTime(CACHE_CONFIG.TTL_MS + 1);
+
+    expect(store().getCachedOrNull('report', 'docs/')).toBeNull();
+  });
+
+  it('evicts the stale entry rather than just hiding it', () => {
+    store().setSearchResults('report', 'docs/', results());
+    vi.advanceTimersByTime(CACHE_CONFIG.TTL_MS + 1);
+
+    store().getSearchResults('report', 'docs/');
+
+    // Reading is what prunes it; leaving it would keep the entry counting
+    // towards the size cap forever.
+    expect(store().searchCache.size).toBe(0);
+  });
+
+  it('sweeps every stale entry on demand, keeping the fresh ones', () => {
+    store().setSearchResults('old-1', 'docs/', results());
+    store().setSearchResults('old-2', 'docs/', results());
+    vi.advanceTimersByTime(CACHE_CONFIG.TTL_MS + 1);
+    store().setSearchResults('fresh', 'docs/', results());
+
+    store().cleanupStaleEntries();
+
+    expect([...store().searchCache.values()].map((e) => e.query)).toEqual(['fresh']);
+  });
+
+  it('leaves a fresh cache untouched when swept', () => {
+    store().setSearchResults('a', 'docs/', results());
+    store().setSearchResults('b', 'docs/', results());
+
+    store().cleanupStaleEntries();
+
+    expect(store().searchCache.size).toBe(2);
+  });
+});
+
+describe('size cap', () => {
+  it('holds exactly the maximum without evicting', () => {
+    for (let i = 0; i < CACHE_CONFIG.MAX_CACHE_SIZE; i++) {
+      store().setSearchResults(`q${i}`, 'docs/', results());
+    }
+
+    expect(store().searchCache.size).toBe(CACHE_CONFIG.MAX_CACHE_SIZE);
+  });
+
+  it('drops the oldest entry when the cap is exceeded', () => {
+    for (let i = 0; i < CACHE_CONFIG.MAX_CACHE_SIZE; i++) {
+      store().setSearchResults(`q${i}`, 'docs/', results());
+      vi.advanceTimersByTime(10); // distinct timestamps, so "oldest" is unambiguous
+    }
+
+    store().setSearchResults('newest', 'docs/', results());
+
+    expect(store().searchCache.size).toBe(CACHE_CONFIG.MAX_CACHE_SIZE);
+    expect(store().getCachedOrNull('q0', 'docs/')).toBeNull();
+    expect(store().getCachedOrNull('newest', 'docs/')).not.toBeNull();
+  });
+
+  it('keeps the most recent searches', () => {
+    for (let i = 0; i < CACHE_CONFIG.MAX_CACHE_SIZE + 3; i++) {
+      store().setSearchResults(`q${i}`, 'docs/', results());
+      vi.advanceTimersByTime(10);
+    }
+
+    // The three oldest go; everything newer survives.
+    expect(store().getCachedOrNull('q0', 'docs/')).toBeNull();
+    expect(store().getCachedOrNull('q2', 'docs/')).toBeNull();
+    expect(store().getCachedOrNull('q3', 'docs/')).not.toBeNull();
+  });
+});
+
+describe('request counting', () => {
+  it('starts a new entry at zero', () => {
+    store().setSearchResults('report', 'docs/', results());
+
+    expect(store().getRequestCount('report', 'docs/')).toBe(0);
+  });
+
+  it('reports zero for an unknown query', () => {
+    expect(store().getRequestCount('never', 'docs/')).toBe(0);
+  });
+
+  it('records a count against an existing entry', () => {
+    store().setSearchResults('report', 'docs/', results());
+
+    store().setRequestCount('report', 'docs/', 4);
+
+    expect(store().getRequestCount('report', 'docs/')).toBe(4);
+  });
+
+  it('creates a placeholder entry when the count arrives first', () => {
+    // The service reports request counts while paging, before any results land.
+    store().setRequestCount('report', 'docs/', 2);
+
+    expect(store().getRequestCount('report', 'docs/')).toBe(2);
+    expect(store().getCachedOrNull('report', 'docs/')).toMatchObject({
+      files: [],
+      folders: [],
+      totalKeys: 0,
+    });
+  });
+
+  it('survives the results arriving afterwards', () => {
+    store().setRequestCount('report', 'docs/', 3);
+
+    store().setSearchResults('report', 'docs/', results({ totalFiles: 8 }));
+
+    // Losing the count here would reset the "searched N folders" indicator to
+    // zero the moment results appeared.
+    expect(store().getRequestCount('report', 'docs/')).toBe(3);
+    expect(store().getCachedOrNull('report', 'docs/')!.totalFiles).toBe(8);
+  });
+
+  it('normalises the key the same way as the rest of the cache', () => {
+    store().setRequestCount('  Report ', 'docs/', 5);
+
+    expect(store().getRequestCount('report', 'docs/')).toBe(5);
+  });
+});
+
+describe('invalidation', () => {
+  beforeEach(() => {
+    store().setSearchResults('report', 'docs/', results());
+    store().setSearchResults('report', 'photos/', results());
+    store().setSearchResults('budget', 'docs/', results());
+  });
+
+  it('drops one query in one prefix when both are given', () => {
+    store().invalidateQuery('report', 'docs/');
+
+    expect(store().getCachedOrNull('report', 'docs/')).toBeNull();
+    expect(store().getCachedOrNull('report', 'photos/')).not.toBeNull();
+  });
+
+  it('drops a query across every prefix when no prefix is given', () => {
+    store().invalidateQuery('report');
+
+    expect(store().getCachedOrNull('report', 'docs/')).toBeNull();
+    expect(store().getCachedOrNull('report', 'photos/')).toBeNull();
+    expect(store().getCachedOrNull('budget', 'docs/')).not.toBeNull();
+  });
+
+  it('matches the query case-insensitively when invalidating everywhere', () => {
+    store().invalidateQuery('REPORT');
+
+    expect(store().getCachedOrNull('report', 'docs/')).toBeNull();
+  });
+
+  it('drops every query for a prefix whose contents changed', () => {
+    store().invalidatePrefix('docs/');
+
+    // Uploading into docs/ makes every cached search of docs/ wrong.
+    expect(store().getCachedOrNull('report', 'docs/')).toBeNull();
+    expect(store().getCachedOrNull('budget', 'docs/')).toBeNull();
+    expect(store().getCachedOrNull('report', 'photos/')).not.toBeNull();
+  });
+
+  it('normalises "/" when invalidating a prefix', () => {
+    store().setSearchResults('root-search', '', results());
+
+    store().invalidatePrefix('/');
+
+    expect(store().getCachedOrNull('root-search', '')).toBeNull();
+  });
+
+  it('is a no-op for a prefix with nothing cached', () => {
+    store().invalidatePrefix('elsewhere/');
+
+    expect(store().searchCache.size).toBe(3);
+  });
+});
+
+describe('active query and loading', () => {
+  it('tracks the query being viewed', () => {
+    store().setCurrentQuery('report', 'docs/');
+
+    expect(store().currentQuery).toBe('report');
+    expect(store().currentPrefix).toBe('docs/');
+  });
+
+  it('clears the active query', () => {
+    store().setCurrentQuery('report', 'docs/');
+
+    store().setCurrentQuery(null, null);
+
+    expect(store().currentQuery).toBeNull();
+    expect(store().currentPrefix).toBeNull();
+  });
+
+  it('toggles the loading flag', () => {
+    expect(store().isLoading).toBe(false);
+
+    store().setLoading(true);
+    expect(store().isLoading).toBe(true);
+
+    store().setLoading(false);
+    expect(store().isLoading).toBe(false);
+  });
+});
+
+describe('clearCache', () => {
+  it('empties the cache and forgets the active query', () => {
+    store().setSearchResults('report', 'docs/', results());
+    store().setCurrentQuery('report', 'docs/');
+
+    store().clearCache();
+
+    expect(store().searchCache.size).toBe(0);
+    expect(store().currentQuery).toBeNull();
+    expect(store().currentPrefix).toBeNull();
+  });
+
+  it('leaves the loading flag alone', () => {
+    store().setLoading(true);
+
+    store().clearCache();
+
+    // A search in flight is still in flight; clearing results does not cancel
+    // it, and lying about that would strand the spinner.
+    expect(store().isLoading).toBe(true);
+  });
+});

--- a/frontend/src/features/upload/components/operations-modal.tsx
+++ b/frontend/src/features/upload/components/operations-modal.tsx
@@ -81,9 +81,13 @@ export const OperationsModal: React.FC = () => {
     deletes,
     removeUpload,
     removeDeleteOperation,
-    duplicateDialog,
+    duplicateQueue,
+    resolveDuplicate,
     hideDuplicateDialog,
   } = useUploadStore();
+
+  // Only the oldest pending duplicate is shown; answering it reveals the next.
+  const currentDuplicate = duplicateQueue[0] ?? null;
   const { getAllDownloads, cancelDownload } = useDownloadList();
   const downloads = getAllDownloads();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -296,7 +300,7 @@ export const OperationsModal: React.FC = () => {
   });
 
   // If no operations and no duplicate dialog, don't show modal
-  if (sortedOperations.length === 0 && !duplicateDialog.isOpen) {
+  if (sortedOperations.length === 0 && !currentDuplicate) {
     return null;
   }
 
@@ -332,7 +336,7 @@ export const OperationsModal: React.FC = () => {
   // Get title based on operations
   const getTitle = () => {
     // If only duplicate dialog is open, show appropriate title
-    if (sortedOperations.length === 0 && duplicateDialog.isOpen) {
+    if (sortedOperations.length === 0 && currentDuplicate) {
       return 'File Upload';
     }
 
@@ -1090,11 +1094,11 @@ export const OperationsModal: React.FC = () => {
 
       {/* Duplicate Dialog */}
       <DuplicateDialog
-        isOpen={duplicateDialog.isOpen}
+        isOpen={currentDuplicate !== null}
         onClose={hideDuplicateDialog}
-        duplicateItem={duplicateDialog.duplicateItem}
-        onReplace={duplicateDialog.onReplace || (() => {})}
-        onKeepBoth={duplicateDialog.onKeepBoth || (() => {})}
+        duplicateItem={currentDuplicate?.duplicateItem ?? null}
+        onReplace={() => resolveDuplicate('replace')}
+        onKeepBoth={() => resolveDuplicate('keepBoth')}
       />
     </>
   );

--- a/frontend/src/features/upload/stores/use-upload-settings-store.test.ts
+++ b/frontend/src/features/upload/stores/use-upload-settings-store.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Upload settings store.
+ *
+ * Small, but the only store in the app wrapped in zustand's `persist`
+ * middleware, so the interesting behaviour is the localStorage round-trip
+ * rather than the single setter.
+ *
+ * Hydration is driven through `persist.rehydrate()` rather than by re-importing
+ * the module: the store is created once at import time, so seeding localStorage
+ * afterwards has no effect on its own.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useUploadSettingsStore } from './use-upload-settings-store';
+
+const STORAGE_KEY = 'upload-settings-storage';
+const store = () => useUploadSettingsStore.getState();
+
+/** What persist writes: the state under `state`, plus its schema version. */
+function stored(mode: string) {
+  return JSON.stringify({ state: { uploadMode: mode }, version: 0 });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('defaults', () => {
+  it('starts on multipart', () => {
+    // Multipart is resumable and handles large files; signed-url is the
+    // fallback for restricted buckets, so it must not be the default.
+    expect(store().uploadMode).toBe('multipart');
+  });
+});
+
+describe('setUploadMode', () => {
+  it('switches to signed-url', () => {
+    store().setUploadMode('signed-url');
+
+    expect(store().uploadMode).toBe('signed-url');
+  });
+
+  it('switches back to multipart', () => {
+    store().setUploadMode('signed-url');
+
+    store().setUploadMode('multipart');
+
+    expect(store().uploadMode).toBe('multipart');
+  });
+
+  it('is idempotent', () => {
+    store().setUploadMode('signed-url');
+    store().setUploadMode('signed-url');
+
+    expect(store().uploadMode).toBe('signed-url');
+  });
+});
+
+describe('persistence', () => {
+  it('writes the choice to localStorage', () => {
+    store().setUploadMode('signed-url');
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!).state.uploadMode).toBe('signed-url');
+  });
+
+  it('stores it under the documented key', () => {
+    store().setUploadMode('signed-url');
+
+    // Renaming this key silently resets everyone's preference on deploy.
+    expect(Object.keys(localStorage)).toContain(STORAGE_KEY);
+  });
+
+  it('hydrates a saved choice', async () => {
+    localStorage.setItem(STORAGE_KEY, stored('signed-url'));
+
+    await useUploadSettingsStore.persist.rehydrate();
+
+    // This is what a returning user gets on page load.
+    expect(store().uploadMode).toBe('signed-url');
+  });
+
+  it('keeps the default when nothing is stored', async () => {
+    await useUploadSettingsStore.persist.rehydrate();
+
+    expect(store().uploadMode).toBe('multipart');
+  });
+
+  it('keeps the default when the stored value is corrupt', async () => {
+    localStorage.setItem(STORAGE_KEY, 'not json at all');
+
+    // A user with a mangled entry should still get a working uploader.
+    await expect(useUploadSettingsStore.persist.rehydrate()).resolves.toBeUndefined();
+    expect(store().uploadMode).toBe('multipart');
+  });
+
+  it('does not lose the setter when hydrating', async () => {
+    localStorage.setItem(STORAGE_KEY, stored('signed-url'));
+
+    await useUploadSettingsStore.persist.rehydrate();
+
+    // Persist merges into the existing state; if it replaced it wholesale the
+    // actions would be gone and the settings UI would crash on click.
+    expect(typeof store().setUploadMode).toBe('function');
+    store().setUploadMode('multipart');
+    expect(store().uploadMode).toBe('multipart');
+  });
+
+  it('reports that hydration has happened', async () => {
+    // hasHydrated is a lifecycle flag on the shared store, not per-test state,
+    // and rehydrate() flips it false until it settles. Driving one here makes
+    // the assertion independent of whatever ran before.
+    await useUploadSettingsStore.persist.rehydrate();
+
+    expect(useUploadSettingsStore.persist.hasHydrated()).toBe(true);
+  });
+});
+
+describe('isolation between tests', () => {
+  it('A: leaves a non-default mode behind', () => {
+    store().setUploadMode('signed-url');
+
+    expect(store().uploadMode).toBe('signed-url');
+  });
+
+  it('B: still starts from the default', () => {
+    // The zustand reset covers persisted stores too, so a preference set in one
+    // test cannot leak into the next.
+    expect(store().uploadMode).toBe('multipart');
+  });
+});

--- a/frontend/src/features/upload/stores/use-upload-store.test.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.test.ts
@@ -161,12 +161,7 @@ describe('clearing', () => {
     expect(store().uploads).toEqual({});
     expect(store().deletes).toEqual({});
     expect(store().batches).toEqual({});
-    expect(store().duplicateDialog).toEqual({
-      isOpen: false,
-      duplicateItem: null,
-      onReplace: null,
-      onKeepBoth: null,
-    });
+    expect(store().duplicateQueue).toEqual([]);
   });
 });
 
@@ -457,52 +452,120 @@ describe('batch tracking', () => {
   });
 });
 
-describe('duplicate dialog', () => {
-  it('opens with the item and both choices', () => {
+describe('duplicate prompt queue', () => {
+  /** Mirrors what DuplicateDialog does: choose, then close. */
+  function answer(choice: 'replace' | 'keepBoth') {
+    store().resolveDuplicate(choice);
+    store().hideDuplicateDialog();
+  }
+
+  it('queues a prompt with its item and both choices', () => {
     const onReplace = vi.fn();
     const onKeepBoth = vi.fn();
 
     store().showDuplicateDialog({ name: 'a.pdf', type: 'file', size: 10 }, onReplace, onKeepBoth);
 
-    expect(store().duplicateDialog).toEqual({
-      isOpen: true,
+    expect(store().duplicateQueue).toHaveLength(1);
+    expect(store().duplicateQueue[0]).toMatchObject({
       duplicateItem: { name: 'a.pdf', type: 'file', size: 10 },
       onReplace,
       onKeepBoth,
     });
   });
 
-  it('KNOWN GAP: a second prompt replaces the first instead of queueing', () => {
+  it('gives each prompt its own id', () => {
+    store().showDuplicateDialog({ name: 'a.txt', type: 'file' }, vi.fn(), vi.fn());
+    store().showDuplicateDialog({ name: 'b.txt', type: 'file' }, vi.fn(), vi.fn());
+
+    const [first, second] = store().duplicateQueue;
+    expect(first!.id).not.toBe(second!.id);
+  });
+
+  it('keeps both prompts when two drops collide, oldest first', () => {
+    store().showDuplicateDialog({ name: 'a.txt', type: 'file' }, vi.fn(), vi.fn());
+    store().showDuplicateDialog({ name: 'b.txt', type: 'file' }, vi.fn(), vi.fn());
+
+    // A single slot used to drop the first prompt's callbacks here, so the
+    // upload waiting on that answer hung forever.
+    expect(store().duplicateQueue.map((p) => p.duplicateItem.name)).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('resolves two concurrent drops in order, each with its own choice', async () => {
+    const outcomes: string[] = [];
+
+    // Exactly the shape the store uses internally: an upload parked on a
+    // promise until the user answers.
+    const dropA = new Promise<string>((resolve) => {
+      store().showDuplicateDialog(
+        { name: 'a.txt', type: 'file' },
+        () => resolve('a:replace'),
+        () => resolve('a:keepBoth')
+      );
+    });
+    const dropB = new Promise<string>((resolve) => {
+      store().showDuplicateDialog(
+        { name: 'b.txt', type: 'file' },
+        () => resolve('b:replace'),
+        () => resolve('b:keepBoth')
+      );
+    });
+
+    expect(store().duplicateQueue).toHaveLength(2);
+
+    answer('replace');
+    expect(store().duplicateQueue).toHaveLength(1);
+    // The next question is now the head, not a lost prompt.
+    expect(store().duplicateQueue[0]!.duplicateItem.name).toBe('b.txt');
+
+    answer('keepBoth');
+    expect(store().duplicateQueue).toHaveLength(0);
+
+    outcomes.push(await dropA, await dropB);
+    // Both uploads resumed, each with the answer the user gave it.
+    expect(outcomes).toEqual(['a:replace', 'b:keepBoth']);
+  });
+
+  it('runs only the head prompt callback', () => {
     const firstReplace = vi.fn();
     const secondReplace = vi.fn();
-
     store().showDuplicateDialog({ name: 'a.txt', type: 'file' }, firstReplace, vi.fn());
     store().showDuplicateDialog({ name: 'b.txt', type: 'file' }, secondReplace, vi.fn());
 
-    // The dialog is a single slot, not a queue. Two duplicates resolved
-    // concurrently would lose the first prompt: its callbacks are dropped, so
-    // whatever it was waiting on never resolves.
-    //
-    // Not reachable from a single drop today - the folder loop returns on the
-    // first duplicate it finds - but two overlapping drops can do it. Pinned so
-    // a future queue implementation has to change this deliberately.
-    expect(store().duplicateDialog.duplicateItem).toEqual({ name: 'b.txt', type: 'file' });
-    expect(store().duplicateDialog.onReplace).toBe(secondReplace);
-    expect(firstReplace).not.toHaveBeenCalled();
+    store().resolveDuplicate('replace');
+
+    expect(firstReplace).toHaveBeenCalledOnce();
+    expect(secondReplace).not.toHaveBeenCalled();
   });
 
-  it('clears the callbacks when hidden', () => {
-    store().showDuplicateDialog({ name: 'a.pdf', type: 'file' }, vi.fn(), vi.fn());
+  it('does not dequeue on resolve alone', () => {
+    store().showDuplicateDialog({ name: 'a.txt', type: 'file' }, vi.fn(), vi.fn());
+
+    store().resolveDuplicate('replace');
+
+    // The dialog component calls the choice handler and THEN onClose, so
+    // dequeuing here as well would silently skip the prompt behind this one.
+    expect(store().duplicateQueue).toHaveLength(1);
+  });
+
+  it('dismisses without answering when closed outright', () => {
+    const onReplace = vi.fn();
+    const onKeepBoth = vi.fn();
+    store().showDuplicateDialog({ name: 'a.txt', type: 'file' }, onReplace, onKeepBoth);
 
     store().hideDuplicateDialog();
 
-    // Leaving the callbacks behind would let a later dialog fire the previous
-    // prompt's decision.
-    expect(store().duplicateDialog).toEqual({
-      isOpen: false,
-      duplicateItem: null,
-      onReplace: null,
-      onKeepBoth: null,
-    });
+    expect(store().duplicateQueue).toHaveLength(0);
+    expect(onReplace).not.toHaveBeenCalled();
+    expect(onKeepBoth).not.toHaveBeenCalled();
+  });
+
+  it('ignores a resolve when nothing is queued', () => {
+    expect(() => store().resolveDuplicate('replace')).not.toThrow();
+    expect(store().duplicateQueue).toEqual([]);
+  });
+
+  it('ignores a dismiss when nothing is queued', () => {
+    expect(() => store().hideDuplicateDialog()).not.toThrow();
+    expect(store().duplicateQueue).toEqual([]);
   });
 });

--- a/frontend/src/features/upload/stores/use-upload-store.test.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Operations store: upload progress, delete operations, batch tracking, and the
+ * duplicate prompt.
+ *
+ * `@opndrive/s3-api` is mocked at the module boundary - it has its own suite and
+ * nothing here should depend on real S3 behaviour. The data context is mocked
+ * too, because completing an upload asks it to refresh.
+ *
+ * NOTE: this store also keeps a module-scope `refreshState` object that lives
+ * OUTSIDE zustand, so the automatic store reset does not clear it. It debounces
+ * refreshes on a 3s window, which would make refresh assertions depend on test
+ * order. The suite moves the system clock forward instead of hoping - see the
+ * 'refresh on completion' block.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useUploadStore } from './use-upload-store';
+
+const { refreshCurrentData } = vi.hoisted(() => ({
+  refreshCurrentData: vi.fn(async () => {}),
+}));
+
+vi.mock('@opndrive/s3-api', () => ({
+  UploadManager: class {},
+  SignedUrlUploadManager: class {},
+  BYOS3ApiProvider: class {},
+}));
+
+vi.mock('@/context/data-context', () => ({
+  useDriveStore: { getState: () => ({ refreshCurrentData }) },
+}));
+
+const store = () => useUploadStore.getState();
+
+type Upload = Parameters<ReturnType<typeof store>['addUpload']>[1];
+type Delete = Parameters<ReturnType<typeof store>['addDeleteOperation']>[1];
+
+function upload(overrides: Partial<Upload> = {}): Upload {
+  return {
+    id: 'u1',
+    name: 'report.pdf',
+    status: 'queued',
+    progress: 0,
+    type: 'file',
+    ...overrides,
+  } as Upload;
+}
+
+function deletion(overrides: Partial<Delete> = {}): Delete {
+  return {
+    id: 'd1',
+    name: 'old.pdf',
+    status: 'queued',
+    progress: 0,
+    type: 'file',
+    ...overrides,
+  } as Delete;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('upload tracking', () => {
+  it('adds an upload under its id', () => {
+    store().addUpload('u1', upload());
+
+    expect(store().uploads.u1).toEqual(upload());
+  });
+
+  it('keeps existing uploads when adding another', () => {
+    store().addUpload('u1', upload());
+    store().addUpload('u2', upload({ id: 'u2', name: 'b.pdf' }));
+
+    expect(Object.keys(store().uploads)).toEqual(['u1', 'u2']);
+  });
+
+  it('merges partial updates into an existing upload', () => {
+    store().addUpload('u1', upload());
+
+    store().updateUpload('u1', { progress: 60, status: 'uploading' });
+
+    expect(store().uploads.u1).toMatchObject({
+      name: 'report.pdf',
+      progress: 60,
+      status: 'uploading',
+    });
+  });
+
+  it('ignores updates for an upload it is no longer tracking', () => {
+    store().updateUpload('never-added', { status: 'cancelled' });
+
+    // Disposing the upload managers on logout emits a trailing 'cancelled' per
+    // in-flight item, which can land after clearSessionData(). Spreading onto a
+    // missing entry would resurrect it as a card with no name or type.
+    expect(store().uploads['never-added']).toBeUndefined();
+    expect(Object.keys(store().uploads)).toEqual([]);
+  });
+
+  it('removes a single upload', () => {
+    store().addUpload('u1', upload());
+    store().addUpload('u2', upload({ id: 'u2' }));
+
+    store().removeUpload('u1');
+
+    expect(Object.keys(store().uploads)).toEqual(['u2']);
+  });
+
+  it('replaces the whole map with setUploads', () => {
+    store().addUpload('u1', upload());
+
+    store().setUploads({ u9: upload({ id: 'u9' }) });
+
+    expect(Object.keys(store().uploads)).toEqual(['u9']);
+  });
+
+  it('stores the upload manager it is given', () => {
+    const manager = { id: 'mgr' } as never;
+
+    store().setUploadManager(manager);
+
+    expect(store().uploadManager).toBe(manager);
+  });
+});
+
+describe('clearing', () => {
+  beforeEach(() => {
+    store().addUpload('done', upload({ id: 'done', status: 'completed' }));
+    store().addUpload('gone', upload({ id: 'gone', status: 'cancelled' }));
+    store().addUpload('bad', upload({ id: 'bad', status: 'failed' }));
+    store().addUpload('live', upload({ id: 'live', status: 'uploading' }));
+    store().addUpload('next', upload({ id: 'next', status: 'queued' }));
+  });
+
+  it('clears only the finished uploads', () => {
+    store().clearCompleted();
+
+    // An in-flight or queued upload must survive - clearing it from the list
+    // would not stop it, just hide it.
+    expect(Object.keys(store().uploads).sort()).toEqual(['live', 'next']);
+  });
+
+  it('clears everything with clearAll', () => {
+    store().clearAll();
+
+    expect(store().uploads).toEqual({});
+  });
+
+  it('wipes every session-scoped collection on logout', () => {
+    store().addDeleteOperation('d1', deletion());
+    store().createUploadBatch('file', ['u1']);
+    store().showDuplicateDialog({ name: 'x', type: 'file' }, vi.fn(), vi.fn());
+
+    store().clearSessionData();
+
+    // Records from one bucket must not surface in the next session.
+    expect(store().uploads).toEqual({});
+    expect(store().deletes).toEqual({});
+    expect(store().batches).toEqual({});
+    expect(store().duplicateDialog).toEqual({
+      isOpen: false,
+      duplicateItem: null,
+      onReplace: null,
+      onKeepBoth: null,
+    });
+  });
+});
+
+describe('refresh on completion', () => {
+  // `refreshState` lives in module scope, outside zustand, so the automatic
+  // store reset does not clear its 3s debounce window. Anchoring each test to a
+  // clock that only ever moves forward makes them independent of each other and
+  // of how long the previous test happened to take. Setting the time relative
+  // to `Date.now()` is NOT enough: afterEach restores real timers, so every
+  // test would otherwise start from roughly the same instant and the second one
+  // would be silently debounced into asserting nothing.
+  let clock = Date.UTC(2026, 0, 1);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clock += 10 * 60 * 1000;
+    vi.setSystemTime(clock);
+  });
+
+  it('refreshes when a standalone file finishes', async () => {
+    store().addUpload('u1', upload({ status: 'uploading' }));
+
+    store().updateUpload('u1', { status: 'completed' });
+
+    // The refresh is invoked synchronously, before its first await suspends.
+    expect(refreshCurrentData).toHaveBeenCalledOnce();
+    await Promise.resolve(); // let the in-flight flag clear
+  });
+
+  it('refreshes when a folder finishes', async () => {
+    store().addUpload('f1', upload({ id: 'f1', type: 'folder', status: 'uploading' }));
+
+    store().updateUpload('f1', { status: 'completed' });
+
+    expect(refreshCurrentData).toHaveBeenCalledOnce();
+    await Promise.resolve();
+  });
+
+  it('does not refresh while a folder still has files in flight', () => {
+    store().addUpload('folder', upload({ id: 'folder', type: 'folder', fileIds: ['a', 'b'] }));
+    store().addUpload('a', upload({ id: 'a', parentFolderId: 'folder' }));
+    store().addUpload('b', upload({ id: 'b', parentFolderId: 'folder' }));
+
+    store().updateUpload('a', { status: 'completed' });
+
+    // Refreshing per file would hammer the listing endpoint on a big folder.
+    expect(refreshCurrentData).not.toHaveBeenCalled();
+  });
+
+  it('refreshes once the last file of a folder finishes', async () => {
+    store().addUpload('folder', upload({ id: 'folder', type: 'folder', fileIds: ['a', 'b'] }));
+    store().addUpload('a', upload({ id: 'a', parentFolderId: 'folder', status: 'completed' }));
+    store().addUpload('b', upload({ id: 'b', parentFolderId: 'folder' }));
+
+    store().updateUpload('b', { status: 'completed' });
+
+    expect(refreshCurrentData).toHaveBeenCalledOnce();
+    await Promise.resolve();
+  });
+
+  it('does not refresh for a non-completion update', () => {
+    store().addUpload('u1', upload());
+
+    store().updateUpload('u1', { progress: 50 });
+
+    expect(refreshCurrentData).not.toHaveBeenCalled();
+  });
+
+  it('survives a failing refresh', () => {
+    refreshCurrentData.mockRejectedValueOnce(new Error('network down'));
+    store().addUpload('u1', upload());
+
+    // A failed background refresh must not surface as a failed upload.
+    expect(() => store().updateUpload('u1', { status: 'completed' })).not.toThrow();
+    expect(store().uploads.u1.status).toBe('completed');
+  });
+});
+
+describe('delete operations', () => {
+  it('adds an operation', () => {
+    store().addDeleteOperation('d1', deletion());
+
+    expect(store().deletes.d1).toEqual(deletion());
+  });
+
+  it('updates progress', () => {
+    store().addDeleteOperation('d1', deletion());
+
+    store().updateDeleteProgress('d1', 40);
+
+    expect(store().deletes.d1).toMatchObject({ progress: 40, name: 'old.pdf' });
+  });
+
+  it('records file counts when given', () => {
+    store().addDeleteOperation('d1', deletion());
+
+    store().updateDeleteProgress('d1', 50, 5, 10);
+
+    expect(store().deletes.d1).toMatchObject({ completedFiles: 5, totalFiles: 10 });
+  });
+
+  it('leaves file counts alone when omitted', () => {
+    store().addDeleteOperation('d1', deletion({ completedFiles: 3, totalFiles: 9 }));
+
+    store().updateDeleteProgress('d1', 60);
+
+    // Spreading `undefined` in would wipe a count the UI is already showing.
+    expect(store().deletes.d1).toMatchObject({ completedFiles: 3, totalFiles: 9 });
+  });
+
+  it('flags size calculation', () => {
+    store().addDeleteOperation('d1', deletion());
+
+    store().setCalculatingSize('d1', true);
+    expect(store().deletes.d1.isCalculatingSize).toBe(true);
+
+    store().setCalculatingSize('d1', false);
+    expect(store().deletes.d1.isCalculatingSize).toBe(false);
+  });
+
+  it('records a measured size', () => {
+    store().addDeleteOperation('d1', deletion());
+
+    store().updateSize('d1', 2048, 7);
+
+    expect(store().deletes.d1).toMatchObject({ size: 2048, totalFiles: 7 });
+  });
+
+  it('completes at 100 percent', () => {
+    store().addDeleteOperation('d1', deletion({ progress: 30 }));
+
+    store().completeDeleteOperation('d1');
+
+    expect(store().deletes.d1).toMatchObject({ status: 'completed', progress: 100 });
+  });
+
+  it('records the reason a delete failed', () => {
+    store().addDeleteOperation('d1', deletion());
+
+    store().failDeleteOperation('d1', 'AccessDenied');
+
+    expect(store().deletes.d1).toMatchObject({ status: 'failed', error: 'AccessDenied' });
+  });
+
+  it('aborts the in-flight request when cancelled', () => {
+    const abortController = new AbortController();
+    store().addDeleteOperation('d1', deletion({ status: 'deleting', abortController }));
+
+    store().cancelDeleteOperation('d1');
+
+    // Marking it cancelled without aborting would leave the request running and
+    // the objects deleted anyway.
+    expect(abortController.signal.aborted).toBe(true);
+    expect(store().deletes.d1.status).toBe('cancelled');
+  });
+
+  it('cancels an operation that has no abort controller', () => {
+    store().addDeleteOperation('d1', deletion());
+
+    expect(() => store().cancelDeleteOperation('d1')).not.toThrow();
+    expect(store().deletes.d1.status).toBe('cancelled');
+  });
+
+  it.each(['queued', 'deleting'] as const)('reports %s as active', (status) => {
+    store().addDeleteOperation('d1', deletion({ status }));
+
+    expect(store().isDeleteOperationActive('d1')).toBe(true);
+  });
+
+  it.each(['completed', 'failed', 'cancelled'] as const)('reports %s as inactive', (status) => {
+    store().addDeleteOperation('d1', deletion({ status }));
+
+    expect(store().isDeleteOperationActive('d1')).toBe(false);
+  });
+
+  it('reports an unknown operation as inactive', () => {
+    expect(store().isDeleteOperationActive('nope')).toBeFalsy();
+  });
+
+  it('exposes the abort controller', () => {
+    const abortController = new AbortController();
+    store().addDeleteOperation('d1', deletion({ abortController }));
+
+    expect(store().getDeleteAbortController('d1')).toBe(abortController);
+    expect(store().getDeleteAbortController('nope')).toBeUndefined();
+  });
+
+  it('removes an operation', () => {
+    store().addDeleteOperation('d1', deletion());
+    store().addDeleteOperation('d2', deletion({ id: 'd2' }));
+
+    store().removeDeleteOperation('d1');
+
+    expect(Object.keys(store().deletes)).toEqual(['d2']);
+  });
+});
+
+describe('batch tracking', () => {
+  it('creates a batch sized to its uploads', () => {
+    const batchId = store().createUploadBatch('file', ['a', 'b', 'c']);
+
+    expect(store().getBatch(batchId)).toMatchObject({
+      type: 'file',
+      uploadIds: ['a', 'b', 'c'],
+      totalCount: 3,
+      completedCount: 0,
+      isComplete: false,
+      hasTriggeredRefresh: false,
+    });
+  });
+
+  it('copies the id list instead of holding the caller array', () => {
+    const ids = ['a', 'b'];
+    const batchId = store().createUploadBatch('file', ids);
+
+    ids.push('c');
+
+    // Holding the caller's array would let a later mutation silently change
+    // totalCount's meaning after the fact.
+    expect(store().getBatch(batchId)!.uploadIds).toEqual(['a', 'b']);
+  });
+
+  it('gives each batch a distinct id', () => {
+    const a = store().createUploadBatch('file', ['x']);
+    const b = store().createUploadBatch('file', ['y']);
+
+    expect(a).not.toBe(b);
+    expect(Object.keys(store().batches)).toHaveLength(2);
+  });
+
+  it('counts completions', () => {
+    const batchId = store().createUploadBatch('file', ['a', 'b']);
+
+    store().updateBatchProgress(batchId, 'a', true);
+
+    expect(store().getBatch(batchId)).toMatchObject({ completedCount: 1, isComplete: false });
+  });
+
+  it('marks the batch complete on the last upload', () => {
+    const batchId = store().createUploadBatch('file', ['a', 'b']);
+
+    store().updateBatchProgress(batchId, 'a', true);
+    store().updateBatchProgress(batchId, 'b', true);
+
+    expect(store().isBatchComplete(batchId)).toBe(true);
+  });
+
+  it('does not count an upload that did not complete', () => {
+    const batchId = store().createUploadBatch('file', ['a', 'b']);
+
+    store().updateBatchProgress(batchId, 'a', false);
+
+    expect(store().getBatch(batchId)!.completedCount).toBe(0);
+  });
+
+  it('ignores progress for an unknown batch', () => {
+    expect(() => store().updateBatchProgress('nope', 'a', true)).not.toThrow();
+    expect(store().batches).toEqual({});
+  });
+
+  it('reports an unknown batch as incomplete', () => {
+    expect(store().isBatchComplete('nope')).toBe(false);
+    expect(store().getBatch('nope')).toBeUndefined();
+  });
+
+  it('keeps recent and in-flight batches during cleanup', () => {
+    const active = store().createUploadBatch('file', ['a', 'b']);
+    const justFinished = store().createUploadBatch('file', ['c']);
+    store().updateBatchProgress(justFinished, 'c', true);
+
+    store().cleanupCompletedBatches();
+
+    expect(Object.keys(store().batches).sort()).toEqual([active, justFinished].sort());
+  });
+
+  it('drops completed batches older than five minutes', () => {
+    vi.useFakeTimers();
+    const stale = store().createUploadBatch('file', ['a']);
+    store().updateBatchProgress(stale, 'a', true);
+    const active = store().createUploadBatch('file', ['b', 'c']);
+
+    vi.setSystemTime(Date.now() + 6 * 60 * 1000);
+    store().cleanupCompletedBatches();
+
+    // Unfinished batches are kept regardless of age - dropping one would lose
+    // the completion tracking for uploads still running.
+    expect(Object.keys(store().batches)).toEqual([active]);
+  });
+});
+
+describe('duplicate dialog', () => {
+  it('opens with the item and both choices', () => {
+    const onReplace = vi.fn();
+    const onKeepBoth = vi.fn();
+
+    store().showDuplicateDialog({ name: 'a.pdf', type: 'file', size: 10 }, onReplace, onKeepBoth);
+
+    expect(store().duplicateDialog).toEqual({
+      isOpen: true,
+      duplicateItem: { name: 'a.pdf', type: 'file', size: 10 },
+      onReplace,
+      onKeepBoth,
+    });
+  });
+
+  it('KNOWN GAP: a second prompt replaces the first instead of queueing', () => {
+    const firstReplace = vi.fn();
+    const secondReplace = vi.fn();
+
+    store().showDuplicateDialog({ name: 'a.txt', type: 'file' }, firstReplace, vi.fn());
+    store().showDuplicateDialog({ name: 'b.txt', type: 'file' }, secondReplace, vi.fn());
+
+    // The dialog is a single slot, not a queue. Two duplicates resolved
+    // concurrently would lose the first prompt: its callbacks are dropped, so
+    // whatever it was waiting on never resolves.
+    //
+    // Not reachable from a single drop today - the folder loop returns on the
+    // first duplicate it finds - but two overlapping drops can do it. Pinned so
+    // a future queue implementation has to change this deliberately.
+    expect(store().duplicateDialog.duplicateItem).toEqual({ name: 'b.txt', type: 'file' });
+    expect(store().duplicateDialog.onReplace).toBe(secondReplace);
+    expect(firstReplace).not.toHaveBeenCalled();
+  });
+
+  it('clears the callbacks when hidden', () => {
+    store().showDuplicateDialog({ name: 'a.pdf', type: 'file' }, vi.fn(), vi.fn());
+
+    store().hideDuplicateDialog();
+
+    // Leaving the callbacks behind would let a later dialog fire the previous
+    // prompt's decision.
+    expect(store().duplicateDialog).toEqual({
+      isOpen: false,
+      duplicateItem: null,
+      onReplace: null,
+      onKeepBoth: null,
+    });
+  });
+});

--- a/frontend/src/features/upload/stores/use-upload-store.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.ts
@@ -27,14 +27,12 @@ interface UploadBatch {
 }
 
 interface RefreshState {
-  debounceTimer: NodeJS.Timeout | null;
   isRefreshing: boolean;
   lastRefreshAttempt: number;
 }
 
 // Global refresh state management
 const refreshState: RefreshState = {
-  debounceTimer: null,
   isRefreshing: false,
   lastRefreshAttempt: 0,
 };
@@ -140,16 +138,26 @@ const reportFolderCheckFailure = (
   });
 };
 
-interface DuplicateDialogState {
-  isOpen: boolean;
-  duplicateItem: {
-    name: string;
-    type: 'file' | 'folder';
-    size?: number;
-    files?: File[];
-  } | null;
-  onReplace: (() => void) | null;
-  onKeepBoth: (() => void) | null;
+export interface DuplicateItem {
+  name: string;
+  type: 'file' | 'folder';
+  size?: number;
+  files?: File[];
+}
+
+/**
+ * One pending "this already exists" question.
+ *
+ * These are queued rather than kept in a single slot. Two drops that both hit a
+ * duplicate used to overwrite each other: the second prompt replaced the first,
+ * and the first prompt's callbacks went with it - so the upload that was
+ * waiting on that answer never resolved and simply hung.
+ */
+export interface DuplicatePrompt {
+  id: string;
+  duplicateItem: DuplicateItem;
+  onReplace: () => void;
+  onKeepBoth: () => void;
 }
 
 interface UploadProgress {
@@ -185,7 +193,8 @@ interface UploadStore {
   uploads: Record<string, UploadProgress>;
   deletes: Record<string, DeleteProgress>;
   batches: Record<string, UploadBatch>;
-  duplicateDialog: DuplicateDialogState;
+  /** Pending duplicate questions, oldest first. The UI renders index 0. */
+  duplicateQueue: DuplicatePrompt[];
   setUploadManager: (manager: UploadManager | SignedUrlUploadManager | null) => void;
   setUploads: (uploads: Record<string, UploadProgress>) => void;
   addUpload: (id: string, upload: UploadProgress) => void;
@@ -231,10 +240,17 @@ interface UploadStore {
 
   // Duplicate dialog methods
   showDuplicateDialog: (
-    duplicateItem: { name: string; type: 'file' | 'folder'; size?: number; files?: File[] },
+    duplicateItem: DuplicateItem,
     onReplace: () => void,
     onKeepBoth: () => void
   ) => void;
+  /**
+   * Runs the head prompt's chosen callback. Deliberately does NOT dequeue: the
+   * dialog component calls the choice handler and then onClose, so dequeuing
+   * here as well would skip the next prompt.
+   */
+  resolveDuplicate: (choice: 'replace' | 'keepBoth') => void;
+  /** Dismisses the head prompt, revealing the next one. */
   hideDuplicateDialog: () => void;
 
   // Batch tracking methods
@@ -257,12 +273,7 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
   uploads: {},
   deletes: {},
   batches: {},
-  duplicateDialog: {
-    isOpen: false,
-    duplicateItem: null,
-    onReplace: null,
-    onKeepBoth: null,
-  },
+  duplicateQueue: [],
 
   setUploads: (uploads: Record<string, UploadProgress>) => set({ uploads }),
 
@@ -350,12 +361,7 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
       uploads: {},
       deletes: {},
       batches: {},
-      duplicateDialog: {
-        isOpen: false,
-        duplicateItem: null,
-        onReplace: null,
-        onKeepBoth: null,
-      },
+      duplicateQueue: [],
     }),
 
   handleFilesDroppedToDirectory: async (
@@ -986,24 +992,33 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
 
   // Duplicate dialog methods
   showDuplicateDialog: (duplicateItem, onReplace, onKeepBoth) =>
-    set({
-      duplicateDialog: {
-        isOpen: true,
-        duplicateItem,
-        onReplace,
-        onKeepBoth,
-      },
-    }),
+    set((state) => ({
+      duplicateQueue: [
+        ...state.duplicateQueue,
+        {
+          id: `dup_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
+          duplicateItem,
+          onReplace,
+          onKeepBoth,
+        },
+      ],
+    })),
+
+  resolveDuplicate: (choice) => {
+    const prompt = get().duplicateQueue[0];
+    if (!prompt) return;
+
+    // Only invokes; hideDuplicateDialog does the dequeue. The dialog component
+    // calls the choice handler and then onClose, so dequeuing here too would
+    // drop the prompt behind this one.
+    if (choice === 'replace') prompt.onReplace();
+    else prompt.onKeepBoth();
+  },
 
   hideDuplicateDialog: () =>
-    set({
-      duplicateDialog: {
-        isOpen: false,
-        duplicateItem: null,
-        onReplace: null,
-        onKeepBoth: null,
-      },
-    }),
+    set((state) => ({
+      duplicateQueue: state.duplicateQueue.slice(1),
+    })),
 
   // Batch tracking methods
   createUploadBatch: (type: UploadBatch['type'], uploadIds: string[]): string => {
@@ -1103,12 +1118,6 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
   },
 
   forceRefreshData: async (): Promise<void> => {
-    // Clear timer
-    if (refreshState.debounceTimer) {
-      clearTimeout(refreshState.debounceTimer);
-      refreshState.debounceTimer = null;
-    }
-
     refreshState.isRefreshing = true;
 
     try {

--- a/frontend/src/services/file-size-limits.test.ts
+++ b/frontend/src/services/file-size-limits.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Preview eligibility and size formatting.
+ *
+ * Pure functions over the extension config, so nothing is mocked. The limits
+ * come from PREVIEW_SIZE_LIMITS and are referenced rather than hardcoded, so
+ * retuning a limit does not require editing assertions here - only a change to
+ * which category a file falls into would.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  checkPreviewEligibility,
+  formatFileSize,
+  getSizeLimitForCategory,
+  isFileSizeAllowedForPreview,
+} from './file-size-limits';
+import { PREVIEW_SIZE_LIMITS } from '@/config/file-extensions';
+
+const MB = 1024 * 1024;
+
+describe('checkPreviewEligibility', () => {
+  it('allows a file inside its limit', () => {
+    const result = checkPreviewEligibility('photo.png', 1 * MB);
+
+    expect(result).toEqual({
+      canPreview: true,
+      sizeLimit: PREVIEW_SIZE_LIMITS.image,
+      actualSize: 1 * MB,
+    });
+  });
+
+  it('allows a file exactly at the limit', () => {
+    // The check is `>` so the boundary itself is still previewable.
+    const result = checkPreviewEligibility('photo.png', PREVIEW_SIZE_LIMITS.image);
+
+    expect(result.canPreview).toBe(true);
+  });
+
+  it('rejects a file one byte over the limit', () => {
+    const result = checkPreviewEligibility('photo.png', PREVIEW_SIZE_LIMITS.image + 1);
+
+    expect(result.canPreview).toBe(false);
+    expect(result.reason).toMatch(/exceeds \d+MB limit/);
+    expect(result.sizeLimit).toBe(PREVIEW_SIZE_LIMITS.image);
+  });
+
+  it('reports the limit in MB in the message', () => {
+    const result = checkPreviewEligibility('sheet.xlsx', PREVIEW_SIZE_LIMITS.spreadsheet + 1);
+
+    expect(result.reason).toBe('File size exceeds 10MB limit');
+  });
+
+  it('rejects an unrecognised extension', () => {
+    const result = checkPreviewEligibility('mystery.qqq', 10);
+
+    expect(result).toEqual({
+      canPreview: false,
+      reason: 'File type not supported for preview',
+      sizeLimit: 0,
+      actualSize: 10,
+    });
+  });
+
+  it('treats a file with no extension as a document', () => {
+    const result = checkPreviewEligibility('noextension', 10);
+
+    // The config falls back to 'document' rather than refusing, so plain
+    // extensionless files (LICENSE, CHANGELOG) still preview as text.
+    expect(result.canPreview).toBe(true);
+    expect(result.sizeLimit).toBe(PREVIEW_SIZE_LIMITS.document);
+  });
+
+  it('rejects a category that has no preview support', () => {
+    // Archives have a limit of 0, meaning "never preview" rather than "no cap".
+    const result = checkPreviewEligibility('bundle.zip', 1);
+
+    expect(result.canPreview).toBe(false);
+    expect(result.sizeLimit).toBe(0);
+  });
+
+  it('allows a zero-byte file of a previewable type', () => {
+    const result = checkPreviewEligibility('empty.png', 0);
+
+    expect(result.canPreview).toBe(true);
+  });
+
+  it('always reports the size it was given', () => {
+    expect(checkPreviewEligibility('mystery.qqq', 1234).actualSize).toBe(1234);
+    expect(checkPreviewEligibility('photo.png', 1234).actualSize).toBe(1234);
+  });
+
+  it.each([
+    ['photo.PNG', true],
+    ['REPORT.PDF', true],
+    ['ARCHIVE.ZIP', false],
+  ])('is case-insensitive about the extension (%s)', (name, expected) => {
+    expect(checkPreviewEligibility(name, 1024).canPreview).toBe(expected);
+  });
+});
+
+describe('formatFileSize', () => {
+  it.each([
+    [0, '0 B'],
+    [512, '512 B'],
+    [1023, '1023 B'],
+  ])('renders %i bytes as %s', (bytes, expected) => {
+    // Bytes get no decimal place; anything larger gets one.
+    expect(formatFileSize(bytes)).toBe(expected);
+  });
+
+  it.each([
+    [1024, '1.0 KB'],
+    [1536, '1.5 KB'],
+    [1024 * 1024, '1.0 MB'],
+    [1024 * 1024 * 1024, '1.0 GB'],
+    [1024 ** 4, '1.0 TB'],
+  ])('renders %i bytes as %s', (bytes, expected) => {
+    expect(formatFileSize(bytes)).toBe(expected);
+  });
+
+  it('stops at terabytes rather than inventing a larger unit', () => {
+    expect(formatFileSize(1024 ** 5)).toBe('1024.0 TB');
+  });
+
+  it('steps up exactly at the 1024 boundary', () => {
+    expect(formatFileSize(1023)).toBe('1023 B');
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+  });
+});
+
+describe('getSizeLimitForCategory', () => {
+  it.each([
+    'image',
+    'video',
+    'document',
+    'spreadsheet',
+    'presentation',
+    'audio',
+    'code',
+    'archive',
+    'executable',
+  ] as const)('KNOWN BUG: returns 0 for %s, the same as every other category', (category) => {
+    // It looks the category up as if it were a file extension
+    // (`getPreviewSizeLimit('.image')`), and no category name is a real
+    // extension - so this returns 0 for everything, including types that do
+    // have a limit.
+    //
+    // Nothing imports it today, which is why the breakage went unnoticed.
+    // Pinned rather than fixed: reading PREVIEW_SIZE_LIMITS[category] directly
+    // would make this fail, which is the prompt to decide whether the function
+    // should exist at all.
+    expect(getSizeLimitForCategory(category)).toBe(0);
+  });
+
+  it('disagrees with the limit the eligibility check actually applies', () => {
+    expect(checkPreviewEligibility('photo.png', 1).sizeLimit).toBe(PREVIEW_SIZE_LIMITS.image);
+    expect(getSizeLimitForCategory('image')).toBe(0);
+  });
+});
+
+describe('isFileSizeAllowedForPreview (legacy shape)', () => {
+  it('reports an allowed file with formatted sizes', () => {
+    const result = isFileSizeAllowedForPreview('photo.png', 2 * MB);
+
+    expect(result).toEqual({
+      allowed: true,
+      reason: undefined,
+      limit: formatFileSize(PREVIEW_SIZE_LIMITS.image),
+      currentSize: '2.0 MB',
+    });
+  });
+
+  it('reports an oversized file with its reason', () => {
+    const result = isFileSizeAllowedForPreview('photo.png', PREVIEW_SIZE_LIMITS.image + 1);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/exceeds/);
+    expect(result.limit).toBe(formatFileSize(PREVIEW_SIZE_LIMITS.image));
+  });
+
+  it('omits the limit when there is none to show', () => {
+    const result = isFileSizeAllowedForPreview('mystery.qqq', 100);
+
+    // A limit of "0 B" would read as though previews were configured off for
+    // this type, rather than the type being unknown.
+    expect(result.limit).toBeUndefined();
+    expect(result.currentSize).toBe('100 B');
+  });
+});

--- a/frontend/src/services/folder-existence.test.ts
+++ b/frontend/src/services/folder-existence.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Folder existence check.
+ *
+ * Tiny, but it is the shared answer to "is this name already taken?" behind
+ * folder creation, rename, and upload. It deliberately does NOT catch: four
+ * call sites used to swallow the error and return false, so a permissions or
+ * network blip read as "nothing here" and the app created, renamed, or uploaded
+ * over data that already existed.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BYOS3ApiProvider } from '@opndrive/s3-api';
+import { folderExists, describeFolderCheckError } from './folder-existence';
+
+function fakeApi(fetchDirectoryStructure = vi.fn(async () => ({ files: [], folders: [] }))) {
+  return {
+    fetchDirectoryStructure,
+  } as unknown as BYOS3ApiProvider & { fetchDirectoryStructure: typeof fetchDirectoryStructure };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('folderExists', () => {
+  it('asks for a single key, since existence needs no more', async () => {
+    const api = fakeApi();
+
+    await folderExists(api, 'docs/photos/');
+
+    // Listing the whole folder to answer a yes/no question would be wasteful
+    // on a folder with thousands of objects.
+    expect(api.fetchDirectoryStructure).toHaveBeenCalledExactlyOnceWith('docs/photos/', 1);
+  });
+
+  it('reports true when a file sits under the prefix', async () => {
+    const api = fakeApi(
+      vi.fn(async () => ({ files: [{ Key: 'docs/photos/a.jpg' }], folders: [] }))
+    );
+
+    await expect(folderExists(api, 'docs/photos/')).resolves.toBe(true);
+  });
+
+  it('reports true when a subfolder sits under the prefix', async () => {
+    const api = fakeApi(
+      vi.fn(async () => ({ files: [], folders: [{ Prefix: 'docs/photos/raw/' }] }))
+    );
+
+    await expect(folderExists(api, 'docs/photos/')).resolves.toBe(true);
+  });
+
+  it('reports false for a prefix holding nothing', async () => {
+    await expect(folderExists(fakeApi(), 'docs/new/')).resolves.toBe(false);
+  });
+
+  it('propagates a listing failure instead of answering false', async () => {
+    const api = fakeApi(
+      vi.fn(async () => {
+        throw new Error('AccessDenied');
+      })
+    );
+
+    // Answering "false" here is what let the app overwrite existing folders.
+    await expect(folderExists(api, 'docs/photos/')).rejects.toThrow('AccessDenied');
+  });
+});
+
+describe('describeFolderCheckError', () => {
+  it('names the action that was cancelled', () => {
+    expect(describeFolderCheckError('creating the folder')).toContain('creating the folder');
+  });
+
+  it('says the check failed, not that the name is taken', () => {
+    const message = describeFolderCheckError('the upload');
+
+    // We genuinely do not know the state of the bucket; claiming the folder
+    // already exists would be a guess presented as fact.
+    expect(message).toMatch(/[Cc]ould not check/);
+    expect(message).not.toMatch(/already exists/);
+  });
+
+  it('tells the user it is worth retrying', () => {
+    expect(describeFolderCheckError('the rename')).toMatch(/try again/i);
+  });
+});

--- a/frontend/src/services/github-service.test.ts
+++ b/frontend/src/services/github-service.test.ts
@@ -1,0 +1,236 @@
+/**
+ * GitHub stats service.
+ *
+ * `fetch` is stubbed; nothing here touches the network.
+ *
+ * NOTE: this is a module-scope singleton with its own 5-minute cache, which
+ * lives outside zustand and is therefore NOT covered by the store reset. Every
+ * test clears it explicitly - without that, the first test to populate the
+ * cache would satisfy all the others and they would pass without exercising
+ * anything.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { githubService } from './github-service';
+
+const repoPayload = {
+  stargazers_count: 1234,
+  forks_count: 56,
+  open_issues_count: 7,
+  watchers_count: 89,
+};
+
+function okResponse(body: unknown = repoPayload) {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body };
+}
+
+function errorResponse(status = 404, statusText = 'Not Found') {
+  return { ok: false, status, statusText, json: async () => ({}) };
+}
+
+beforeEach(() => {
+  githubService.clearCache();
+  vi.useFakeTimers();
+  vi.setSystemTime(Date.UTC(2026, 0, 1));
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  githubService.clearCache();
+});
+
+describe('fetchRepoData', () => {
+  it('maps the GitHub payload onto our shape', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse())
+    );
+
+    const data = await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    // The API's snake_case names never leak past this boundary.
+    expect(data).toEqual({ stars: 1234, forks: 56, issues: 7, watchers: 89 });
+  });
+
+  it('calls the repo endpoint with the v3 accept header', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.github.com/repos/Opndrive/opndrive', {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+    });
+  });
+
+  it('returns null on a non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(404))
+    );
+
+    // A missing repo must not break the page that renders the star count.
+    await expect(githubService.fetchRepoData('nope', 'nope')).resolves.toBeNull();
+  });
+
+  it('returns null when the request itself fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      })
+    );
+
+    await expect(githubService.fetchRepoData('Opndrive', 'opndrive')).resolves.toBeNull();
+  });
+
+  it('returns null when the body is not the expected JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => {
+          throw new SyntaxError('Unexpected token');
+        },
+      }))
+    );
+
+    await expect(githubService.fetchRepoData('Opndrive', 'opndrive')).resolves.toBeNull();
+  });
+
+  it('does not cache a failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(500))
+      .mockResolvedValueOnce(okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+    const second = await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    // Caching a transient 500 would leave the count blank for five minutes.
+    expect(second).toMatchObject({ stars: 1234 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('caching', () => {
+  it('serves a repeat request from cache', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('keeps repos apart', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+    await githubService.fetchRepoData('Opndrive', 'docs');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches once the entry is five minutes old', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('still serves from cache just under the expiry', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    vi.advanceTimersByTime(5 * 60 * 1000 - 1);
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('reports what it is holding', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse())
+    );
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    expect(githubService.getCacheInfo()).toEqual({ size: 1, keys: ['Opndrive/opndrive'] });
+  });
+
+  it('empties on clearCache', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse())
+    );
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+
+    githubService.clearCache();
+
+    expect(githubService.getCacheInfo()).toEqual({ size: 0, keys: [] });
+  });
+});
+
+describe('fetchStarCount', () => {
+  it('pulls just the star count', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse())
+    );
+
+    await expect(githubService.fetchStarCount('Opndrive', 'opndrive')).resolves.toBe(1234);
+  });
+
+  it('returns null when the repo cannot be read', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse())
+    );
+
+    // Distinguishable from a real zero, so the UI can hide the badge.
+    await expect(githubService.fetchStarCount('nope', 'nope')).resolves.toBeNull();
+  });
+
+  it('reports a genuine zero as zero', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse({ ...repoPayload, stargazers_count: 0 }))
+    );
+
+    // `?? null` and not `|| null`: a brand-new repo has 0 stars, not "unknown".
+    await expect(githubService.fetchStarCount('Opndrive', 'new')).resolves.toBe(0);
+  });
+
+  it('shares the cache with fetchRepoData', async () => {
+    const fetchMock = vi.fn(async () => okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await githubService.fetchRepoData('Opndrive', 'opndrive');
+    await githubService.fetchStarCount('Opndrive', 'opndrive');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('singleton', () => {
+  it('is the same instance across imports', async () => {
+    const again = (await import('./github-service')).githubService;
+
+    // A second instance would mean a second cache and double the API calls,
+    // which matters against GitHub's unauthenticated rate limit.
+    expect(again).toBe(githubService);
+  });
+});

--- a/frontend/src/services/s3-preview-service.test.ts
+++ b/frontend/src/services/s3-preview-service.test.ts
@@ -1,0 +1,167 @@
+/**
+ * S3 preview service: turns a file into a signed URL the viewer can load.
+ *
+ * The provider is injected and faked. What this layer owns is picking the key
+ * off an object that may spell it three different ways, asking for an inline
+ * disposition, and rewrapping failures with context.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BYOS3ApiProvider } from '@opndrive/s3-api';
+import { createS3PreviewService } from './s3-preview-service';
+import type { PreviewableFile } from '@/types/file-preview';
+
+function fakeApi(getSignedUrl = vi.fn(async () => 'https://signed.example/preview')) {
+  return { getSignedUrl } as unknown as BYOS3ApiProvider & { getSignedUrl: typeof getSignedUrl };
+}
+
+const asFile = (partial: Record<string, unknown>) => partial as unknown as PreviewableFile;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('resolving the object key', () => {
+  it('prefers the S3-style Key', async () => {
+    const api = fakeApi();
+
+    await createS3PreviewService(api).getSignedUrl(
+      asFile({ Key: 'docs/report.pdf', key: 'ignored', name: 'ignored.pdf' })
+    );
+
+    expect(api.getSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'docs/report.pdf' })
+    );
+  });
+
+  it('falls back to a lowercase key', async () => {
+    const api = fakeApi();
+
+    await createS3PreviewService(api).getSignedUrl(
+      asFile({ key: 'docs/report.pdf', name: 'report.pdf' })
+    );
+
+    expect(api.getSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'docs/report.pdf' })
+    );
+  });
+
+  it('falls back to the name when neither key is present', async () => {
+    const api = fakeApi();
+
+    await createS3PreviewService(api).getSignedUrl(asFile({ name: 'report.pdf' }));
+
+    expect(api.getSignedUrl).toHaveBeenCalledWith(expect.objectContaining({ key: 'report.pdf' }));
+  });
+
+  it('rejects a file with nothing to address it by', async () => {
+    const api = fakeApi();
+
+    await expect(createS3PreviewService(api).getSignedUrl(asFile({}))).rejects.toThrow(
+      /No file key found/
+    );
+
+    expect(api.getSignedUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe('the signing request', () => {
+  it('asks for an inline preview URL valid for an hour', async () => {
+    const api = fakeApi();
+
+    await createS3PreviewService(api).getSignedUrl(asFile({ Key: 'docs/report.pdf' }));
+
+    // isPreview drives Content-Disposition: inline, which is what makes the
+    // browser render the file instead of downloading it.
+    expect(api.getSignedUrl).toHaveBeenCalledWith({
+      key: 'docs/report.pdf',
+      expiryInSeconds: 3600,
+      isPreview: true,
+      responseContentType: 'application/pdf',
+    });
+  });
+
+  it('derives the content type from the key, not the display name', async () => {
+    const api = fakeApi();
+
+    await createS3PreviewService(api).getSignedUrl(
+      asFile({ Key: 'photos/holiday.png', name: 'whatever.pdf' })
+    );
+
+    expect(api.getSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ responseContentType: 'image/png' })
+    );
+  });
+
+  it('falls back to a binary content type for an unknown extension', async () => {
+    const api = fakeApi();
+
+    await createS3PreviewService(api).getSignedUrl(asFile({ Key: 'thing.qqq' }));
+
+    expect(api.getSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ responseContentType: 'application/octet-stream' })
+    );
+  });
+
+  it('returns the signed URL unchanged', async () => {
+    const api = fakeApi(vi.fn(async () => 'https://signed.example/abc?sig=1'));
+
+    await expect(createS3PreviewService(api).getSignedUrl(asFile({ Key: 'a.pdf' }))).resolves.toBe(
+      'https://signed.example/abc?sig=1'
+    );
+  });
+});
+
+describe('failures', () => {
+  it('rejects when signing produces nothing', async () => {
+    const api = fakeApi(vi.fn(async () => ''));
+
+    // An empty URL would put the viewer into a permanent loading state.
+    await expect(
+      createS3PreviewService(api).getSignedUrl(asFile({ Key: 'a.pdf' }))
+    ).rejects.toThrow(/Failed to generate signed URL/);
+  });
+
+  it('wraps a provider error with its message', async () => {
+    const api = fakeApi(
+      vi.fn(async () => {
+        throw new Error('Key starting with /');
+      })
+    );
+
+    await expect(
+      createS3PreviewService(api).getSignedUrl(asFile({ Key: '/a.pdf' }))
+    ).rejects.toThrow('Failed to generate signed URL: Key starting with /');
+  });
+
+  it('describes a non-Error rejection', async () => {
+    const api = fakeApi(
+      vi.fn(async () => {
+        throw 'just a string';
+      })
+    );
+
+    await expect(
+      createS3PreviewService(api).getSignedUrl(asFile({ Key: 'a.pdf' }))
+    ).rejects.toThrow('Failed to generate signed URL for file preview');
+  });
+
+  it('logs the underlying failure for debugging', async () => {
+    const api = fakeApi(
+      vi.fn(async () => {
+        throw new Error('AccessDenied');
+      })
+    );
+
+    await expect(
+      createS3PreviewService(api).getSignedUrl(asFile({ Key: 'a.pdf' }))
+    ).rejects.toThrow();
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('gives each provider its own service', () => {
+    expect(createS3PreviewService(fakeApi())).not.toBe(createS3PreviewService(fakeApi()));
+  });
+});

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,0 +1,12 @@
+/**
+ * Global test setup for the frontend package.
+ *
+ * The `vi.mock('zustand')` below is not optional decoration - it is what makes
+ * `__mocks__/zustand.ts` take effect, which resets every store between tests.
+ * Without it, stores keep their state across the whole file and tests silently
+ * depend on the order they run in.
+ */
+
+import { vi } from 'vitest';
+
+vi.mock('zustand');

--- a/frontend/src/tests/zustand-reset.test.ts
+++ b/frontend/src/tests/zustand-reset.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Guards the store-reset harness itself (`__mocks__/zustand.ts`).
+ *
+ * Every other store suite trusts that state does not survive a test. If that
+ * ever breaks, the symptom is a distant, order-dependent failure somewhere
+ * else, so it is worth catching here instead.
+ *
+ * Each pair below is deliberately ordered: the first test dirties the store,
+ * the second asserts it came back clean.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { useDownloadStore } from '@/features/dashboard/stores/use-download-store';
+import { useUploadStore } from '@/features/upload/stores/use-upload-store';
+
+const download = () => useDownloadStore.getState();
+const upload = () => useUploadStore.getState();
+
+describe('state written through actions', () => {
+  it('dirties both stores', () => {
+    download().setProgress({
+      fileId: 'f',
+      fileName: 'f',
+      progress: 1,
+      status: 'downloading',
+    });
+    upload().addUpload('u', {
+      id: 'u',
+      name: 'u',
+      status: 'queued',
+      progress: 0,
+      type: 'file',
+    });
+
+    expect(download().downloads.size).toBe(1);
+    expect(Object.keys(upload().uploads)).toHaveLength(1);
+  });
+
+  it('finds both stores clean again', () => {
+    expect(download().downloads.size).toBe(0);
+    expect(upload().uploads).toEqual({});
+  });
+});
+
+describe('state mutated in place, bypassing actions', () => {
+  it('mutates the nested containers directly', () => {
+    // Not how the app writes state, but a test can do it - and if the harness
+    // restored the captured object by reference, this would poison the initial
+    // state for every test that follows, permanently.
+    download().downloads.set('sneaky', { fileId: 'sneaky' } as never);
+    upload().uploads.sneaky = { id: 'sneaky' } as never;
+
+    expect(download().downloads.size).toBe(1);
+    expect(Object.keys(upload().uploads)).toHaveLength(1);
+  });
+
+  it('still finds both stores clean', () => {
+    expect(download().downloads.size).toBe(0);
+    expect(upload().uploads).toEqual({});
+  });
+});
+
+describe('keys a test adds to the state', () => {
+  it('adds a key that is not part of the store shape', () => {
+    useDownloadStore.setState({ somethingExtra: true } as never);
+
+    expect((download() as unknown as Record<string, unknown>).somethingExtra).toBe(true);
+  });
+
+  it('drops the extra key on reset', () => {
+    // Requires `replace: true`; a merging set would leave it behind.
+    expect((download() as unknown as Record<string, unknown>).somethingExtra).toBeUndefined();
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,6 +8,23 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}'],
+    // Activates __mocks__/zustand.ts, which resets every store after each test.
+    setupFiles: ['./src/tests/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      // Phase 2 covers the state layer. Scoping the report to it keeps the
+      // numbers meaningful instead of diluting them across thousands of
+      // untested UI lines; widen this when component tests land.
+      include: [
+        'src/features/**/stores/**/*.ts',
+        'src/features/**/services/**/*.ts',
+        'src/services/**/*.ts',
+      ],
+      exclude: ['**/*.test.{ts,tsx}'],
+      // No thresholds yet - Phase 2 is only half written. Add them at the end,
+      // the way s3-api did.
+    },
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -334,6 +337,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -1136,6 +1143,14 @@ packages:
   '@internationalized/string@3.2.10':
     resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1435,6 +1450,10 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@radix-ui/number@1.1.3':
     resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
@@ -2543,6 +2562,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+    peerDependencies:
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
@@ -2639,6 +2667,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -2646,6 +2678,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -2669,6 +2705,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   ast-v8-to-istanbul@1.0.5:
     resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
@@ -2722,6 +2761,9 @@ packages:
 
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -3133,11 +3175,20 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.396:
     resolution: {integrity: sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
@@ -3361,6 +3412,10 @@ packages:
       debug:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -3428,6 +3483,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3588,6 +3648,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -3634,9 +3698,16 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -3850,6 +3921,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -3873,6 +3947,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
@@ -4124,6 +4201,14 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
 
@@ -4248,6 +4333,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
@@ -4291,6 +4379,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -4730,8 +4822,24 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -4799,6 +4907,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -5218,6 +5330,14 @@ packages:
     resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
     engines: {node: '>=0.8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   xlsx@0.18.5:
     resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
     engines: {node: '>=0.8'}
@@ -5292,6 +5412,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -6026,6 +6151,17 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.23
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6261,6 +6397,9 @@ snapshots:
     optional: true
 
   '@pagefind/windows-x64@1.5.2':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@radix-ui/number@1.1.3': {}
@@ -7420,6 +7559,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -7542,11 +7700,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -7565,6 +7727,12 @@ snapshots:
   array-iterate@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   ast-v8-to-istanbul@1.0.5:
     dependencies:
@@ -7622,6 +7790,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.9:
     dependencies:
@@ -8018,11 +8190,17 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.396: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -8326,6 +8504,11 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -8387,6 +8570,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   globals@14.0.0: {}
 
@@ -8618,6 +8810,8 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -8654,10 +8848,24 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.7.0: {}
 
@@ -8849,6 +9057,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
@@ -8868,6 +9078,12 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
 
   magicast@0.5.4:
     dependencies:
@@ -9424,6 +9640,12 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.16
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
+  minipass@7.1.3: {}
+
   mj-context-menu@0.6.1: {}
 
   mlly@1.8.2:
@@ -9604,6 +9826,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@1.8.0: {}
 
   pagefind@1.5.2:
@@ -9658,6 +9882,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 
@@ -10224,10 +10453,30 @@ snapshots:
 
   string-argv@0.3.2: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-final-newline@3.0.0: {}
 
@@ -10283,6 +10532,12 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.6
 
   thenify-all@1.6.0:
     dependencies:
@@ -10725,6 +10980,18 @@ snapshots:
   word-wrap@1.2.5: {}
 
   word@0.3.0: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   xlsx@0.18.5:
     dependencies:


### PR DESCRIPTION
Phase 2 of the testing work: the zustand stores and the frontend services.
27 tests to 320.

**Stores can no longer bleed between tests.** They are created once at module
scope, so a store written to in one test still held that state in the next.
`__mocks__/zustand.ts` snapshots each store as it is created and restores it
after every test. The snapshot is deep-copied per key, because restoring the
captured object by reference means a test that mutates a nested value in place
poisons the initial state for everything that follows.

**Two bugs found and fixed along the way:**

- Renaming a file to the name it already had went straight through to moveFile,
  which copies the object onto itself and then deletes that key. Real S3 refuses
  the self-copy, but that safety belongs to the backend, not to us.
- The duplicate prompt was a single slot. Two drops that both hit a duplicate
  overwrote each other, and the first prompt's callbacks went with it, so the
  upload waiting on that answer hung forever. It is a queue now.

Also fixed a pre-existing flaky test in `use-search.test.tsx`: the suites used
`mockClear`, which leaves a configured `mockReturnValue` in place, so the
memoisation assertions passed or failed depending on test order.

**Four bugs are pinned, not fixed.** Each has a `KNOWN BUG:` test asserting the
current behaviour and saying what would make it fail:

- `getSizeLimitForCategory` returns 0 for every category (it looks a category
  name up as a file extension). Nothing imports it.
- A corrupt search resume token returns no results instead of restarting.
- A complete first search page abandons folders already queued for the walk.
- `totalFiles` counts duplicates that were stripped from `files`.

Coverage is scoped to stores and services, no thresholds yet. Drag-and-drop
handlers are deliberately untested here and belong with the component tests.

Tests: 320 pass, clean across five shuffled orderings.
