### PR TITLE
test(upload): cover drag-and-drop folder extraction

### DIFF
--- a/frontend/src/features/upload/hooks/use-folder-drop-target.test.ts
+++ b/frontend/src/features/upload/hooks/use-folder-drop-target.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Folder drop target: the drag handlers a folder row spreads onto itself.
+ *
+ * The hook reads its drag state from EnhancedDragDropProvider, which is mocked
+ * at the module boundary - what matters here is the handler logic, not the
+ * provider's own bookkeeping.
+ *
+ * The recurring rule is that every handler is inert unless an EXTERNAL file
+ * drag is in progress. Without that guard, dragging a file row across the list
+ * to reorder it would light up every folder as a drop target and a stray drop
+ * would start an upload.
+ *
+ * This is the first suite to use renderHook. Phase 2 excluded it deliberately;
+ * a hook that returns event handlers cannot be exercised any other way.
+ *
+ * The synchronous handlers are called directly, NOT wrapped in act(). The
+ * provider is mocked, so they only invoke vi.fn() spies - there is no React
+ * state update and therefore no update queue to flush, and wrapping would be
+ * noise. act() is kept on the async drop path, where real awaited work runs
+ * and where a future switch to the real provider would need it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFolderDropTarget } from './use-folder-drop-target';
+import { FolderStructureProcessor } from '../utils/folder-structure-processor';
+import type { DragDropSource } from '../types/drag-drop-types';
+
+const { context } = vi.hoisted(() => ({
+  context: {
+    source: null as DragDropSource | null,
+    registerDropTarget: vi.fn(),
+    unregisterDropTarget: vi.fn(),
+    setHoverTarget: vi.fn(),
+    getTargetState: vi.fn(() => ({
+      isHovered: false,
+      canAcceptDrop: true,
+      isDraggedOver: false,
+    })),
+  },
+}));
+
+vi.mock('../providers/enhanced-drag-drop-provider', () => ({
+  useEnhancedDragDrop: () => context,
+}));
+
+vi.mock('../utils/folder-structure-processor', () => ({
+  FolderStructureProcessor: { processDataTransferItems: vi.fn() },
+}));
+
+const processItems = vi.mocked(FolderStructureProcessor.processDataTransferItems);
+
+const externalDrag: DragDropSource = { type: 'external-files', items: [], count: 1 };
+const internalDrag: DragDropSource = { type: 'internal-files', items: [], count: 1 };
+
+const folder = { id: 'f1', name: 'Photos', path: 'docs/photos/' };
+
+/**
+ * A drag event with the bits the handlers touch. `getBoundingClientRect` backs
+ * the leave test's inside/outside check.
+ */
+function dragEvent(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer: { items: {} as DataTransferItemList, dropEffect: 'none' },
+    clientX: 50,
+    clientY: 50,
+    currentTarget: {
+      getBoundingClientRect: () => ({ left: 0, right: 100, top: 0, bottom: 100 }),
+    },
+    ...overrides,
+  } as unknown as React.DragEvent;
+}
+
+function mount(onFilesDropped = vi.fn()) {
+  const rendered = renderHook(() => useFolderDropTarget({ folder, onFilesDropped }));
+  return { ...rendered, onFilesDropped };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  context.source = null;
+  context.getTargetState.mockReturnValue({
+    isHovered: false,
+    canAcceptDrop: true,
+    isDraggedOver: false,
+  });
+  processItems.mockResolvedValue({ individualFiles: [], folderStructures: [] });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('registration', () => {
+  it('registers the folder as a drop target on mount', () => {
+    mount();
+
+    expect(context.registerDropTarget).toHaveBeenCalledWith({
+      type: 'folder',
+      id: 'folder-f1',
+      path: 'docs/photos/',
+      name: 'Photos',
+    });
+  });
+
+  it('unregisters on unmount', () => {
+    const { unmount } = mount();
+
+    unmount();
+
+    // A folder scrolled out of the virtualised list must stop claiming drops.
+    expect(context.unregisterDropTarget).toHaveBeenCalledWith('folder-f1');
+  });
+
+  it('namespaces the target id so folders cannot collide with other targets', () => {
+    mount();
+
+    expect(context.registerDropTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'folder-f1' })
+    );
+  });
+});
+
+describe('dragEnter', () => {
+  it('marks the folder hovered during an external drag', () => {
+    context.source = externalDrag;
+    const { result } = mount();
+    const event = dragEvent();
+
+    result.current.dragHandlers.onDragEnter(event);
+
+    expect(context.setHoverTarget).toHaveBeenCalledWith({
+      type: 'folder',
+      id: 'folder-f1',
+      path: 'docs/photos/',
+      name: 'Photos',
+    });
+    // Without preventDefault the browser refuses the drop outright.
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+  });
+
+  it('ignores an internal drag', () => {
+    context.source = internalDrag;
+    const { result } = mount();
+    const event = dragEvent();
+
+    result.current.dragHandlers.onDragEnter(event);
+
+    // Dragging a row within the list must not light up folders as targets.
+    expect(context.setHoverTarget).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('ignores an enter with no drag in progress', () => {
+    const { result } = mount();
+
+    result.current.dragHandlers.onDragEnter(dragEvent());
+
+    expect(context.setHoverTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe('dragLeave', () => {
+  beforeEach(() => {
+    context.source = externalDrag;
+  });
+
+  it('clears the hover once the pointer is outside the row', () => {
+    const { result } = mount();
+
+    result.current.dragHandlers.onDragLeave(dragEvent({ clientX: 150, clientY: 50 }));
+
+    expect(context.setHoverTarget).toHaveBeenCalledWith(null);
+  });
+
+  it('keeps the hover while the pointer is still inside', () => {
+    const { result } = mount();
+
+    result.current.dragHandlers.onDragLeave(dragEvent({ clientX: 50, clientY: 50 }));
+
+    // dragleave also fires when crossing onto a CHILD element. Clearing then
+    // would make the highlight flicker off as the pointer moves over the row's
+    // icon or label.
+    expect(context.setHoverTarget).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['left of the row', { clientX: -1, clientY: 50 }],
+    ['right of the row', { clientX: 101, clientY: 50 }],
+    ['above the row', { clientX: 50, clientY: -1 }],
+    ['below the row', { clientX: 50, clientY: 101 }],
+  ])('clears the hover when the pointer is %s', (_label, coords) => {
+    const { result } = mount();
+
+    result.current.dragHandlers.onDragLeave(dragEvent(coords));
+
+    expect(context.setHoverTarget).toHaveBeenCalledWith(null);
+  });
+
+  it('treats the exact edge as still inside', () => {
+    const { result } = mount();
+
+    result.current.dragHandlers.onDragLeave(dragEvent({ clientX: 100, clientY: 100 }));
+
+    // The bounds check is exclusive, so the boundary pixel stays hovered.
+    expect(context.setHoverTarget).not.toHaveBeenCalled();
+  });
+
+  it('ignores an internal drag', () => {
+    context.source = internalDrag;
+    const { result } = mount();
+
+    result.current.dragHandlers.onDragLeave(dragEvent({ clientX: 999 }));
+
+    expect(context.setHoverTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe('dragOver', () => {
+  it('asks the browser for a copy cursor during an external drag', () => {
+    context.source = externalDrag;
+    const { result } = mount();
+    const event = dragEvent();
+
+    result.current.dragHandlers.onDragOver(event);
+
+    // Without preventDefault on dragover the drop event never fires at all.
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.dataTransfer.dropEffect).toBe('copy');
+  });
+
+  it('leaves the cursor alone for an internal drag', () => {
+    context.source = internalDrag;
+    const { result } = mount();
+    const event = dragEvent();
+
+    result.current.dragHandlers.onDragOver(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.dataTransfer.dropEffect).toBe('none');
+  });
+});
+
+describe('drop', () => {
+  beforeEach(() => {
+    context.source = externalDrag;
+  });
+
+  it('hands the extracted files to the caller with this folder as the target', async () => {
+    const extracted = { individualFiles: [new File([], 'a.txt')], folderStructures: [] };
+    processItems.mockResolvedValue(extracted);
+    const { result, onFilesDropped } = mount();
+
+    await act(async () => result.current.dragHandlers.onDrop(dragEvent()));
+
+    expect(onFilesDropped).toHaveBeenCalledExactlyOnceWith(extracted, {
+      type: 'folder',
+      id: 'folder-f1',
+      path: 'docs/photos/',
+      name: 'Photos',
+    });
+  });
+
+  it('clears the hover afterwards', async () => {
+    const { result } = mount();
+
+    await act(async () => result.current.dragHandlers.onDrop(dragEvent()));
+
+    // A highlight left behind would follow the user around the list.
+    expect(context.setHoverTarget).toHaveBeenLastCalledWith(null);
+  });
+
+  it('ignores an internal drag', async () => {
+    context.source = internalDrag;
+    const { result, onFilesDropped } = mount();
+
+    await act(async () => result.current.dragHandlers.onDrop(dragEvent()));
+
+    expect(processItems).not.toHaveBeenCalled();
+    expect(onFilesDropped).not.toHaveBeenCalled();
+  });
+
+  it('ignores a drop with no drag registered', async () => {
+    context.source = null;
+    const { result, onFilesDropped } = mount();
+
+    await act(async () => result.current.dragHandlers.onDrop(dragEvent()));
+
+    expect(onFilesDropped).not.toHaveBeenCalled();
+  });
+
+  it('ignores a drop carrying no dataTransfer', async () => {
+    const { result, onFilesDropped } = mount();
+
+    await act(async () => result.current.dragHandlers.onDrop(dragEvent({ dataTransfer: null })));
+
+    // Some synthetic events arrive without one; reading .items would throw.
+    expect(onFilesDropped).not.toHaveBeenCalled();
+  });
+
+  it('does not crash when extraction fails', async () => {
+    processItems.mockRejectedValue(new Error('SecurityError'));
+    const { result, onFilesDropped } = mount();
+
+    await act(async () => result.current.dragHandlers.onDrop(dragEvent()));
+
+    expect(onFilesDropped).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('still clears the hover when extraction fails', async () => {
+    processItems.mockRejectedValue(new Error('SecurityError'));
+    const { result } = mount();
+
+    await act(async () => result.current.dragHandlers.onDrop(dragEvent()));
+
+    // Otherwise a failed drop leaves the folder permanently highlighted.
+    expect(context.setHoverTarget).toHaveBeenLastCalledWith(null);
+  });
+
+  it('survives the row unmounting while extraction is still running', async () => {
+    // Drop a folder, navigate away, and the walk is still going. Everything the
+    // continuation touches lives ABOVE this component - setHoverTarget belongs
+    // to the provider and onFilesDropped to the upload store - so there is no
+    // setState on an unmounted component. React 19 would not warn either way,
+    // which is exactly why this is worth asserting rather than assuming.
+    let release!: (v: { individualFiles: File[]; folderStructures: [] }) => void;
+    processItems.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      })
+    );
+    const { result, unmount, onFilesDropped } = mount();
+
+    const dropping = result.current.dragHandlers.onDrop(dragEvent());
+    unmount();
+    release({ individualFiles: [new File([], 'a.txt')], folderStructures: [] });
+    await act(async () => {
+      await dropping;
+    });
+
+    // The upload still starts: the user asked for it before navigating away.
+    expect(onFilesDropped).toHaveBeenCalledOnce();
+    expect(context.unregisterDropTarget).toHaveBeenCalledWith('folder-f1');
+  });
+
+  it('forwards an empty extraction rather than swallowing it', async () => {
+    processItems.mockResolvedValue({ individualFiles: [], folderStructures: [] });
+    const { result, onFilesDropped } = mount();
+
+    await act(async () => result.current.dragHandlers.onDrop(dragEvent()));
+
+    // Dropping something that yields nothing is the caller's call to report.
+    expect(onFilesDropped).toHaveBeenCalledOnce();
+  });
+});
+
+describe('reported state', () => {
+  it('can accept a drop while an external drag is running', () => {
+    context.source = externalDrag;
+
+    const { result } = mount();
+
+    expect(result.current.canAcceptDrop).toBe(true);
+  });
+
+  it('cannot accept a drop with no drag in progress', () => {
+    context.source = null;
+
+    const { result } = mount();
+
+    // The row must not render as a live target when nothing is being dragged.
+    expect(result.current.canAcceptDrop).toBe(false);
+  });
+
+  it('cannot accept a drop the provider has ruled out', () => {
+    context.source = externalDrag;
+    context.getTargetState.mockReturnValue({
+      isHovered: false,
+      canAcceptDrop: false,
+      isDraggedOver: false,
+    });
+
+    const { result } = mount();
+
+    expect(result.current.canAcceptDrop).toBe(false);
+  });
+
+  it('passes the provider target state straight through', () => {
+    const state = { isHovered: true, canAcceptDrop: true, isDraggedOver: true };
+    context.getTargetState.mockReturnValue(state);
+
+    const { result } = mount();
+
+    expect(result.current.targetState).toEqual(state);
+  });
+});

--- a/frontend/src/features/upload/utils/folder-structure-processor.test.ts
+++ b/frontend/src/features/upload/utils/folder-structure-processor.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Folder structure processor: turns a drop into files and folders.
+ *
+ * Two entry points, two very different worlds:
+ *
+ *  - `processDataTransferItems` walks the FileSystem Entry API a browser hands
+ *    you on a drop. Callback based, batched, recursive.
+ *  - `processFileList` handles `<input webkitdirectory>`, where the browser has
+ *    already flattened everything and the structure lives in
+ *    `webkitRelativePath`.
+ *
+ * The mocks live in src/tests/dnd-mocks.ts and deliberately batch `readEntries`
+ * the way Chrome does, because a reader that is only called once silently
+ * truncates a large folder at 100 files.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { FolderStructureProcessor } from './folder-structure-processor';
+import {
+  makeFile,
+  makeFileWithPath,
+  mockDataTransferItem,
+  mockDataTransferItemList,
+  mockDirectoryEntry,
+  mockFileEntry,
+  READ_ENTRIES_BATCH_SIZE,
+} from '@/tests/dnd-mocks';
+
+const process = (items: DataTransferItem[]) =>
+  FolderStructureProcessor.processDataTransferItems(mockDataTransferItemList(items));
+
+/** Every file the walk found, by its assigned relative path. */
+const pathsOf = (files: File[]) =>
+  files.map((f) => (f as File & { webkitRelativePath: string }).webkitRelativePath);
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('dropping loose files', () => {
+  it('collects a single dropped file', async () => {
+    const file = makeFile('report.pdf');
+    const item = mockDataTransferItem(mockFileEntry(file), { file });
+
+    const result = await process([item]);
+
+    expect(result.individualFiles).toEqual([file]);
+    expect(result.folderStructures).toEqual([]);
+  });
+
+  it('collects several files', async () => {
+    const a = makeFile('a.txt');
+    const b = makeFile('b.txt');
+
+    const result = await process([
+      mockDataTransferItem(mockFileEntry(a), { file: a }),
+      mockDataTransferItem(mockFileEntry(b), { file: b }),
+    ]);
+
+    expect(result.individualFiles).toEqual([a, b]);
+  });
+
+  it('ignores dragged text', async () => {
+    const result = await process([mockDataTransferItem(null, { kind: 'string' })]);
+
+    // Dragging a text selection onto the dropzone must not start an upload.
+    expect(result.individualFiles).toEqual([]);
+    expect(result.folderStructures).toEqual([]);
+  });
+
+  it('falls back to getAsFile when the entry API is missing', async () => {
+    const file = makeFile('legacy.txt');
+    const item = mockDataTransferItem(null, { file, noGetAsEntry: true });
+
+    // Older browsers do not implement webkitGetAsEntry; the file still uploads.
+    const result = await process([item]);
+
+    expect(result.individualFiles).toEqual([file]);
+  });
+
+  it('falls back to getAsFile when the entry is neither file nor directory', async () => {
+    const file = makeFile('odd.txt');
+    const weirdEntry = { isFile: false, isDirectory: false, name: 'odd.txt' };
+    const item = mockDataTransferItem(weirdEntry as unknown as FileSystemEntry, { file });
+
+    const result = await process([item]);
+
+    expect(result.individualFiles).toEqual([file]);
+  });
+
+  it('skips an item that yields no file at all', async () => {
+    const item = mockDataTransferItem(null, { file: null });
+
+    expect(await process([item])).toEqual({ individualFiles: [], folderStructures: [] });
+  });
+
+  it('handles an empty drop', async () => {
+    expect(await process([])).toEqual({ individualFiles: [], folderStructures: [] });
+  });
+});
+
+describe('dropping a folder', () => {
+  it('extracts the files inside it', async () => {
+    const a = makeFile('a.txt', 100);
+    const b = makeFile('b.txt', 200);
+    const dir = mockDirectoryEntry('docs', [mockFileEntry(a), mockFileEntry(b)]);
+
+    const result = await process([mockDataTransferItem(dir)]);
+
+    expect(result.individualFiles).toEqual([]);
+    expect(result.folderStructures).toHaveLength(1);
+    expect(result.folderStructures[0]).toMatchObject({
+      name: 'docs',
+      relativePath: 'docs',
+      totalSize: 300,
+    });
+    expect(result.folderStructures[0]!.files).toHaveLength(2);
+  });
+
+  it('prefixes each file with the folder path', async () => {
+    const dir = mockDirectoryEntry('docs', [mockFileEntry(makeFile('a.txt'))]);
+
+    const result = await process([mockDataTransferItem(dir)]);
+
+    // The upload keys are built from webkitRelativePath, so losing the prefix
+    // would flatten the folder into the destination root.
+    expect(pathsOf(result.folderStructures[0]!.files)).toEqual(['docs/a.txt']);
+  });
+
+  it('recurses into nested folders', async () => {
+    const deep = mockDirectoryEntry('deep', [mockFileEntry(makeFile('d.txt'))]);
+    const nested = mockDirectoryEntry('nested', [mockFileEntry(makeFile('n.txt')), deep]);
+    const root = mockDirectoryEntry('root', [mockFileEntry(makeFile('r.txt')), nested]);
+
+    const result = await process([mockDataTransferItem(root)]);
+
+    expect(pathsOf(result.folderStructures[0]!.files).sort()).toEqual([
+      'root/nested/deep/d.txt',
+      'root/nested/n.txt',
+      'root/r.txt',
+    ]);
+  });
+
+  it('keeps recursing past the readEntries batch limit', async () => {
+    // Chrome hands back at most 100 entries per call and expects you to keep
+    // asking. A processor that read once would silently drop everything after
+    // the 100th file - the single most likely bug in this code.
+    const children = Array.from({ length: 250 }, (_, i) => mockFileEntry(makeFile(`f${i}.txt`)));
+    const dir = mockDirectoryEntry('big', children, { batchSize: READ_ENTRIES_BATCH_SIZE });
+
+    const result = await process([mockDataTransferItem(dir)]);
+
+    expect(result.folderStructures[0]!.files).toHaveLength(250);
+    // 3 batches (100/100/50) plus the empty read that signals the end.
+    expect(dir.readCallCount()).toBe(4);
+  });
+
+  it('skips a folder that contains nothing', async () => {
+    const empty = mockDirectoryEntry('empty', []);
+
+    const result = await process([mockDataTransferItem(empty)]);
+
+    // Creating a zero-file upload would leave a phantom folder in the UI.
+    expect(result.folderStructures).toEqual([]);
+  });
+
+  it('skips a folder whose subfolders are all empty', async () => {
+    const dir = mockDirectoryEntry('outer', [mockDirectoryEntry('inner', [])]);
+
+    const result = await process([mockDataTransferItem(dir)]);
+
+    expect(result.folderStructures).toEqual([]);
+  });
+
+  it('sums the total size across nested folders', async () => {
+    const inner = mockDirectoryEntry('inner', [mockFileEntry(makeFile('b.txt', 50))]);
+    const dir = mockDirectoryEntry('outer', [mockFileEntry(makeFile('a.txt', 25)), inner]);
+
+    const result = await process([mockDataTransferItem(dir)]);
+
+    expect(result.folderStructures[0]!.totalSize).toBe(75);
+  });
+
+  it('handles a mixed drop of files and folders', async () => {
+    const loose = makeFile('loose.txt');
+    const dir = mockDirectoryEntry('docs', [mockFileEntry(makeFile('a.txt'))]);
+
+    const result = await process([
+      mockDataTransferItem(mockFileEntry(loose), { file: loose }),
+      mockDataTransferItem(dir),
+    ]);
+
+    expect(result.individualFiles).toEqual([loose]);
+    expect(result.folderStructures.map((f) => f.name)).toEqual(['docs']);
+  });
+
+  it('processes several folders concurrently', async () => {
+    const one = mockDirectoryEntry('one', [mockFileEntry(makeFile('a.txt'))]);
+    const two = mockDirectoryEntry('two', [mockFileEntry(makeFile('b.txt'))]);
+
+    const result = await process([mockDataTransferItem(one), mockDataTransferItem(two)]);
+
+    // Both are awaited together, so neither is lost.
+    expect(result.folderStructures.map((f) => f.name).sort()).toEqual(['one', 'two']);
+  });
+
+  it('reads every DataTransferItem before the first await', async () => {
+    // A DataTransferItem is only valid during the synchronous part of the drop
+    // event; the browser neuters the list the moment the handler returns.
+    // Extraction therefore has to read webkitGetAsEntry() up front and hold the
+    // ENTRY, which stays valid. Neutering the list right after the call proves
+    // nothing is read late - if someone moves that read behind an await, this
+    // fails here instead of only in a real browser.
+    const dir = mockDirectoryEntry('docs', [mockFileEntry(makeFile('a.txt'))]);
+    const list = mockDataTransferItemList([mockDataTransferItem(dir)]);
+
+    const pending = FolderStructureProcessor.processDataTransferItems(list);
+    list.neuter();
+
+    await expect(pending).resolves.toMatchObject({
+      folderStructures: [expect.objectContaining({ name: 'docs' })],
+    });
+  });
+
+  it('KNOWN GAP: folders come back in completion order, not drop order', async () => {
+    const slow = mockDirectoryEntry('dropped-first', [mockFileEntry(makeFile('a.txt'))], {
+      readDelayTicks: 40,
+    });
+    const fast = mockDirectoryEntry('dropped-second', [mockFileEntry(makeFile('b.txt'))]);
+
+    const result = await process([mockDataTransferItem(slow), mockDataTransferItem(fast)]);
+
+    // Each folder pushes itself when its own walk finishes, so a large folder
+    // dropped first appears after a small one dropped second. Harmless for
+    // correctness - every file still uploads - but the operations list shows
+    // them in an order the user did not choose.
+    //
+    // Pinned, not endorsed: collecting results positionally (map to indexed
+    // slots rather than push) would make this fail.
+    expect(result.folderStructures.map((f) => f.name)).toEqual(['dropped-second', 'dropped-first']);
+  });
+
+  it('KNOWN GAP: two dropped folders sharing a name stay separate', async () => {
+    const first = mockDirectoryEntry('photos', [mockFileEntry(makeFile('a.txt'))]);
+    const second = mockDirectoryEntry('photos', [mockFileEntry(makeFile('b.txt'))]);
+
+    const result = await process([mockDataTransferItem(first), mockDataTransferItem(second)]);
+
+    // Dragging two same-named folders from different places yields two
+    // structures with the same name, so both upload to the same prefix and the
+    // second overwrites the first. Nothing here merges or disambiguates them.
+    expect(result.folderStructures.map((f) => f.name)).toEqual(['photos', 'photos']);
+  });
+});
+
+describe('failures during extraction', () => {
+  it('skips a file it cannot read and keeps the rest', async () => {
+    const good = makeFile('good.txt');
+    const dir = mockDirectoryEntry('docs', [
+      mockFileEntry(makeFile('locked.txt'), { failWith: new Error('NotReadableError') }),
+      mockFileEntry(good),
+    ]);
+
+    const result = await process([mockDataTransferItem(dir)]);
+
+    // One unreadable file must not abandon the whole folder.
+    expect(pathsOf(result.folderStructures[0]!.files)).toEqual(['docs/good.txt']);
+  });
+
+  it('skips a subdirectory it cannot read and keeps the rest', async () => {
+    const broken = mockDirectoryEntry('broken', [], { failWith: new Error('SecurityError') });
+    const dir = mockDirectoryEntry('docs', [mockFileEntry(makeFile('a.txt')), broken]);
+
+    const result = await process([mockDataTransferItem(dir)]);
+
+    expect(pathsOf(result.folderStructures[0]!.files)).toEqual(['docs/a.txt']);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('drops a top-level folder whose read fails outright', async () => {
+    const dir = mockDirectoryEntry('docs', [], { failWith: new Error('SecurityError') });
+
+    const result = await process([mockDataTransferItem(dir)]);
+
+    // Reported, not thrown: the rest of the drop still goes through.
+    expect(result.folderStructures).toEqual([]);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('rejects the walk when the reader throws on a follow-up read', async () => {
+    // The recursive readEntries() call sits inside the outer try, so a
+    // synchronous throw there rejects the whole directory promise rather than
+    // hanging it. Chrome throws InvalidStateError if a reader is driven
+    // incorrectly, which is exactly this shape.
+    let calls = 0;
+    const dir = {
+      isFile: false,
+      isDirectory: true,
+      name: 'docs',
+      fullPath: '/docs',
+      createReader: () => ({
+        readEntries(onSuccess: (entries: unknown[]) => void) {
+          calls++;
+          if (calls > 1) throw new DOMException('InvalidStateError');
+          queueMicrotask(() => onSuccess([mockFileEntry(makeFile('a.txt'))]));
+        },
+      }),
+    };
+
+    const result = await process([mockDataTransferItem(dir as unknown as FileSystemEntry)]);
+
+    // Reported and dropped, not left pending - a hung promise here would stall
+    // the entire drop behind Promise.all forever.
+    expect(result.folderStructures).toEqual([]);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('rejects the walk when an entry is revoked mid-read', async () => {
+    // Deleting the folder while the drop is being processed leaves entries
+    // whose property access throws.
+    const revoked = {
+      get isFile(): boolean {
+        throw new DOMException('NotFoundError');
+      },
+      name: 'ghost',
+    };
+    const dir = {
+      isFile: false,
+      isDirectory: true,
+      name: 'docs',
+      fullPath: '/docs',
+      createReader: () => ({
+        readEntries(onSuccess: (entries: unknown[]) => void) {
+          queueMicrotask(() => onSuccess([revoked]));
+        },
+      }),
+    };
+
+    const result = await process([mockDataTransferItem(dir as unknown as FileSystemEntry)]);
+
+    expect(result.folderStructures).toEqual([]);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('still uploads loose files when a folder fails', async () => {
+    const loose = makeFile('loose.txt');
+    const broken = mockDirectoryEntry('broken', [], { failWith: new Error('SecurityError') });
+
+    const result = await process([
+      mockDataTransferItem(mockFileEntry(loose), { file: loose }),
+      mockDataTransferItem(broken),
+    ]);
+
+    expect(result.individualFiles).toEqual([loose]);
+  });
+});
+
+describe('processFileList', () => {
+  it('treats a flat selection as individual files', () => {
+    const a = makeFile('a.txt');
+    const b = makeFile('b.txt');
+
+    const result = FolderStructureProcessor.processFileList([a, b]);
+
+    expect(result.individualFiles).toEqual([a, b]);
+    expect(result.folderStructures).toEqual([]);
+  });
+
+  it('groups files by their top-level folder', () => {
+    const result = FolderStructureProcessor.processFileList([
+      makeFileWithPath('a.txt', 'docs/a.txt', 10),
+      makeFileWithPath('b.txt', 'docs/sub/b.txt', 20),
+      makeFileWithPath('c.txt', 'photos/c.txt', 30),
+    ]);
+
+    expect(result.folderStructures.map((f) => f.name)).toEqual(['docs', 'photos']);
+    expect(result.folderStructures[0]).toMatchObject({ totalSize: 30, relativePath: 'docs' });
+    expect(result.folderStructures[1]).toMatchObject({ totalSize: 30 });
+  });
+
+  it('keeps nested files under their root folder, not their own', () => {
+    const result = FolderStructureProcessor.processFileList([
+      makeFileWithPath('deep.txt', 'root/a/b/deep.txt'),
+    ]);
+
+    // Grouping on the first path segment is what makes one upload per dropped
+    // folder rather than one per nesting level.
+    expect(result.folderStructures).toHaveLength(1);
+    expect(result.folderStructures[0]!.name).toBe('root');
+  });
+
+  it('treats a relative path with no slash as a loose file', () => {
+    const file = makeFileWithPath('a.txt', 'a.txt');
+
+    const result = FolderStructureProcessor.processFileList([file]);
+
+    expect(result.individualFiles).toEqual([file]);
+    expect(result.folderStructures).toEqual([]);
+  });
+
+  it('skips the zero-byte entries browsers emit for directories', () => {
+    const directoryMarker = new File([], 'subdir');
+    const real = makeFile('a.txt');
+
+    const result = FolderStructureProcessor.processFileList([directoryMarker, real]);
+
+    // Uploading these would create phantom zero-byte objects shadowing real
+    // folder prefixes.
+    expect(result.individualFiles).toEqual([real]);
+  });
+
+  it('keeps a genuinely empty file that has an extension', () => {
+    const empty = new File([], 'empty.txt', { type: 'text/plain' });
+
+    const result = FolderStructureProcessor.processFileList([empty]);
+
+    // Only extension-less, type-less, zero-byte entries look like directories.
+    expect(result.individualFiles).toEqual([empty]);
+  });
+
+  it('accepts a FileList as well as an array', () => {
+    const files = [makeFile('a.txt')];
+    const fileList = files as unknown as FileList;
+
+    expect(FolderStructureProcessor.processFileList(fileList).individualFiles).toEqual(files);
+  });
+
+  it('handles an empty selection', () => {
+    expect(FolderStructureProcessor.processFileList([])).toEqual({
+      individualFiles: [],
+      folderStructures: [],
+    });
+  });
+});

--- a/frontend/src/tests/dnd-mocks.ts
+++ b/frontend/src/tests/dnd-mocks.ts
@@ -1,0 +1,201 @@
+/**
+ * Mocks for the drag-and-drop file APIs.
+ *
+ * Browsers expose dropped folders through the non-standard FileSystem Entry
+ * API (`webkitGetAsEntry`, `createReader`, `readEntries`). jsdom implements
+ * none of it, so anything touching dropped folders needs these.
+ *
+ * Two details are what make this a faithful mock rather than a convenient one,
+ * and both are places real code breaks:
+ *
+ *  - `readEntries` is CALLBACK based, not promise based, and it hands back a
+ *    BATCH at a time. Chrome caps that batch at 100 entries and you must keep
+ *    calling the same reader until it answers with an empty array. A mock that
+ *    returns everything in one call would let a caller that reads only once
+ *    pass here and silently truncate at 100 files in production.
+ *  - `FileSystemFileEntry.file()` is callback based too, with a separate error
+ *    callback, which is how unreadable files surface.
+ *
+ * Nothing here touches globals, so there is nothing to restore between tests -
+ * every helper returns a fresh object the caller owns.
+ */
+
+/** How many entries a real `readEntries` call returns at most. */
+export const READ_ENTRIES_BATCH_SIZE = 100;
+
+export interface MockFileEntry extends FileSystemFileEntry {
+  /** Set to make `file()` invoke its error callback, as a locked file would. */
+  failWith?: Error;
+}
+
+export interface MockDirectoryEntry extends FileSystemDirectoryEntry {
+  /** Set to make `readEntries` invoke its error callback. */
+  failWith?: Error;
+  /** How many times `readEntries` has been called on readers from this entry. */
+  readCallCount: () => number;
+}
+
+/**
+ * A file entry wrapping a real `File`.
+ *
+ * `failWith` makes `file()` reject the way a deleted or permission-denied file
+ * does mid-drop.
+ */
+export function mockFileEntry(file: File, options: { failWith?: Error } = {}): MockFileEntry {
+  const entry = {
+    isFile: true as const,
+    isDirectory: false as const,
+    name: file.name,
+    fullPath: `/${file.name}`,
+    filesystem: {} as FileSystem,
+    failWith: options.failWith,
+    file(onSuccess: (f: File) => void, onError?: (e: DOMException) => void) {
+      // Callback based and asynchronous, like the real API.
+      queueMicrotask(() => {
+        if (options.failWith) onError?.(options.failWith as unknown as DOMException);
+        else onSuccess(file);
+      });
+    },
+    getParent: () => undefined,
+  };
+  return entry as unknown as MockFileEntry;
+}
+
+/**
+ * A directory entry whose reader hands `children` back in batches.
+ *
+ * Each `createReader()` gets its own cursor, matching the real API where a
+ * reader is single-use and drains its directory.
+ */
+export function mockDirectoryEntry(
+  name: string,
+  children: Array<MockFileEntry | MockDirectoryEntry>,
+  options: { failWith?: Error; batchSize?: number; readDelayTicks?: number } = {}
+): MockDirectoryEntry {
+  const batchSize = options.batchSize ?? READ_ENTRIES_BATCH_SIZE;
+  const delayTicks = options.readDelayTicks ?? 0;
+  let readCalls = 0;
+
+  const entry = {
+    isFile: false as const,
+    isDirectory: true as const,
+    name,
+    fullPath: `/${name}`,
+    filesystem: {} as FileSystem,
+    failWith: options.failWith,
+    readCallCount: () => readCalls,
+    createReader(): FileSystemDirectoryReader {
+      let cursor = 0;
+      return {
+        readEntries(
+          onSuccess: (entries: FileSystemEntry[]) => void,
+          onError?: (e: DOMException) => void
+        ) {
+          readCalls++;
+          // The batch is taken NOW, before any delay, so a slow reader cannot
+          // race its own cursor.
+          const batch = children.slice(cursor, cursor + batchSize);
+          cursor += batch.length;
+
+          // `readDelayTicks` lets a test make one directory finish after
+          // another, which is how completion-order behaviour is exercised.
+          let scheduled = Promise.resolve();
+          for (let i = 0; i < delayTicks; i++) scheduled = scheduled.then(() => {});
+
+          scheduled.then(() => {
+            if (options.failWith) {
+              onError?.(options.failWith as unknown as DOMException);
+              return;
+            }
+            // An empty array means "done", which is the only way the caller
+            // learns to stop asking.
+            onSuccess(batch as unknown as FileSystemEntry[]);
+          });
+        },
+      } as FileSystemDirectoryReader;
+    },
+    getParent: () => undefined,
+  };
+  return entry as unknown as MockDirectoryEntry;
+}
+
+/**
+ * A `DataTransferItem` whose `webkitGetAsEntry` returns `entry`.
+ *
+ * `kind` defaults to 'file'. Pass 'string' to simulate dragged text, which the
+ * processor must ignore.
+ */
+export function mockDataTransferItem(
+  entry: FileSystemEntry | null,
+  options: { kind?: 'file' | 'string'; file?: File | null; noGetAsEntry?: boolean } = {}
+): DataTransferItem {
+  const item = {
+    kind: options.kind ?? 'file',
+    type: '',
+    getAsFile: () => options.file ?? null,
+    getAsString: (cb?: (s: string) => void) => cb?.(''),
+    // Older browsers do not implement this at all; the processor optional-calls
+    // it, so the mock has to be able to be absent.
+    ...(options.noGetAsEntry ? {} : { webkitGetAsEntry: () => entry }),
+  };
+  return item as unknown as DataTransferItem;
+}
+
+export interface MockDataTransferItemList extends DataTransferItemList {
+  /**
+   * Simulates the browser neutering the list once the drop handler returns.
+   *
+   * This is the sharpest edge of the real API: a `DataTransferItem` is only
+   * valid during the synchronous part of the event. Read one after an `await`
+   * and you get nothing, which is why extraction must call
+   * `webkitGetAsEntry()` up front and hold the ENTRY (entries stay valid)
+   * rather than holding the item.
+   */
+  neuter: () => void;
+}
+
+/**
+ * A `DataTransferItemList`: array-like with a numeric index and `length`, which
+ * is exactly what the processor's `for` loop walks.
+ */
+export function mockDataTransferItemList(items: DataTransferItem[]): MockDataTransferItemList {
+  let live = true;
+  const list: Record<number | string, unknown> & { length: number } = {
+    length: items.length,
+    neuter() {
+      live = false;
+      list.length = 0;
+    },
+  };
+
+  items.forEach((item, index) => {
+    Object.defineProperty(list, index, {
+      enumerable: true,
+      get() {
+        if (!live) {
+          throw new TypeError(
+            'DataTransferItem accessed after the drop handler returned. Read entries synchronously.'
+          );
+        }
+        return item;
+      },
+    });
+  });
+
+  return list as unknown as MockDataTransferItemList;
+}
+
+/** Convenience: a real `File` of a given size, so totalSize sums are meaningful. */
+export function makeFile(name: string, size = 10, type = 'text/plain'): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+/**
+ * A `File` carrying `webkitRelativePath`, the shape `<input webkitdirectory>`
+ * produces and what `processFileList` groups on.
+ */
+export function makeFileWithPath(name: string, relativePath: string, size = 10): File {
+  const file = makeFile(name, size);
+  Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+  return file;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
         'src/features/**/stores/**/*.ts',
         'src/features/**/services/**/*.ts',
         'src/services/**/*.ts',
+        // Phase 3 adds the interaction layer: drop extraction and the drag
+        // handlers. Components are still out of scope.
+        'src/features/**/utils/folder-structure-processor.ts',
+        'src/features/**/hooks/use-folder-drop-target.ts',
       ],
       exclude: ['**/*.test.{ts,tsx}'],
       // No thresholds yet - Phase 2 is only half written. Add them at the end,


### PR DESCRIPTION
Stacked on #133. Base is the Phase 2 branch, not main, so the diff here is only
the drag-and-drop work.

The DnD logic is not in `use-upload-store.ts` as the roadmap assumed - that file
handles upload orchestration and receives already-extracted data. Extraction
lives in `utils/folder-structure-processor.ts` and the drag handlers in
`hooks/use-folder-drop-target.ts`. Both went from untested to ~97-100%.

jsdom implements none of the FileSystem entry API, so `src/tests/dnd-mocks.ts`
provides it. The mocks batch `readEntries` the way Chrome does and can neuter
the item list on demand, because those are the two places real code breaks: a
reader that is not drained silently truncates a folder at 100 files, and a
`DataTransferItem` read after an await is already dead.

**Two behaviours pinned, not changed:**

- Folders come back in completion order, not drop order. Cosmetic.
- Two dropped folders sharing a name stay separate, so both target the same S3
  prefix and the second would overwrite the first. This belongs in the upload
  queue, not the processor - its job is to report what was dropped.

**Three findings from a read of the implementation, no fix included:**

- `files.push(...subFiles)` throws RangeError somewhere past 100k entries in one
  subtree, and it sits inside a catch that logs, so that whole subdirectory
  would be dropped from the upload with only a console line.
- The per-file catch is completely silent - not even a log. A locked file is
  skipped and nothing downstream can tell, because `ProcessedDragData` carries
  no error channel.
- No memory risk otherwise: the processor holds `File` handles and never reads
  bytes, and it yields per file, so a large drop is slow rather than fatal.

Tests: 382 pass, clean across shuffled orderings.
