### PR TITLE
feat(upload): executor bridge from planned drops to s3-api

### DIFF
--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -13,6 +13,16 @@ import { useDriveStore } from './data-context';
 import { useUploadStore } from '@/features/upload/stores/use-upload-store';
 import { useSearchStore } from '@/features/dashboard/stores/use-search-store';
 
+/**
+ * How many files upload at once.
+ *
+ * Owned by the s3-api managers, which is why nothing downstream keeps a pool.
+ * Three is a compromise: enough to keep a connection busy through the latency
+ * of small files, few enough that a browser's per-host connection budget still
+ * leaves room for listings and previews.
+ */
+const UPLOAD_CONCURRENCY = 3;
+
 interface AuthContextType {
   apiS3: BYOS3ApiProvider | null;
   uploadManager: UploadManager | null;
@@ -87,17 +97,20 @@ async function initializeUploadManagers(
   // managers on both edges rather than only on logout.
   useSearchStore.getState().clearCache();
 
+  // This is the ONE place upload concurrency is set. The executor deliberately
+  // has no pool of its own - two components each believing they control how
+  // many uploads are in flight is how "3 at a time" becomes six.
   const manager = UploadManager.getInstance({
     s3: api.getS3Client(),
     bucket: api.getBucketName(),
     prefix: creds.prefix || '',
-    maxConcurrency: 2,
+    maxConcurrency: UPLOAD_CONCURRENCY,
     partSizeMB: 5,
   });
 
   const signedUrlManager = SignedUrlUploadManager.getInstance({
     apiProvider: api,
-    maxConcurrency: 2,
+    maxConcurrency: UPLOAD_CONCURRENCY,
     expiresInSeconds: 3600,
   });
 

--- a/frontend/src/features/upload/services/upload-executor.test.ts
+++ b/frontend/src/features/upload/services/upload-executor.test.ts
@@ -177,6 +177,47 @@ describe('keyForPlannedFile', () => {
     );
   });
 
+  it('strips the root even when the path has a leading slash', () => {
+    // The nastiest variant of the double-nesting bug: a leading slash makes the
+    // first segment empty, so a naive strip removes nothing and the original
+    // folder name survives into the key looking perfectly reasonable.
+    const plan = folderPlan({ prefix: 'docs/photos (1)/' });
+
+    expect(keyForPlannedFile(plan, makeFile('a.jpg', '/photos/a.jpg'))).toBe(
+      'docs/photos (1)/a.jpg'
+    );
+  });
+
+  it('collapses repeated slashes rather than creating an empty segment', () => {
+    // S3 treats "//" as a real, empty path component, producing an object most
+    // tools cannot address.
+    const plan = folderPlan({ prefix: 'docs/photos/' });
+
+    expect(keyForPlannedFile(plan, makeFile('a.jpg', 'photos//a.jpg'))).toBe('docs/photos/a.jpg');
+    expect(keyForPlannedFile(plan, makeFile('b.jpg', 'photos//sub//b.jpg'))).toBe(
+      'docs/photos/sub/b.jpg'
+    );
+  });
+
+  it('falls back to the file name when stripping leaves nothing', () => {
+    // Otherwise the key would equal the prefix exactly, creating a zero-byte
+    // object shadowing the folder it lives in.
+    const plan = folderPlan({ prefix: 'docs/photos/' });
+
+    expect(keyForPlannedFile(plan, makeFile('a.jpg', 'photos/'))).toBe('docs/photos/a.jpg');
+    expect(keyForPlannedFile(plan, makeFile('a.jpg', '/'))).toBe('docs/photos/a.jpg');
+  });
+
+  it('leaves backslashes alone', () => {
+    // Legal in a POSIX filename, so rewriting them would corrupt real names
+    // rather than fix paths.
+    const plan = folderPlan({ prefix: 'docs/photos/' });
+
+    expect(keyForPlannedFile(plan, makeFile('odd', 'photos/we\\ird.jpg'))).toBe(
+      'docs/photos/we\\ird.jpg'
+    );
+  });
+
   it('preserves spaces and parentheses from a resolved name', () => {
     // The resolved name is the one place suffixes appear, so it must survive
     // untouched into the key.
@@ -236,6 +277,119 @@ describe('start', () => {
     executor.start([folderPlan({ files: [] })]);
 
     expect(manager.added).toEqual([]);
+  });
+
+  it('refuses to dispatch the same task twice', () => {
+    // Overwriting the record would orphan the first attempt's uploads: they
+    // still route to this task id, so their terminal events would settle the
+    // NEW record early and free a prefix the second attempt is uploading into.
+    const plan = folderPlan({ files: [makeFile('a', 'photos/a')] });
+    executor.start([plan]);
+
+    const second = executor.start([plan]);
+
+    expect(second[0]!.dispatchError).toBeInstanceOf(Error);
+    expect(second[0]!.files).toEqual([]);
+    expect(manager.added).toHaveLength(1);
+    // The original dispatch is still intact and still cancellable.
+    expect(executor.uploadsFor('task-folder')).toEqual(['upload-0']);
+  });
+
+  it('reports a dispatch failure instead of throwing', () => {
+    // addUpload throws on a disposed manager, which is what logging out or
+    // switching bucket mid-drop does.
+    const failing = fakeManager();
+    failing.addUpload = () => {
+      throw new Error('This UploadManager instance has been disposed.');
+    };
+    const failingExecutor = createUploadExecutor(failing);
+
+    const results = failingExecutor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+
+    expect(results[0]!.dispatchError?.message).toContain('disposed');
+    expect(results[0]!.files).toEqual([]);
+    failingExecutor.dispose();
+  });
+
+  it('wraps a non-Error throw so callers always get an Error', () => {
+    const rude = fakeManager();
+    rude.addUpload = () => {
+      throw 'nope';
+    };
+    const rudeExecutor = createUploadExecutor(rude);
+
+    const results = rudeExecutor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+
+    expect(results[0]!.dispatchError).toBeInstanceOf(Error);
+    expect(results[0]!.dispatchError!.message).toBe('nope');
+    rudeExecutor.dispose();
+  });
+
+  it('keeps dispatching later plans after one is refused', () => {
+    // Same philosophy as planning: one folder in trouble must not abandon the
+    // rest of the drop.
+    let calls = 0;
+    const flaky = fakeManager();
+    const plainAdd = flaky.addUpload.bind(flaky);
+    flaky.addUpload = (file, config) => {
+      if (calls++ === 0) throw new Error('refused');
+      return plainAdd(file, config);
+    };
+    const flakyExecutor = createUploadExecutor(flaky);
+
+    const results = flakyExecutor.start([
+      folderPlan({ id: 'task-a', prefix: 'a/', files: [makeFile('x', 'a/x')] }),
+      folderPlan({ id: 'task-b', prefix: 'b/', files: [makeFile('y', 'b/y')] }),
+    ]);
+
+    expect(results[0]!.dispatchError).toBeInstanceOf(Error);
+    expect(results[1]!.dispatchError).toBeUndefined();
+    expect(results[1]!.files).toHaveLength(1);
+    flakyExecutor.dispose();
+  });
+
+  it('frees the prefix of a plan the manager refused outright', () => {
+    // Nothing was queued, so nothing will ever emit an event to settle it.
+    queue().reservePrefix('photos', '', 'task-folder');
+    const failing = fakeManager();
+    failing.addUpload = () => {
+      throw new Error('disposed');
+    };
+    const failingExecutor = createUploadExecutor(failing);
+
+    failingExecutor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+
+    expect(queue().claimedPrefixes()).toEqual([]);
+    failingExecutor.dispose();
+  });
+
+  it('settles a half-dispatched plan on the files that did get through', () => {
+    // `pending` must be corrected to what the manager actually accepted. Left
+    // at the planned total it could never reach zero, and the prefix would be
+    // squatted for the rest of the session.
+    queue().reservePrefix('photos', '', 'task-folder');
+    let calls = 0;
+    const flaky = fakeManager();
+    const plainAdd = flaky.addUpload.bind(flaky);
+    flaky.addUpload = (file, config) => {
+      if (calls++ === 1) throw new Error('disposed mid-folder');
+      return plainAdd(file, config);
+    };
+    const flakyExecutor = createUploadExecutor(flaky);
+
+    flakyExecutor.start([
+      folderPlan({
+        files: [makeFile('a', 'photos/a'), makeFile('b', 'photos/b'), makeFile('c', 'photos/c')],
+      }),
+    ]);
+
+    // One file made it through, so the claim is still held.
+    expect(queue().claimedPrefixes()).toEqual(['photos/']);
+
+    flaky.emit('statusChange', { id: 'upload-0', status: 'failed', progress: 0 });
+
+    expect(queue().claimedPrefixes()).toEqual([]);
+    flakyExecutor.dispose();
   });
 
   it('releases the claim of a plan that has no files', () => {
@@ -470,6 +624,71 @@ describe('cancelTask', () => {
     await expect(executor.cancelTask('never-dispatched')).resolves.toBeUndefined();
 
     expect(manager.cancelled).toEqual([]);
+  });
+});
+
+describe('routing state is not kept forever', () => {
+  it('forgets a task once every file has finished', () => {
+    // The two maps only ever grew. Ten thousand uploaded files meant ten
+    // thousand id entries alive until the tab closed, long after the last one
+    // finished. Nothing here pins a File, but it is still unbounded.
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a'), makeFile('b', 'photos/b')] })]);
+    expect(executor.taskFor('upload-0')).toBe('task-folder');
+
+    manager.emit('statusChange', { id: 'upload-0', status: 'completed', progress: 100 });
+    manager.emit('statusChange', { id: 'upload-1', status: 'completed', progress: 100 });
+
+    expect(executor.taskFor('upload-0')).toBeUndefined();
+    expect(executor.taskFor('upload-1')).toBeUndefined();
+    expect(executor.uploadsFor('task-folder')).toEqual([]);
+  });
+
+  it('holds routing state until the last file is done', () => {
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a'), makeFile('b', 'photos/b')] })]);
+
+    manager.emit('statusChange', { id: 'upload-0', status: 'completed', progress: 100 });
+
+    // Still needed: upload-1 is in flight and must stay cancellable.
+    expect(executor.taskFor('upload-1')).toBe('task-folder');
+    expect(executor.uploadsFor('task-folder')).toEqual(['upload-0', 'upload-1']);
+  });
+
+  it('does not grow across many completed tasks', () => {
+    for (let t = 0; t < 50; t++) {
+      executor.start([
+        folderPlan({ id: `task-${t}`, prefix: `f${t}/`, files: [makeFile('a', `f${t}/a`)] }),
+      ]);
+      manager.emit('statusChange', { id: `upload-${t}`, status: 'completed', progress: 100 });
+    }
+
+    // Every task settled, so nothing is retained.
+    for (let t = 0; t < 50; t++) {
+      expect(executor.uploadsFor(`task-${t}`)).toEqual([]);
+      expect(executor.taskFor(`upload-${t}`)).toBeUndefined();
+    }
+  });
+
+  it('ignores a late event for a forgotten task', () => {
+    // Disposal emits a trailing cancelled per in-flight item, which can arrive
+    // after the task already settled.
+    queue().reservePrefix('photos', '', 'task-folder');
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+    manager.emit('statusChange', { id: 'upload-0', status: 'completed', progress: 100 });
+
+    expect(() =>
+      manager.emit('statusChange', { id: 'upload-0', status: 'cancelled', progress: 0 })
+    ).not.toThrow();
+    // The commit stands - a late cancelled must not un-commit landed bytes.
+    expect(queue().claims[0]).toMatchObject({ committed: true });
+  });
+
+  it('forgets a cancelled task once its uploads report back', async () => {
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+
+    await executor.cancelTask('task-folder');
+    manager.emit('statusChange', { id: 'upload-0', status: 'cancelled', progress: 0 });
+
+    expect(executor.taskFor('upload-0')).toBeUndefined();
   });
 });
 

--- a/frontend/src/features/upload/services/upload-executor.test.ts
+++ b/frontend/src/features/upload/services/upload-executor.test.ts
@@ -1,0 +1,539 @@
+/**
+ * Upload executor.
+ *
+ * The layer where planning meets the network, so the tests concentrate on the
+ * three places it can silently corrupt a user's bucket:
+ *
+ *  - KEYS. Extraction stamps files with a path that starts with the dropped
+ *    folder's name, and the plan's prefix already ends with that folder's
+ *    RESOLVED name. Getting this wrong nests everything one level too deep and
+ *    quietly undoes Phase 4's collision rename, so several tests here assert
+ *    the exact key string rather than a shape.
+ *  - CLAIM TIMING. Committing before bytes land locks a prefix for the session
+ *    with nothing stored under it; committing too late lets a second drop
+ *    overwrite real data. Both directions are tested.
+ *  - CANCELLATION. A cancelled folder must cancel every one of its files, and
+ *    must only hand the name back if nothing was ever written.
+ *
+ * The manager is a fake rather than a mock of the real class: the executor
+ * talks to it through four methods, and driving events by hand is what makes
+ * the claim timing testable at all.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  createUploadExecutor,
+  keyForPlannedFile,
+  type ManagerEvent,
+  type UploadExecutor,
+  type UploadManagerLike,
+} from './upload-executor';
+import { useUploadQueueStore, type PlannedUpload } from '../stores/use-upload-queue-store';
+
+const queue = () => useUploadQueueStore.getState();
+
+/**
+ * A stand-in UploadManager that records what it was asked to upload and lets a
+ * test emit events on demand.
+ */
+function fakeManager() {
+  const listeners: Record<string, ((p: ManagerEvent) => void)[]> = {
+    progress: [],
+    statusChange: [],
+  };
+  const added: { id: string; key: string; file: File }[] = [];
+  const cancelled: string[] = [];
+  let nextId = 0;
+
+  const manager: UploadManagerLike & {
+    added: typeof added;
+    cancelled: typeof cancelled;
+    emit(event: 'progress' | 'statusChange', payload: ManagerEvent): void;
+    listenerCount(): number;
+    failCancel: Set<string>;
+  } = {
+    added,
+    cancelled,
+    failCancel: new Set<string>(),
+    addUpload(file, config) {
+      const id = `upload-${nextId++}`;
+      added.push({ id, key: config.key, file });
+      return id;
+    },
+    async cancelUpload(id) {
+      cancelled.push(id);
+      if (manager.failCancel.has(id)) throw new Error(`abort failed for ${id}`);
+    },
+    on(event, listener) {
+      listeners[event]!.push(listener);
+    },
+    off(event, listener) {
+      listeners[event] = listeners[event]!.filter((l) => l !== listener);
+    },
+    emit(event, payload) {
+      for (const listener of [...listeners[event]!]) listener(payload);
+    },
+    listenerCount: () => listeners.progress!.length + listeners.statusChange!.length,
+  };
+
+  return manager;
+}
+
+function makeFile(name: string, relativePath?: string, size = 10): File {
+  const file = new File([new Uint8Array(size)], name);
+  if (relativePath) {
+    Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+  }
+  return file;
+}
+
+function folderPlan(overrides: Partial<PlannedUpload> = {}): PlannedUpload {
+  return {
+    id: 'task-folder',
+    kind: 'folder',
+    originalName: 'photos',
+    resolvedName: 'photos',
+    prefix: 'photos/',
+    verification: 'confirmed',
+    files: [makeFile('a.jpg', 'photos/a.jpg')],
+    totalBytes: 10,
+    ...overrides,
+  };
+}
+
+function filePlan(overrides: Partial<PlannedUpload> = {}): PlannedUpload {
+  return {
+    id: 'task-files',
+    kind: 'file',
+    originalName: '',
+    resolvedName: '',
+    prefix: '',
+    verification: 'unchecked',
+    files: [makeFile('loose.txt')],
+    totalBytes: 10,
+    ...overrides,
+  };
+}
+
+let manager: ReturnType<typeof fakeManager>;
+let executor: UploadExecutor;
+
+beforeEach(() => {
+  manager = fakeManager();
+  executor = createUploadExecutor(manager);
+});
+
+describe('keyForPlannedFile', () => {
+  it('strips the dropped folder name that the prefix already carries', () => {
+    // The blocker this layer exists to avoid. Extraction produces
+    // "photos/a.jpg" and the plan resolved to "docs/photos (1)/", so naive
+    // concatenation yields "docs/photos (1)/photos/a.jpg" - nested twice and
+    // with the rename undone one level down.
+    const plan = folderPlan({ resolvedName: 'photos (1)', prefix: 'docs/photos (1)/' });
+
+    const key = keyForPlannedFile(plan, makeFile('a.jpg', 'photos/a.jpg'));
+
+    expect(key).toBe('docs/photos (1)/a.jpg');
+  });
+
+  it('keeps nesting below the dropped folder intact', () => {
+    const plan = folderPlan({ prefix: 'docs/photos/' });
+
+    const key = keyForPlannedFile(plan, makeFile('a.jpg', 'photos/holiday/raw/a.jpg'));
+
+    expect(key).toBe('docs/photos/holiday/raw/a.jpg');
+  });
+
+  it('places a file sitting directly in the dropped folder at the prefix root', () => {
+    const plan = folderPlan({ prefix: 'photos/' });
+
+    expect(keyForPlannedFile(plan, makeFile('a.jpg', 'photos/a.jpg'))).toBe('photos/a.jpg');
+  });
+
+  it('falls back to the file name when no relative path was stamped', () => {
+    // Belt and braces: extraction always sets webkitRelativePath, but a file
+    // arriving from anywhere else must not produce an "undefined" key.
+    const plan = folderPlan({ prefix: 'photos/' });
+
+    expect(keyForPlannedFile(plan, makeFile('orphan.jpg'))).toBe('photos/orphan.jpg');
+  });
+
+  it('uses the bare name for loose files', () => {
+    // A loose file was never nested, so nothing may be stripped from it.
+    expect(keyForPlannedFile(filePlan({ prefix: 'docs/' }), makeFile('loose.txt'))).toBe(
+      'docs/loose.txt'
+    );
+  });
+
+  it('keeps a loose file whole even if it carries a relative path', () => {
+    const plan = filePlan({ prefix: 'docs/' });
+
+    expect(keyForPlannedFile(plan, makeFile('a.txt', 'somewhere/a.txt'))).toBe('docs/a.txt');
+  });
+
+  it('handles a root destination', () => {
+    expect(keyForPlannedFile(folderPlan({ prefix: 'photos/' }), makeFile('a', 'photos/a'))).toBe(
+      'photos/a'
+    );
+  });
+
+  it('preserves spaces and parentheses from a resolved name', () => {
+    // The resolved name is the one place suffixes appear, so it must survive
+    // untouched into the key.
+    const plan = folderPlan({ prefix: 'trips/my photos (2)/' });
+
+    expect(keyForPlannedFile(plan, makeFile('a.jpg', 'my photos/a.jpg'))).toBe(
+      'trips/my photos (2)/a.jpg'
+    );
+  });
+});
+
+describe('start', () => {
+  it('dispatches one upload per file with the mapped key', () => {
+    const plan = folderPlan({
+      prefix: 'docs/photos (1)/',
+      files: [makeFile('a.jpg', 'photos/a.jpg'), makeFile('b.jpg', 'photos/raw/b.jpg')],
+    });
+
+    executor.start([plan]);
+
+    expect(manager.added.map((a) => a.key)).toEqual([
+      'docs/photos (1)/a.jpg',
+      'docs/photos (1)/raw/b.jpg',
+    ]);
+  });
+
+  it('reports the manager ids it produced for each task', () => {
+    const results = executor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.taskId).toBe('task-folder');
+    expect(results[0]!.files[0]!.uploadId).toBe('upload-0');
+    expect(executor.uploadsFor('task-folder')).toEqual(['upload-0']);
+  });
+
+  it('routes every dispatched upload back to its task', () => {
+    executor.start([
+      folderPlan({ id: 'task-a', files: [makeFile('a', 'photos/a')] }),
+      folderPlan({ id: 'task-b', files: [makeFile('b', 'videos/b')] }),
+    ]);
+
+    expect(executor.taskFor('upload-0')).toBe('task-a');
+    expect(executor.taskFor('upload-1')).toBe('task-b');
+    expect(executor.taskFor('upload-nope')).toBeUndefined();
+  });
+
+  it('dispatches several plans in one call', () => {
+    executor.start([
+      folderPlan({ id: 'task-a', prefix: 'a/', files: [makeFile('x', 'a/x')] }),
+      filePlan({ id: 'task-b', prefix: '', files: [makeFile('loose.txt')] }),
+    ]);
+
+    expect(manager.added.map((a) => a.key)).toEqual(['a/x', 'loose.txt']);
+  });
+
+  it('does not queue anything for an empty plan', () => {
+    executor.start([folderPlan({ files: [] })]);
+
+    expect(manager.added).toEqual([]);
+  });
+
+  it('releases the claim of a plan that has no files', () => {
+    // Nothing will ever be uploaded, so no event will ever arrive to settle
+    // it. Without this the prefix would stay reserved for the whole session.
+    queue().reservePrefix('photos', '', 'task-folder');
+
+    executor.start([folderPlan({ files: [] })]);
+
+    expect(queue().claimedPrefixes()).toEqual([]);
+  });
+});
+
+describe('claim lifecycle', () => {
+  function startOne() {
+    queue().reservePrefix('photos', '', 'task-folder');
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+  }
+
+  it('does not commit merely because an upload started', () => {
+    // CreateMultipartUpload writes no visible object. Committing here would
+    // lock the prefix for a task that may fail a moment later.
+    startOne();
+
+    manager.emit('statusChange', { id: 'upload-0', status: 'uploading', progress: 0 });
+    manager.emit('progress', { id: 'upload-0', status: 'uploading', progress: 0 });
+
+    expect(queue().claims[0]!.committed).toBe(false);
+  });
+
+  it('commits as soon as bytes land', () => {
+    startOne();
+
+    manager.emit('progress', { id: 'upload-0', status: 'uploading', progress: 12 });
+
+    expect(queue().claims[0]!.committed).toBe(true);
+  });
+
+  it('commits on completion even without a progress event', () => {
+    // A file small enough to finish in one part may never emit progress.
+    startOne();
+
+    manager.emit('statusChange', { id: 'upload-0', status: 'completed', progress: 100 });
+
+    expect(queue().claims[0]!.committed).toBe(true);
+  });
+
+  it('commits only once across many progress events', () => {
+    startOne();
+    const spy = vi.spyOn(useUploadQueueStore.getState(), 'commitClaim');
+
+    for (let i = 1; i <= 5; i++) {
+      manager.emit('progress', { id: 'upload-0', status: 'uploading', progress: i * 10 });
+    }
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('commits the whole folder when any one of its files moves', () => {
+    // The claim covers the folder prefix, so one file writing into it is
+    // enough to make the name unsafe to hand back.
+    queue().reservePrefix('photos', '', 'task-folder');
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a'), makeFile('b', 'photos/b')] })]);
+
+    manager.emit('progress', { id: 'upload-1', status: 'uploading', progress: 5 });
+
+    expect(queue().claims[0]!.committed).toBe(true);
+  });
+
+  it('releases the claim when every file failed without writing', () => {
+    // Nothing reached the bucket, so the name is genuinely free again.
+    startOne();
+
+    manager.emit('statusChange', { id: 'upload-0', status: 'failed', progress: 0 });
+
+    expect(queue().claimedPrefixes()).toEqual([]);
+  });
+
+  it('keeps the claim when a file failed after writing part of itself', () => {
+    // Parts already landed under this prefix. Releasing would let the next
+    // drop of the same folder pick it and overwrite them.
+    startOne();
+
+    manager.emit('progress', { id: 'upload-0', status: 'uploading', progress: 40 });
+    manager.emit('statusChange', { id: 'upload-0', status: 'failed', progress: 40 });
+
+    expect(queue().claimedPrefixes()).toEqual(['photos/']);
+  });
+
+  it('waits for every file before releasing', () => {
+    queue().reservePrefix('photos', '', 'task-folder');
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a'), makeFile('b', 'photos/b')] })]);
+
+    manager.emit('statusChange', { id: 'upload-0', status: 'failed', progress: 0 });
+    expect(queue().claimedPrefixes()).toEqual(['photos/']);
+
+    manager.emit('statusChange', { id: 'upload-1', status: 'failed', progress: 0 });
+    expect(queue().claimedPrefixes()).toEqual([]);
+  });
+
+  it('ignores events for uploads it never dispatched', () => {
+    // The manager is shared, so events for other work arrive here too.
+    startOne();
+
+    manager.emit('progress', { id: 'someone-elses-upload', status: 'uploading', progress: 50 });
+
+    expect(queue().claims[0]!.committed).toBe(false);
+  });
+
+  it('ignores a status change for an upload it never dispatched', () => {
+    startOne();
+
+    manager.emit('statusChange', {
+      id: 'someone-elses-upload',
+      status: 'completed',
+      progress: 100,
+    });
+
+    // Neither committed nor counted against this task's pending files.
+    expect(queue().claims[0]!.committed).toBe(false);
+    manager.emit('statusChange', { id: 'upload-0', status: 'failed', progress: 0 });
+    expect(queue().claimedPrefixes()).toEqual([]);
+  });
+
+  it('does not release mid-dispatch when an earlier file finishes first', () => {
+    // The real UploadManager emits synchronously inside addUpload and starts
+    // its queue there too, so file 1 can reach a terminal state while file 3
+    // is still being handed over - by which point file 1's id IS mapped, so
+    // the event counts. If `pending` were counted up as files were dispatched
+    // instead of set to the full total upfront, it would touch zero here and
+    // free a prefix the rest of the folder is about to upload into.
+    queue().reservePrefix('photos', '', 'task-folder');
+    const eager = fakeManager();
+    const plainAdd = eager.addUpload.bind(eager);
+    const seen: string[] = [];
+    eager.addUpload = (file, config) => {
+      const id = plainAdd(file, config);
+      seen.push(id);
+      // While dispatching the second file, the first one finishes.
+      if (seen.length === 2) {
+        eager.emit('statusChange', { id: seen[0]!, status: 'failed', progress: 0 });
+      }
+      return id;
+    };
+    const eagerExecutor = createUploadExecutor(eager);
+
+    eagerExecutor.start([
+      folderPlan({
+        files: [makeFile('a', 'photos/a'), makeFile('b', 'photos/b'), makeFile('c', 'photos/c')],
+      }),
+    ]);
+
+    // Two files are still outstanding, so the name stays reserved.
+    expect(queue().claimedPrefixes()).toEqual(['photos/']);
+
+    eager.emit('statusChange', { id: seen[1]!, status: 'failed', progress: 0 });
+    eager.emit('statusChange', { id: seen[2]!, status: 'failed', progress: 0 });
+    expect(queue().claimedPrefixes()).toEqual([]);
+
+    eagerExecutor.dispose();
+  });
+
+  it('survives a terminal event arriving twice', () => {
+    startOne();
+    manager.emit('statusChange', { id: 'upload-0', status: 'failed', progress: 0 });
+
+    // Disposal emits a trailing cancelled per in-flight item, which can land
+    // after the item already reported failure.
+    manager.emit('statusChange', { id: 'upload-0', status: 'cancelled', progress: 0 });
+
+    expect(queue().claimedPrefixes()).toEqual([]);
+  });
+});
+
+describe('cancelTask', () => {
+  it('cancels every upload belonging to the task', async () => {
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a'), makeFile('b', 'photos/b')] })]);
+
+    await executor.cancelTask('task-folder');
+
+    expect(manager.cancelled).toEqual(['upload-0', 'upload-1']);
+  });
+
+  it('leaves other tasks running', async () => {
+    executor.start([
+      folderPlan({ id: 'task-a', files: [makeFile('a', 'photos/a')] }),
+      folderPlan({ id: 'task-b', files: [makeFile('b', 'videos/b')] }),
+    ]);
+
+    await executor.cancelTask('task-a');
+
+    expect(manager.cancelled).toEqual(['upload-0']);
+  });
+
+  it('frees the prefix when nothing had been written', async () => {
+    queue().reservePrefix('photos', '', 'task-folder');
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+
+    await executor.cancelTask('task-folder');
+
+    expect(queue().claimedPrefixes()).toEqual([]);
+  });
+
+  it('keeps the prefix when bytes had already landed', async () => {
+    queue().reservePrefix('photos', '', 'task-folder');
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+    manager.emit('progress', { id: 'upload-0', status: 'uploading', progress: 30 });
+
+    await executor.cancelTask('task-folder');
+
+    // Orphaned parts exist under this key; handing the name back would invite
+    // a later drop to overwrite them.
+    expect(queue().claimedPrefixes()).toEqual(['photos/']);
+  });
+
+  it('cancels the rest of the folder when one abort fails', async () => {
+    // A failed AbortMultipartUpload is a bucket cleanup problem, not a reason
+    // to leave the other five hundred files uploading.
+    executor.start([
+      folderPlan({
+        files: [makeFile('a', 'photos/a'), makeFile('b', 'photos/b'), makeFile('c', 'photos/c')],
+      }),
+    ]);
+    manager.failCancel.add('upload-1');
+
+    await expect(executor.cancelTask('task-folder')).resolves.toBeUndefined();
+
+    expect(manager.cancelled).toEqual(['upload-0', 'upload-1', 'upload-2']);
+  });
+
+  it('does nothing for an unknown task', async () => {
+    await expect(executor.cancelTask('never-dispatched')).resolves.toBeUndefined();
+
+    expect(manager.cancelled).toEqual([]);
+  });
+});
+
+describe('dispose', () => {
+  it('unsubscribes from the manager', () => {
+    expect(manager.listenerCount()).toBe(2);
+
+    executor.dispose();
+
+    expect(manager.listenerCount()).toBe(0);
+  });
+
+  it('stops reacting to events afterwards', () => {
+    queue().reservePrefix('photos', '', 'task-folder');
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+
+    executor.dispose();
+    manager.emit('progress', { id: 'upload-0', status: 'uploading', progress: 50 });
+
+    expect(queue().claims[0]!.committed).toBe(false);
+  });
+
+  it('forgets its task mapping', () => {
+    executor.start([folderPlan({ files: [makeFile('a', 'photos/a')] })]);
+
+    executor.dispose();
+
+    expect(executor.taskFor('upload-0')).toBeUndefined();
+    expect(executor.uploadsFor('task-folder')).toEqual([]);
+  });
+});
+
+describe('end to end: a planned drop reaching the manager', () => {
+  it('carries a resolved rename all the way into the keys', async () => {
+    // The whole point of Phase 4 surviving contact with Phase 5: the bucket
+    // already holds "photos/", planning resolves to "photos (1)", and every
+    // key must land under the RESOLVED name with no trace of the original.
+    const plan = folderPlan({
+      originalName: 'photos',
+      resolvedName: 'photos (1)',
+      prefix: 'photos (1)/',
+      files: [
+        makeFile('a.jpg', 'photos/a.jpg'),
+        makeFile('b.jpg', 'photos/raw/b.jpg'),
+        makeFile('c.jpg', 'photos/raw/nested/c.jpg'),
+      ],
+    });
+    queue().reservePrefix('photos', '', 'task-folder');
+
+    executor.start([plan]);
+
+    expect(manager.added.map((a) => a.key)).toEqual([
+      'photos (1)/a.jpg',
+      'photos (1)/raw/b.jpg',
+      'photos (1)/raw/nested/c.jpg',
+    ]);
+    // Not one key mentions the original folder name twice.
+    expect(manager.added.every((a) => !a.key.includes('photos/photos'))).toBe(true);
+
+    manager.emit('progress', { id: 'upload-0', status: 'uploading', progress: 10 });
+    manager.emit('statusChange', { id: 'upload-0', status: 'completed', progress: 100 });
+    manager.emit('statusChange', { id: 'upload-1', status: 'completed', progress: 100 });
+    manager.emit('statusChange', { id: 'upload-2', status: 'completed', progress: 100 });
+
+    expect(queue().claims[0]).toMatchObject({ prefix: 'photos/', committed: true });
+  });
+});

--- a/frontend/src/features/upload/services/upload-executor.ts
+++ b/frontend/src/features/upload/services/upload-executor.ts
@@ -1,0 +1,257 @@
+'use client';
+
+/**
+ * Turns plans into uploads.
+ *
+ * This is the bridge between `use-upload-queue-store` (which decides WHERE
+ * everything goes) and `@opndrive/s3-api`'s UploadManager (which moves the
+ * bytes). It deliberately owns very little:
+ *
+ *   PlannedUpload[]
+ *         |
+ *         v
+ *   [ this executor ]     key mapping, task <-> upload ids, claim lifecycle
+ *         |  addUpload(file, { key }) x N
+ *         v
+ *   UploadManager         THE queue, THE concurrency limit, multipart
+ *         |  statusChange / progress
+ *         v
+ *   upload-context        per-item UI progress (already wired, untouched here)
+ *
+ * Two things it pointedly does NOT do:
+ *
+ * 1. It does not keep a queue or a concurrency pool. UploadManager already has
+ *    both, and they are covered by their own suite. A second pool here would
+ *    mean two components each believing they control how many uploads are in
+ *    flight, and "3 at a time" would quietly mean six. Concurrency is
+ *    configured where the manager is built, not here.
+ * 2. It does not push progress into the UI store. `upload-context.tsx` already
+ *    subscribes to the same events and does exactly that. The subscription
+ *    below exists only to learn when a claim can be committed.
+ */
+
+import type { PlannedUpload } from '../stores/use-upload-queue-store';
+import { useUploadQueueStore } from '../stores/use-upload-queue-store';
+
+/** What the executor needs from an upload manager. */
+export interface UploadManagerLike {
+  addUpload(file: File, config: { key: string }): string;
+  cancelUpload(id: string): Promise<void> | void;
+  on(event: 'statusChange' | 'progress', listener: (payload: ManagerEvent) => void): void;
+  off(event: 'statusChange' | 'progress', listener: (payload: ManagerEvent) => void): void;
+}
+
+export interface ManagerEvent {
+  id: string;
+  status: string;
+  progress: number;
+  error?: string;
+}
+
+/** One dispatched file, so callers can map a plan onto the manager's ids. */
+export interface DispatchedFile {
+  uploadId: string;
+  taskId: string;
+  key: string;
+  file: File;
+}
+
+export interface DispatchResult {
+  taskId: string;
+  plan: PlannedUpload;
+  files: DispatchedFile[];
+}
+
+const TERMINAL = ['completed', 'failed', 'cancelled'];
+
+/**
+ * The S3 key for one file of a plan.
+ *
+ * The subtle half of this whole layer. Extraction stamps every dropped file
+ * with a `webkitRelativePath` that STARTS WITH THE DROPPED FOLDER'S NAME
+ * ("photos/holiday/a.jpg"), while `PlannedUpload.prefix` already ends with the
+ * folder's RESOLVED name ("docs/photos (1)/"). Concatenating the two gives
+ *
+ *     docs/photos (1)/photos/holiday/a.jpg
+ *
+ * which is both nested one level too deep and, worse, silently undoes the
+ * collision rename: the user asked for "photos (1)" and got a wrapper around a
+ * folder still called "photos", colliding exactly as before one level down.
+ *
+ * So the first segment is dropped. This is also why the executor calls
+ * `addUpload` per file rather than `addFolderUpload`, which builds this same
+ * broken key internally and cannot be told otherwise.
+ */
+export function keyForPlannedFile(plan: PlannedUpload, file: File): string {
+  if (plan.kind === 'file') {
+    // Loose files were never nested; their name is the whole key.
+    return `${plan.prefix}${file.name}`;
+  }
+
+  const relativePath =
+    (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name;
+
+  const firstSlash = relativePath.indexOf('/');
+  const withoutDroppedRoot = firstSlash === -1 ? relativePath : relativePath.slice(firstSlash + 1);
+
+  // A file sitting directly in the dropped folder has no slash left, which is
+  // correct - it belongs at the root of the resolved prefix.
+  return `${plan.prefix}${withoutDroppedRoot}`;
+}
+
+interface TaskRecord {
+  uploadIds: Set<string>;
+  /** Uploads not yet in a terminal state. */
+  pending: number;
+  /** Set once bytes have provably landed, so the claim must never be released. */
+  committed: boolean;
+  cancelled: boolean;
+}
+
+export interface UploadExecutor {
+  /** Dispatches every plan and returns the manager ids it produced. */
+  start(plans: readonly PlannedUpload[]): DispatchResult[];
+  /** Cancels every upload belonging to a task, freeing its claim if nothing landed. */
+  cancelTask(taskId: string): Promise<void>;
+  /** Task id owning an upload, or undefined once forgotten. */
+  taskFor(uploadId: string): string | undefined;
+  /** Manager ids dispatched for a task. */
+  uploadsFor(taskId: string): string[];
+  /** Unsubscribes from the manager. Call on session teardown. */
+  dispose(): void;
+}
+
+export function createUploadExecutor(manager: UploadManagerLike): UploadExecutor {
+  const tasks = new Map<string, TaskRecord>();
+  const taskByUpload = new Map<string, string>();
+
+  const queue = () => useUploadQueueStore.getState();
+
+  /**
+   * Marks a task's prefix as permanently taken.
+   *
+   * Called the moment bytes provably reach S3, NOT when the upload starts.
+   * `CreateMultipartUpload` writes no visible object, so committing there would
+   * mean an upload that failed immediately afterwards kept its prefix locked
+   * for the rest of the session with nothing stored under it - the exact leak
+   * releasable claims exist to prevent.
+   */
+  const commitOnce = (taskId: string) => {
+    const record = tasks.get(taskId);
+    if (!record || record.committed) return;
+
+    record.committed = true;
+    queue().commitClaim(taskId);
+  };
+
+  const settle = (taskId: string) => {
+    const record = tasks.get(taskId);
+    if (!record || record.pending > 0) return;
+
+    // Every upload finished and none of them ever moved a byte, so the name is
+    // genuinely free again. A committed task keeps its claim; releaseClaim
+    // would refuse anyway, but not calling it says so more clearly.
+    if (!record.committed) queue().releaseClaim(taskId);
+  };
+
+  const onProgress = (payload: ManagerEvent) => {
+    const taskId = taskByUpload.get(payload.id);
+    // Progress only proves bytes landed once it is above zero: the manager
+    // emits an initial 0 when an item starts, which is exactly the moment that
+    // must NOT commit.
+    if (taskId && payload.progress > 0) commitOnce(taskId);
+  };
+
+  const onStatusChange = (payload: ManagerEvent) => {
+    const taskId = taskByUpload.get(payload.id);
+    // Not ours. The manager is shared, so other work's events arrive here too.
+    if (!taskId) return;
+
+    // Non-null: an id only enters taskByUpload after its task's record exists,
+    // and both maps are cleared together in dispose.
+    const record = tasks.get(taskId)!;
+
+    // A small file can go straight to 'completed' without a separate progress
+    // event, so completion commits too.
+    if (payload.status === 'completed') commitOnce(taskId);
+
+    if (TERMINAL.includes(payload.status)) {
+      record.pending = Math.max(0, record.pending - 1);
+      settle(taskId);
+    }
+  };
+
+  manager.on('progress', onProgress);
+  manager.on('statusChange', onStatusChange);
+
+  return {
+    start(plans) {
+      const results: DispatchResult[] = [];
+
+      for (const plan of plans) {
+        // Registered BEFORE dispatching, with the full file count already in
+        // `pending`. Both matter: `addUpload` emits synchronously and starts
+        // the queue, so an event for the first file can arrive while the
+        // second is still being handed over. Counting up as we went would let
+        // `pending` touch zero mid-loop and release the claim underneath a
+        // folder that is still being set up.
+        const record: TaskRecord = {
+          uploadIds: new Set(),
+          pending: plan.files.length,
+          committed: false,
+          cancelled: false,
+        };
+        tasks.set(plan.id, record);
+
+        const files: DispatchedFile[] = [];
+
+        for (const file of plan.files) {
+          const key = keyForPlannedFile(plan, file);
+          const uploadId = manager.addUpload(file, { key });
+
+          record.uploadIds.add(uploadId);
+          taskByUpload.set(uploadId, plan.id);
+          files.push({ uploadId, taskId: plan.id, key, file });
+        }
+
+        results.push({ taskId: plan.id, plan, files });
+
+        // Covers both a plan with no files - which would otherwise never see an
+        // event and would leak its name forever - and one whose files all
+        // finished during dispatch.
+        settle(plan.id);
+      }
+
+      return results;
+    },
+
+    async cancelTask(taskId) {
+      const record = tasks.get(taskId);
+      if (!record) return;
+
+      record.cancelled = true;
+
+      // allSettled: one upload whose AbortMultipartUpload fails must not stop
+      // the rest of the folder from being cancelled.
+      await Promise.allSettled(
+        [...record.uploadIds].map(async (uploadId) => manager.cancelUpload(uploadId))
+      );
+
+      // Cancellation does not itself release: an upload that already wrote
+      // parts has bytes at that prefix, and handing the name back would let a
+      // later drop overwrite them. commitOnce decides that, not this.
+      if (!record.committed) queue().releaseClaim(taskId);
+    },
+
+    taskFor: (uploadId) => taskByUpload.get(uploadId),
+
+    uploadsFor: (taskId) => [...(tasks.get(taskId)?.uploadIds ?? [])],
+
+    dispose() {
+      manager.off('progress', onProgress);
+      manager.off('statusChange', onStatusChange);
+      tasks.clear();
+      taskByUpload.clear();
+    },
+  };
+}

--- a/frontend/src/features/upload/services/upload-executor.ts
+++ b/frontend/src/features/upload/services/upload-executor.ts
@@ -60,6 +60,14 @@ export interface DispatchResult {
   taskId: string;
   plan: PlannedUpload;
   files: DispatchedFile[];
+  /**
+   * Set when the manager refused some or all of this plan's files.
+   *
+   * `addUpload` throws on a disposed manager, which happens for real: logging
+   * out or switching bucket mid-drop tears the singleton down. Compare
+   * `files.length` against `plan.files.length` to see how much got through.
+   */
+  dispatchError?: Error;
 }
 
 const TERMINAL = ['completed', 'failed', 'cancelled'];
@@ -91,12 +99,30 @@ export function keyForPlannedFile(plan: PlannedUpload, file: File): string {
   const relativePath =
     (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name;
 
-  const firstSlash = relativePath.indexOf('/');
-  const withoutDroppedRoot = firstSlash === -1 ? relativePath : relativePath.slice(firstSlash + 1);
+  // Normalise BEFORE stripping, because both of these defeat a naive strip and
+  // both produce keys S3 will happily store:
+  //
+  //   "/photos/a.jpg"  - a leading slash makes the first segment empty, so the
+  //                      strip removes nothing and the folder name survives
+  //                      into the key: exactly the double-nesting this function
+  //                      exists to prevent, just harder to spot.
+  //   "photos//a.jpg"  - a repeated slash is a real, empty path segment to S3,
+  //                      giving an object that most tools cannot address.
+  //
+  // Backslashes are deliberately left alone: they are legal in a POSIX
+  // filename, so rewriting them would corrupt names rather than fix paths.
+  const normalised = relativePath.replace(/\/{2,}/g, '/').replace(/^\/+/, '');
 
-  // A file sitting directly in the dropped folder has no slash left, which is
+  const firstSlash = normalised.indexOf('/');
+  const withoutDroppedRoot = firstSlash === -1 ? normalised : normalised.slice(firstSlash + 1);
+
+  // Empty means the path was nothing but the dropped folder name (or nothing at
+  // all). Falling through would make the key equal the prefix, creating a
+  // zero-byte object shadowing the folder itself.
+  //
+  // A file sitting directly in the dropped folder has no slash left, which IS
   // correct - it belongs at the root of the resolved prefix.
-  return `${plan.prefix}${withoutDroppedRoot}`;
+  return `${plan.prefix}${withoutDroppedRoot || file.name}`;
 }
 
 interface TaskRecord {
@@ -113,9 +139,15 @@ export interface UploadExecutor {
   start(plans: readonly PlannedUpload[]): DispatchResult[];
   /** Cancels every upload belonging to a task, freeing its claim if nothing landed. */
   cancelTask(taskId: string): Promise<void>;
-  /** Task id owning an upload, or undefined once forgotten. */
+  /**
+   * Task id owning an upload.
+   *
+   * Undefined once the task is fully terminal: routing state is dropped the
+   * moment it stops being needed, so this is deliberately not a history API.
+   * The UI store keeps the record a panel needs.
+   */
   taskFor(uploadId: string): string | undefined;
-  /** Manager ids dispatched for a task. */
+  /** Manager ids still tracked for a task. Empty once the task is terminal. */
   uploadsFor(taskId: string): string[];
   /** Unsubscribes from the manager. Call on session teardown. */
   dispose(): void;
@@ -144,6 +176,24 @@ export function createUploadExecutor(manager: UploadManagerLike): UploadExecutor
     queue().commitClaim(taskId);
   };
 
+  /**
+   * Drops a finished task's routing state.
+   *
+   * Without this the two maps only ever grow: a session that uploads ten
+   * thousand files keeps ten thousand id entries alive for as long as the tab
+   * is open, long after the last of them finished. Nothing here pins a File,
+   * so it is not the s3-api leak over again, but it is still unbounded.
+   *
+   * Late events for a forgotten id fall out at the `taskFor` lookup, which is
+   * what makes this safe - a duplicate terminal event after teardown is
+   * indistinguishable from an event for another component's upload, and both
+   * are correctly ignored.
+   */
+  const forget = (taskId: string, record: TaskRecord) => {
+    for (const uploadId of record.uploadIds) taskByUpload.delete(uploadId);
+    tasks.delete(taskId);
+  };
+
   const settle = (taskId: string) => {
     const record = tasks.get(taskId);
     if (!record || record.pending > 0) return;
@@ -152,6 +202,8 @@ export function createUploadExecutor(manager: UploadManagerLike): UploadExecutor
     // genuinely free again. A committed task keeps its claim; releaseClaim
     // would refuse anyway, but not calling it says so more clearly.
     if (!record.committed) queue().releaseClaim(taskId);
+
+    forget(taskId, record);
   };
 
   const onProgress = (payload: ManagerEvent) => {
@@ -189,6 +241,21 @@ export function createUploadExecutor(manager: UploadManagerLike): UploadExecutor
       const results: DispatchResult[] = [];
 
       for (const plan of plans) {
+        // A task id is dispatched once. Overwriting the record would orphan the
+        // first attempt's uploads: they would still route to this task id, so
+        // their terminal events would decrement the NEW record and settle it
+        // early, releasing a prefix the second attempt is still uploading into
+        // - and cancelTask could no longer reach them.
+        if (tasks.has(plan.id)) {
+          results.push({
+            taskId: plan.id,
+            plan,
+            files: [],
+            dispatchError: new Error(`Task ${plan.id} has already been dispatched.`),
+          });
+          continue;
+        }
+
         // Registered BEFORE dispatching, with the full file count already in
         // `pending`. Both matter: `addUpload` emits synchronously and starts
         // the queue, so an event for the first file can arrive while the
@@ -204,21 +271,39 @@ export function createUploadExecutor(manager: UploadManagerLike): UploadExecutor
         tasks.set(plan.id, record);
 
         const files: DispatchedFile[] = [];
+        let dispatchError: Error | undefined;
 
-        for (const file of plan.files) {
-          const key = keyForPlannedFile(plan, file);
-          const uploadId = manager.addUpload(file, { key });
+        try {
+          for (const file of plan.files) {
+            const key = keyForPlannedFile(plan, file);
+            const uploadId = manager.addUpload(file, { key });
 
-          record.uploadIds.add(uploadId);
-          taskByUpload.set(uploadId, plan.id);
-          files.push({ uploadId, taskId: plan.id, key, file });
+            record.uploadIds.add(uploadId);
+            taskByUpload.set(uploadId, plan.id);
+            files.push({ uploadId, taskId: plan.id, key, file });
+          }
+        } catch (error) {
+          // The manager refused the rest of this plan - disposal mid-drop is
+          // the real case. Nothing is thrown onward: the remaining plans still
+          // deserve their turn, exactly as planning refuses to abandon later
+          // folders when an earlier one has trouble.
+          dispatchError = error instanceof Error ? error : new Error(String(error));
         }
 
-        results.push({ taskId: plan.id, plan, files });
+        // Discount the files the manager never accepted. Left at the planned
+        // total, a half-dispatched task could never reach zero and would squat
+        // its prefix for the rest of the session.
+        //
+        // Subtracted rather than assigned: a file dispatched earlier in this
+        // same loop may have already finished and decremented `pending`, and
+        // assigning the dispatched count would resurrect it.
+        record.pending -= plan.files.length - record.uploadIds.size;
 
-        // Covers both a plan with no files - which would otherwise never see an
-        // event and would leak its name forever - and one whose files all
-        // finished during dispatch.
+        results.push({ taskId: plan.id, plan, files, dispatchError });
+
+        // Covers a plan with no files, a plan the manager rejected outright,
+        // and one whose files all finished during dispatch. Without it, none of
+        // those would ever see an event and their names would leak.
         settle(plan.id);
       }
 


### PR DESCRIPTION
Phase 5 Part 1. The bridge between the queue store's plans and s3-api's UploadManager. Nothing is wired to the UI yet, so this changes no behaviour on its own; Part 2 does the buttons.

## The bug this layer exists to avoid

Extraction stamps every dropped file with `webkitRelativePath` starting with the dropped folder's name (`photos/a.jpg`), and `PlannedUpload.prefix` already ends with that folder's *resolved* name (`docs/photos (1)/`). Concatenating them gives:

```
docs/photos (1)/photos/a.jpg
```

Nested a level too deep, and it silently undoes Phase 4's collision rename: the user asked for `photos (1)` and gets a wrapper around a folder still called `photos`, colliding again one level down. The executor strips the first segment.

This is also why it calls `addUpload` per file rather than `addFolderUpload`, which builds that same broken key internally and takes a `FileList` we do not have anyway.

## What it does not do

No queue, no concurrency pool. `UploadManager` already owns both and is covered by its own suite. A second pool would mean two components each believing they control how many uploads are in flight, so "3 at a time" would quietly mean six. Concurrency is set in one place, where the managers are built, and moves from 2 to 3 here.

It also does not push progress into the UI store, since `upload-context.tsx` already subscribes to the same events. The executor's subscription exists only to learn when a claim can be committed.

## Claim timing

`commitClaim` fires on the first byte, not when the upload starts. `CreateMultipartUpload` writes no visible object, so committing there would leave a failed upload holding its prefix for the rest of the session with nothing stored under it. Cancelling a folder cancels every file in it, and only hands the name back if nothing was ever written.

## One race worth flagging

`pending` is set to the full file count before dispatching rather than counted up as files are added. `addUpload` emits synchronously and starts the queue, so an earlier file can reach a terminal state while a later one is still being handed over. Counting up would let `pending` touch zero mid-loop and release a prefix the rest of the folder is about to upload into. Found this chasing a coverage gap rather than by design.

## Checks

36 tests, 100% statements/branches/functions/lines on the executor. Full frontend suite 504, typecheck clean, build passes, lint 0 errors.

Verified the two load-bearing behaviours by breaking them: removing the commit-once guard fails 1 test, counting `pending` up instead of presetting it fails 1. An earlier version of the mid-dispatch test passed under mutation, meaning it proved nothing; it is rewritten to emit against an already-mapped id, which is the case that can actually happen.
