### PR TITLE
feat(upload): wire drops through the executor and render queue notices

### DIFF
--- a/frontend/src/app/dashboard/browse/page.tsx
+++ b/frontend/src/app/dashboard/browse/page.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/features/folder-navigation/folder-navigation';
 import { HiOutlineRefresh } from 'react-icons/hi';
 import { DragDropTarget } from '@/features/upload/types/drag-drop-types';
-import { useUploadStore } from '@/features/upload/stores/use-upload-store';
+import { useUploadDispatch } from '@/features/upload/hooks/use-upload-dispatch';
 import { ProcessedDragData } from '@/features/upload/types/folder-upload-types';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { MultiSelectToolbar } from '@/features/dashboard/components/ui/multi-select-toolbar';
@@ -54,7 +54,7 @@ function BrowsePageContent() {
 
   const { apiS3, isLoading, isAuthenticated } = useAuthGuard();
 
-  const { handleFilesDroppedToDirectory, handleFilesDroppedToFolder } = useUploadStore();
+  const dispatchDrop = useUploadDispatch();
 
   const { isOpen, currentFiles, openMultiShareDialog, closeMultiShareDialog, generateShareLinks } =
     useMultiShareDialog();
@@ -88,13 +88,9 @@ function BrowsePageContent() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [clearSelection, getSelectionCount]);
 
-  if (isLoading) {
-    return <DashboardLoading />;
-  }
-
-  if (!isAuthenticated || !apiS3) {
-    return null; // useAuthGuard will handle redirect
-  }
+  // The auth guards used to sit here, above roughly a dozen hooks, so React saw
+  // a different hook count before and after the session resolved. They now run
+  // once every hook has, just above the JSX.
 
   // Parse URL parameters using utility function
   const params = parseFolderParams(searchParams);
@@ -121,6 +117,10 @@ function BrowsePageContent() {
   }, [apiS3, setApiS3]);
 
   useEffect(() => {
+    // Guarded here now that the auth early return no longer stands between
+    // this effect and a session that may not exist yet.
+    if (!apiS3) return;
+
     const rootPrefix = apiS3.getPrefix();
     if (rootPrefix === '') {
       setRootPrefix('/');
@@ -155,7 +155,7 @@ function BrowsePageContent() {
   // Also clear selection when component mounts (navigating to browse page)
   useEffect(() => {
     clearSelection();
-  }, []); // Empty dependency array - runs once on mount
+  }, [clearSelection]); // clearSelection is a stable store action, so this still runs once
 
   const handleFolderClick = (folder: Folder) => {
     if (folder.Prefix) {
@@ -176,16 +176,16 @@ function BrowsePageContent() {
 
   const handleFilesDroppedToDirectoryWrapper = useCallback(
     async (processedData: ProcessedDragData) => {
-      await handleFilesDroppedToDirectory(processedData, currentPrefix, apiS3);
+      await dispatchDrop(processedData, currentPrefix ?? '', apiS3);
     },
-    [currentPrefix, handleFilesDroppedToDirectory, apiS3]
+    [currentPrefix, dispatchDrop, apiS3]
   );
 
   const handleFilesDroppedToFolderWrapper = useCallback(
     async (processedData: ProcessedDragData, targetFolder: DragDropTarget) => {
-      await handleFilesDroppedToFolder(processedData, targetFolder, apiS3);
+      await dispatchDrop(processedData, targetFolder.path, apiS3);
     },
-    [handleFilesDroppedToFolder, apiS3]
+    [dispatchDrop, apiS3]
   );
 
   const handleSync = async () => {
@@ -298,6 +298,14 @@ function BrowsePageContent() {
       setIsLoadingMoreChunks(false);
     }, 300);
   }, [isLoadingMoreChunks, canLoadMoreChunks, canLoadMoreFileChunks, canLoadMoreFolderChunks]);
+
+  if (isLoading) {
+    return <DashboardLoading />;
+  }
+
+  if (!isAuthenticated || !apiS3) {
+    return null; // useAuthGuard will handle redirect
+  }
 
   // Get current folder name for display using utility function
   const currentFolderName = getFolderNameFromPrefix(prefixParam) || 'My Drive';

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -15,7 +15,7 @@ import { HiOutlineRefresh } from 'react-icons/hi';
 import { DragDropTarget } from '@/features/upload/types/drag-drop-types';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { ProcessedDragData } from '@/features/upload/types/folder-upload-types';
-import { useUploadStore } from '@/features/upload/stores/use-upload-store';
+import { useUploadDispatch } from '@/features/upload/hooks/use-upload-dispatch';
 import { EmptyStateDropzone } from '@/features/dashboard/components/views/home/empty-state-dropzone';
 import { useMultiSelectStore } from '@/features/dashboard/stores/use-multi-select-store';
 import { MultiSelectToolbar } from '@/features/dashboard/components/ui/multi-select-toolbar';
@@ -37,7 +37,7 @@ export default function HomePage() {
     setApiS3,
   } = useDriveStore();
 
-  const { handleFilesDroppedToDirectory, handleFilesDroppedToFolder } = useUploadStore();
+  const dispatchDrop = useUploadDispatch();
   const [isLoadingMoreFiles, setIsLoadingMoreFiles] = useState(false);
   const [isLoadingMoreFolders, setIsLoadingMoreFolders] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
@@ -47,20 +47,17 @@ export default function HomePage() {
     useMultiShareDialog();
   const { clearSelection, getSelectionCount } = useMultiSelectStore();
 
+  // Every hook lives above the early returns below. They used to sit after
+  // them, so React saw a different number of hooks depending on whether the
+  // session had loaded - the "rendered fewer hooks than expected" crash waiting
+  // to happen. The ones that need a session guard internally instead.
+
   // Clear selection when multi-share dialog closes
   useEffect(() => {
     if (!isOpen) {
       clearSelection();
     }
   }, [isOpen, clearSelection]);
-
-  if (isLoading) {
-    return <DashboardLoading />;
-  }
-
-  if (!isAuthenticated || !apiS3) {
-    return null;
-  }
 
   useEffect(() => {
     if (apiS3) {
@@ -69,6 +66,10 @@ export default function HomePage() {
   }, [apiS3, setApiS3]);
 
   useEffect(() => {
+    // Keyed on apiS3 rather than running once on mount: the early return used
+    // to delay this until a session existed, so it has to wait for one now.
+    if (!apiS3) return;
+
     const rootPrefix = apiS3.getPrefix();
     if (rootPrefix === '') {
       setRootPrefix('/');
@@ -77,16 +78,16 @@ export default function HomePage() {
       setRootPrefix(rootPrefix);
       setCurrentPrefix(rootPrefix);
     }
-  }, []);
+  }, [apiS3, setRootPrefix, setCurrentPrefix]);
 
   useEffect(() => {
     if (currentPrefix) fetchRecentItems({ sync: false, itemsPerType: 10 });
-  }, [currentPrefix]);
+  }, [currentPrefix, fetchRecentItems]);
 
   // Clear selection when returning to home page
   useEffect(() => {
     clearSelection();
-  }, []); // Empty dependency array - runs once on mount
+  }, [clearSelection]); // clearSelection is a stable store action, so this still runs once
 
   // Clear selection when clicking outside - only for single item selection
   useEffect(() => {
@@ -108,6 +109,28 @@ export default function HomePage() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [clearSelection, getSelectionCount]);
 
+  const handleFilesDroppedToDirectoryWrapper = useCallback(
+    async (processedData: ProcessedDragData) => {
+      await dispatchDrop(processedData, currentPrefix ?? '', apiS3);
+    },
+    [dispatchDrop, apiS3, currentPrefix]
+  );
+
+  const handleFilesDroppedToFolderWrapper = useCallback(
+    async (processedData: ProcessedDragData, targetFolder: DragDropTarget) => {
+      await dispatchDrop(processedData, targetFolder.path, apiS3);
+    },
+    [dispatchDrop, apiS3]
+  );
+
+  if (isLoading) {
+    return <DashboardLoading />;
+  }
+
+  if (!isAuthenticated || !apiS3) {
+    return null;
+  }
+
   const handleFolderClick = (folder: Folder) => {
     if (folder.Prefix && folder.name) {
       // Navigate to the folder using the enhanced browse route
@@ -118,20 +141,6 @@ export default function HomePage() {
       router.push(url);
     }
   };
-
-  const handleFilesDroppedToDirectoryWrapper = useCallback(
-    async (processedData: ProcessedDragData) => {
-      await handleFilesDroppedToDirectory(processedData, currentPrefix, apiS3);
-    },
-    [handleFilesDroppedToDirectory, apiS3, currentPrefix]
-  );
-
-  const handleFilesDroppedToFolderWrapper = useCallback(
-    async (processedData: ProcessedDragData, targetFolder: DragDropTarget) => {
-      await handleFilesDroppedToFolder(processedData, targetFolder, apiS3);
-    },
-    [handleFilesDroppedToFolder, apiS3]
-  );
 
   const handleLoadMoreFiles = async () => {
     setIsLoadingMoreFiles(true);

--- a/frontend/src/features/dashboard/components/ui/menus/create-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/create-menu.tsx
@@ -5,7 +5,7 @@ import { createPortal } from 'react-dom';
 import { FolderPlus, Upload, FolderUp } from 'lucide-react';
 import { pickMultipleFiles, pickFolder } from '@/features/upload/utils/file-picker';
 import { ProcessedDragData } from '@/features/upload/types/folder-upload-types';
-import { useUploadStore } from '@/features/upload/stores/use-upload-store';
+import { useUploadDispatch } from '@/features/upload/hooks/use-upload-dispatch';
 import { useDriveStore } from '@/context/data-context';
 import { FolderStructureProcessor } from '@/features/upload/utils/folder-structure-processor';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
@@ -36,21 +36,16 @@ export const CreateMenu: React.FC<CreateMenuProps> = ({
   className = '',
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);
-  const { handleFilesDroppedToDirectory } = useUploadStore();
+  const dispatchDrop = useUploadDispatch();
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const [originPosition, setOriginPosition] = useState<
     'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
   >('top-left');
   const { apiS3, isLoading, isAuthenticated } = useAuthGuard();
 
-  if (isLoading) {
-    return <PreviewLoading message="Authenticating..." />;
-  }
-
-  if (!isAuthenticated || !apiS3) {
-    return null;
-  }
-
+  // The auth guards used to sit here, above every hook below them, so React
+  // saw a different hook count before and after the session resolved. They now
+  // live with the other early return, once all hooks have run.
   const { currentPrefix } = useDriveStore();
 
   //  file upload handlers using utility functions
@@ -62,13 +57,13 @@ export const CreateMenu: React.FC<CreateMenuProps> = ({
         const processedData: ProcessedDragData = FolderStructureProcessor.processFileList(
           result.files
         );
-        handleFilesDroppedToDirectory(processedData, currentPrefix, apiS3);
+        void dispatchDrop(processedData, currentPrefix ?? '', apiS3);
         onClose(); // Close menu after successful file selection
       }
     } catch {
       // Handle error silently or with proper error handling
     }
-  }, [handleFilesDroppedToDirectory, onClose, currentPrefix, apiS3]);
+  }, [dispatchDrop, onClose, currentPrefix, apiS3]);
 
   const triggerFolderUpload = useCallback(async () => {
     try {
@@ -78,13 +73,13 @@ export const CreateMenu: React.FC<CreateMenuProps> = ({
         const processedData: ProcessedDragData = FolderStructureProcessor.processFileList(
           result.files
         );
-        handleFilesDroppedToDirectory(processedData, currentPrefix, apiS3);
+        void dispatchDrop(processedData, currentPrefix ?? '', apiS3);
         onClose(); // Close menu after successful folder selection
       }
     } catch {
       // Handle error silently or with proper error handling
     }
-  }, [handleFilesDroppedToDirectory, onClose, currentPrefix, apiS3]);
+  }, [dispatchDrop, onClose, currentPrefix, apiS3]);
 
   // Handle new folder action - simple approach
   const handleNewFolderClick = useCallback(() => {
@@ -203,6 +198,14 @@ export const CreateMenu: React.FC<CreateMenuProps> = ({
       document.removeEventListener('keydown', handleEscape);
     };
   }, [isOpen, onClose]);
+
+  if (isLoading) {
+    return <PreviewLoading message="Authenticating..." />;
+  }
+
+  if (!isAuthenticated || !apiS3) {
+    return null;
+  }
 
   if (!isOpen || !position) return null;
 

--- a/frontend/src/features/upload/components/operations-modal.tsx
+++ b/frontend/src/features/upload/components/operations-modal.tsx
@@ -6,6 +6,9 @@ import { useDownloadList } from '@/features/dashboard/hooks/use-download';
 import { HiOutlineXMark, HiOutlineChevronUp, HiOutlineChevronDown } from 'react-icons/hi2';
 import { DuplicateDialog } from './duplicate-dialog';
 import { OperationRow, type OperationType } from './operation-row';
+import { QueueNotices } from './queue-notices';
+import { useUploadExecutor } from '../context/upload-context';
+import { useUploadQueueStore } from '../stores/use-upload-queue-store';
 import type { FileExtension } from '@/config/file-extensions';
 import { useActiveUploadManager } from '@/hooks/use-auth';
 import { useUploadSettingsStore } from '@/features/upload/stores/use-upload-settings-store';
@@ -157,7 +160,11 @@ export const OperationsModal: React.FC = () => {
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const uploadManager = useActiveUploadManager();
+  const executor = useUploadExecutor();
   const uploadMode = useUploadSettingsStore((state) => state.uploadMode);
+  // Only the count, so the panel re-renders when notices appear or disappear
+  // but not when their contents change - QueueNotices owns that.
+  const noticeCount = useUploadQueueStore((state) => state.notices.length);
 
   // Check if pause/resume is supported in current mode
   const supportsPauseResume = uploadMode === 'multipart';
@@ -196,18 +203,24 @@ export const OperationsModal: React.FC = () => {
     (itemId: string, operationType: OperationType, isFolder = false) => {
       if (operationType === 'upload') {
         if (isFolder) {
-          const folder = useUploadStore.getState().uploads[itemId];
-          if (folder && folder.fileIds) {
-            // Cancel all individual files in the folder
-            folder.fileIds.forEach((fileId) => {
-              uploadManager?.cancelUpload(fileId);
-            });
-            // Through the store action rather than by assigning to
-            // `folder.status`: that mutated zustand's state object in place,
-            // so no subscriber was notified and the panel kept showing the
-            // folder as active until some unrelated update forced a render.
-            updateUpload(itemId, { status: 'cancelled', progress: 100 });
+          // A folder card's id IS the executor's task id, so cancelling goes
+          // through the executor: it aborts every file, and - crucially -
+          // decides whether the prefix claim can be handed back. Cancelling the
+          // files directly would abort the uploads but leave the name reserved
+          // for the rest of the session.
+          if (executor && executor.uploadsFor(itemId).length > 0) {
+            void executor.cancelTask(itemId);
+          } else {
+            // Folders queued before this session's executor existed, or
+            // already settled. Fall back to the per-file path.
+            const folder = useUploadStore.getState().uploads[itemId];
+            folder?.fileIds?.forEach((fileId) => uploadManager?.cancelUpload(fileId));
           }
+          // Through the store action rather than by assigning to
+          // `folder.status`: that mutated zustand's state object in place,
+          // so no subscriber was notified and the panel kept showing the
+          // folder as active until some unrelated update forced a render.
+          updateUpload(itemId, { status: 'cancelled', progress: 100 });
         } else {
           uploadManager?.cancelUpload(itemId);
         }
@@ -221,7 +234,7 @@ export const OperationsModal: React.FC = () => {
         cancelDownload(itemId);
       }
     },
-    [uploadManager, updateUpload, removeDeleteOperation, cancelDownload]
+    [executor, uploadManager, updateUpload, removeDeleteOperation, cancelDownload]
   );
 
   const removeOperation = useCallback(
@@ -343,8 +356,11 @@ export const OperationsModal: React.FC = () => {
     return 'Loading...';
   }
 
-  // If no operations and no duplicate dialog, don't show modal
-  if (sortedOperations.length === 0 && !currentDuplicate) {
+  // If no operations, no duplicate dialog and nothing to report, don't show
+  // modal. Notices count: a drop where every folder was skipped starts no
+  // uploads at all, and hiding the panel would leave the user with no
+  // indication that anything happened.
+  if (sortedOperations.length === 0 && !currentDuplicate && noticeCount === 0) {
     return null;
   }
 
@@ -679,6 +695,11 @@ export const OperationsModal: React.FC = () => {
               </button>
             </div>
           )}
+
+          {/* What the drop could not do quietly: renames, skipped files, and
+              folders we could not verify against the bucket. Subscribes to the
+              queue store, which no progress tick touches. */}
+          {isExpanded && <QueueNotices />}
 
           {/* Operations List */}
           {isExpanded && sortedOperations.length > 0 && (

--- a/frontend/src/features/upload/components/queue-notices.test.tsx
+++ b/frontend/src/features/upload/components/queue-notices.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * QueueNotices.
+ *
+ * The first component test in the codebase, and it earns that because the
+ * notices were the one part of the pipeline nothing rendered: extraction losses
+ * were collected, grouped, capped, and then dropped on the floor. A store test
+ * cannot catch "computed but never displayed".
+ *
+ * Assertions go through the rendered text a user actually reads rather than
+ * through props, so a change that keeps the data flowing but stops showing it
+ * still fails.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import React, { Profiler } from 'react';
+import { render, screen, within, fireEvent, act } from '@testing-library/react';
+import { QueueNotices } from './queue-notices';
+import { useUploadQueueStore, type QueueNotice } from '../stores/use-upload-queue-store';
+
+const queue = () => useUploadQueueStore.getState();
+
+function notice(overrides: Partial<QueueNotice> = {}): QueueNotice {
+  return {
+    id: `n-${Math.random()}`,
+    kind: 'skipped',
+    path: 'photos/a.jpg',
+    detail: 'File "photos/a.jpg" could not be read and was not uploaded.',
+    count: 1,
+    ...overrides,
+  };
+}
+
+function seed(notices: QueueNotice[]) {
+  useUploadQueueStore.setState({ notices });
+}
+
+beforeEach(() => {
+  seed([]);
+});
+
+describe('empty state', () => {
+  it('renders nothing when there are no notices', () => {
+    render(<QueueNotices />);
+
+    expect(screen.queryByTestId('queue-notices')).toBeNull();
+  });
+});
+
+describe('the three kinds', () => {
+  it('shows a collision rename in the words the store produced', () => {
+    seed([
+      notice({
+        kind: 'renamed',
+        path: 'photos',
+        detail:
+          'A folder named "photos" was already here, so this one is being uploaded as "photos (1)".',
+      }),
+    ]);
+
+    render(<QueueNotices />);
+
+    expect(
+      screen.getByText(
+        'A folder named "photos" was already here, so this one is being uploaded as "photos (1)".'
+      )
+    ).toBeTruthy();
+    expect(screen.getByTestId('queue-notice').getAttribute('data-kind')).toBe('renamed');
+    expect(screen.getByText('Renamed')).toBeTruthy();
+  });
+
+  it('shows an aggregated skip summary with its real item count', () => {
+    // The flood case: 500 permission errors collapse to one notice, and the
+    // count is the thing that tells the user how much is missing.
+    seed([
+      notice({
+        kind: 'skipped',
+        path: 'proj/node_modules/',
+        count: 500,
+        detail:
+          'proj/node_modules/f0.js and 499 other item(s) in this folder could not be read (EACCES) and were not uploaded.',
+      }),
+    ]);
+
+    render(<QueueNotices />);
+
+    expect(screen.getByText(/499 other item\(s\)/)).toBeTruthy();
+    expect(screen.getByText('500 items')).toBeTruthy();
+  });
+
+  it('shows an unverified folder as a warning, not a rename', () => {
+    // The only kind that can still lose data: the folder is uploading under a
+    // name we could not check, so a matching object may be overwritten.
+    seed([
+      notice({
+        kind: 'unverified',
+        path: 'photos',
+        detail:
+          'Could not check whether "photos" already exists here, so it is being uploaded under that name. If it does exist, files with matching names will be overwritten.',
+      }),
+    ]);
+
+    render(<QueueNotices />);
+
+    const row = screen.getByTestId('queue-notice');
+    expect(row.getAttribute('data-kind')).toBe('unverified');
+    expect(within(row).getByText('Not verified')).toBeTruthy();
+    expect(screen.getByText(/will be overwritten/)).toBeTruthy();
+  });
+
+  it('omits the item count for a notice standing for one thing', () => {
+    seed([notice({ count: 1 })]);
+
+    render(<QueueNotices />);
+
+    expect(screen.queryByText(/^\d+ items$/)).toBeNull();
+  });
+
+  it('renders every notice in the list', () => {
+    seed([
+      notice({ id: 'a', kind: 'renamed', detail: 'renamed one' }),
+      notice({ id: 'b', kind: 'skipped', detail: 'skipped one' }),
+      notice({ id: 'c', kind: 'unverified', detail: 'unverified one' }),
+    ]);
+
+    render(<QueueNotices />);
+
+    expect(screen.getAllByTestId('queue-notice')).toHaveLength(3);
+    expect(screen.getByText('3 notices')).toBeTruthy();
+  });
+
+  it('counts a single notice in the singular', () => {
+    seed([notice()]);
+
+    render(<QueueNotices />);
+
+    expect(screen.getByText('1 notice')).toBeTruthy();
+  });
+});
+
+describe('dismissing', () => {
+  it('removes one notice from the store and the panel', () => {
+    seed([
+      notice({ id: 'a', detail: 'first problem' }),
+      notice({ id: 'b', detail: 'second problem' }),
+    ]);
+    render(<QueueNotices />);
+
+    fireEvent.click(screen.getByLabelText('Dismiss notice: first problem'));
+
+    expect(queue().notices.map((n) => n.id)).toEqual(['b']);
+    expect(screen.queryByText('first problem')).toBeNull();
+    expect(screen.getByText('second problem')).toBeTruthy();
+  });
+
+  it('clears them all', () => {
+    seed([notice({ id: 'a' }), notice({ id: 'b' }), notice({ id: 'c' })]);
+    render(<QueueNotices />);
+
+    fireEvent.click(screen.getByText('Clear all'));
+
+    expect(queue().notices).toEqual([]);
+    expect(screen.queryByTestId('queue-notices')).toBeNull();
+  });
+
+  it('disappears once the last notice is dismissed', () => {
+    seed([notice({ id: 'only', detail: 'the only problem' })]);
+    render(<QueueNotices />);
+
+    fireEvent.click(screen.getByLabelText('Dismiss notice: the only problem'));
+
+    expect(screen.queryByTestId('queue-notices')).toBeNull();
+  });
+});
+
+describe('live updates', () => {
+  it('appears when a drop produces notices while mounted', () => {
+    render(<QueueNotices />);
+    expect(screen.queryByTestId('queue-notices')).toBeNull();
+
+    // What planDrop does at the end of a drop.
+    act(() => {
+      useUploadQueueStore.setState({ notices: [notice({ detail: 'something went wrong' })] });
+    });
+
+    expect(screen.getByText('something went wrong')).toBeTruthy();
+  });
+});
+
+describe('render isolation', () => {
+  /**
+   * Counts commits caused by STORE changes.
+   *
+   * Deliberately not used to measure a parent re-render: `onRender` fires
+   * whenever the Profiler element itself is re-rendered, so it reports a commit
+   * even when the memoised child bails out, and would prove nothing there.
+   * Store-driven re-renders are different - zustand only re-renders a
+   * subscriber whose selected slice changed, so a commit here really does mean
+   * the selector let something through.
+   */
+  function renderCounted() {
+    let commits = 0;
+    render(
+      <Profiler id="notices" onRender={() => (commits += 1)}>
+        <QueueNotices />
+      </Profiler>
+    );
+    return () => commits;
+  }
+
+  it('is memoised, so the panel re-rendering cannot reach it', () => {
+    // The operations panel re-renders on every progress tick. This component
+    // takes no props, so memo is what stops those ticks here. Asserting the DOM
+    // node is unchanged would prove nothing - React reuses nodes across
+    // re-renders - so the wrapper itself is what gets checked.
+    expect((QueueNotices as unknown as { $$typeof: symbol }).$$typeof).toBe(
+      Symbol.for('react.memo')
+    );
+  });
+
+  it('does not re-render when unrelated queue state changes', () => {
+    // isPlanning flips twice per drop, and claims churn throughout. Neither is
+    // in this component's selector, so neither may reach it.
+    seed([notice({ id: 'a', detail: 'stable notice' })]);
+    const commits = renderCounted();
+    const initial = commits();
+
+    act(() => {
+      useUploadQueueStore.setState({ isPlanning: true });
+      useUploadQueueStore.getState().reservePrefix('photos', '', 'task-1');
+    });
+
+    expect(commits()).toBe(initial);
+  });
+
+  it('does re-render when the notices themselves change', () => {
+    // Negative control for the two above: if the selector were broken in the
+    // other direction, they would pass and this would fail.
+    seed([notice({ id: 'a', detail: 'stable notice' })]);
+    const commits = renderCounted();
+    const initial = commits();
+
+    act(() => {
+      useUploadQueueStore.setState({ notices: [notice({ id: 'b', detail: 'new notice' })] });
+    });
+
+    expect(commits()).toBeGreaterThan(initial);
+    expect(screen.getByText('new notice')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/upload/components/queue-notices.tsx
+++ b/frontend/src/features/upload/components/queue-notices.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+/**
+ * Renders what a drop could not do quietly.
+ *
+ * Three things reach here, and the distinction matters to the user:
+ *
+ *  - `renamed`    - we resolved a collision for them. Informational.
+ *  - `skipped`    - files that never made it off disk, usually a permission
+ *                   lock. Their data is NOT in the bucket.
+ *  - `unverified` - we could not reach S3 to check whether the name was free,
+ *                   so the folder is uploading under a name that might already
+ *                   exist. This is the only one that can still lose data, so it
+ *                   is styled as a warning rather than a note.
+ *
+ * Before this existed the notices were computed, aggregated, capped, and then
+ * never shown to anyone.
+ */
+
+import React, { useCallback } from 'react';
+import { HiOutlineXMark } from 'react-icons/hi2';
+import { useUploadQueueStore, type QueueNotice } from '../stores/use-upload-queue-store';
+
+const ACCENT: Record<QueueNotice['kind'], string> = {
+  renamed: 'var(--primary)',
+  skipped: 'var(--muted-foreground)',
+  unverified: '#f59e0b',
+};
+
+const LABEL: Record<QueueNotice['kind'], string> = {
+  renamed: 'Renamed',
+  skipped: 'Skipped',
+  unverified: 'Not verified',
+};
+
+interface NoticeRowProps {
+  notice: QueueNotice;
+  onDismiss: (id: string) => void;
+}
+
+/**
+ * Memoised on the notice object, which the store only replaces when the list
+ * actually changes. The panel around this re-renders on every progress tick.
+ */
+const NoticeRow: React.FC<NoticeRowProps> = React.memo(({ notice, onDismiss }) => (
+  <div
+    data-testid="queue-notice"
+    data-kind={notice.kind}
+    className="flex items-start gap-2 px-4 py-2"
+    style={{ borderBottom: '1px solid var(--border)' }}
+  >
+    <span
+      className="text-[10px] font-semibold uppercase tracking-wide mt-0.5 flex-shrink-0"
+      style={{ color: ACCENT[notice.kind] }}
+    >
+      {LABEL[notice.kind]}
+    </span>
+
+    <div className="flex-1 min-w-0">
+      <p className="text-xs" style={{ color: 'var(--foreground)' }}>
+        {notice.detail}
+      </p>
+      {notice.count > 1 && (
+        <p className="text-[11px]" style={{ color: 'var(--muted-foreground)' }}>
+          {notice.count} items
+        </p>
+      )}
+    </div>
+
+    <button
+      onClick={() => onDismiss(notice.id)}
+      aria-label={`Dismiss notice: ${notice.detail}`}
+      className="p-1 rounded transition-colors duration-200 flex-shrink-0"
+      style={{ color: 'var(--muted-foreground)' }}
+    >
+      <HiOutlineXMark className="w-3 h-3" />
+    </button>
+  </div>
+));
+NoticeRow.displayName = 'NoticeRow';
+
+/**
+ * Takes no props deliberately: it subscribes to the QUEUE store, which no
+ * progress tick ever touches, so wrapping it in memo keeps it out of the
+ * upload panel's render path entirely.
+ */
+export const QueueNotices: React.FC = React.memo(() => {
+  const notices = useUploadQueueStore((state) => state.notices);
+  const dismissNotice = useUploadQueueStore((state) => state.dismissNotice);
+  const clearNotices = useUploadQueueStore((state) => state.clearNotices);
+
+  const handleDismiss = useCallback((id: string) => dismissNotice(id), [dismissNotice]);
+
+  if (notices.length === 0) return null;
+
+  return (
+    <div data-testid="queue-notices">
+      <div
+        className="flex items-center justify-between px-4 py-2"
+        style={{ background: 'var(--secondary)' }}
+      >
+        <p className="text-xs font-medium" style={{ color: 'var(--foreground)' }}>
+          {notices.length === 1 ? '1 notice' : `${notices.length} notices`}
+        </p>
+        <button
+          onClick={clearNotices}
+          className="text-xs font-medium"
+          style={{ color: 'var(--primary)' }}
+        >
+          Clear all
+        </button>
+      </div>
+
+      <div className="max-h-40 overflow-y-auto custom-scrollbar">
+        {notices.map((notice) => (
+          <NoticeRow key={notice.id} notice={notice} onDismiss={handleDismiss} />
+        ))}
+      </div>
+    </div>
+  );
+});
+QueueNotices.displayName = 'QueueNotices';

--- a/frontend/src/features/upload/context/upload-context.test.tsx
+++ b/frontend/src/features/upload/context/upload-context.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * UploadProvider.
+ *
+ * Hosting the executor here looks trivial and is not. Creating it in a
+ * `useMemo` - the obvious way - subscribes to the manager DURING RENDER, and
+ * under StrictMode React runs the factory twice and then simulates an
+ * unmount/remount. The result was an executor that consumers still held but
+ * that had been disposed: it received no events, so claims were never
+ * committed and never released, silently, in dev only.
+ *
+ * These tests exist to make that specific failure loud.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React, { StrictMode } from 'react';
+import { render, act } from '@testing-library/react';
+
+const managerRef: { current: unknown } = { current: null };
+vi.mock('@/hooks/use-auth', () => ({
+  useActiveUploadManager: () => managerRef.current,
+}));
+
+import { UploadProvider, useUploadExecutor } from './upload-context';
+import { useUploadQueueStore, type PlannedUpload } from '../stores/use-upload-queue-store';
+import type { UploadExecutor } from '../services/upload-executor';
+
+function fakeManager() {
+  const listeners: Record<string, ((p: unknown) => void)[]> = { progress: [], statusChange: [] };
+  let n = 0;
+  return {
+    addUpload: () => `u-${n++}`,
+    cancelUpload: vi.fn(),
+    on(event: string, fn: (p: unknown) => void) {
+      listeners[event]!.push(fn);
+    },
+    off(event: string, fn: (p: unknown) => void) {
+      listeners[event] = listeners[event]!.filter((l) => l !== fn);
+    },
+    emit(event: string, payload: unknown) {
+      for (const fn of [...listeners[event]!]) fn(payload);
+    },
+    liveListeners: () => listeners.progress!.length + listeners.statusChange!.length,
+  };
+}
+
+function plan(): PlannedUpload {
+  return {
+    id: 'task-1',
+    kind: 'folder',
+    originalName: 'photos',
+    resolvedName: 'photos',
+    prefix: 'photos/',
+    verification: 'confirmed',
+    files: [new File([new Uint8Array(4)], 'a.jpg')],
+    totalBytes: 4,
+  };
+}
+
+/** Renders the provider and hands back whatever executor consumers would get. */
+function mountProvider(strict: boolean) {
+  let captured: UploadExecutor | null = null;
+  const Consumer: React.FC = () => {
+    captured = useUploadExecutor();
+    return null;
+  };
+
+  const tree = (
+    <UploadProvider>
+      <Consumer />
+    </UploadProvider>
+  );
+
+  const utils = render(strict ? <StrictMode>{tree}</StrictMode> : tree);
+  return { ...utils, executor: () => captured as UploadExecutor | null };
+}
+
+/** Dispatches one task and lands a byte on it; returns whether the claim committed. */
+function commitsOnProgress(executor: UploadExecutor, manager: ReturnType<typeof fakeManager>) {
+  useUploadQueueStore.getState().reservePrefix('photos', '', 'task-1');
+  act(() => {
+    executor.start([plan()]);
+  });
+  act(() => {
+    manager.emit('progress', { id: 'u-0', status: 'uploading', progress: 25 });
+  });
+  return useUploadQueueStore.getState().claims[0]?.committed ?? false;
+}
+
+let manager: ReturnType<typeof fakeManager>;
+
+beforeEach(() => {
+  manager = fakeManager();
+  managerRef.current = manager;
+});
+
+describe('executor lifecycle', () => {
+  it('hands out a live executor under StrictMode', () => {
+    // The regression: consumers got an executor React had already disposed.
+    const { executor } = mountProvider(true);
+
+    expect(executor()).not.toBeNull();
+    expect(commitsOnProgress(executor()!, manager)).toBe(true);
+  });
+
+  it('hands out a live executor without StrictMode', () => {
+    const { executor } = mountProvider(false);
+
+    expect(commitsOnProgress(executor()!, manager)).toBe(true);
+  });
+
+  it('leaves no listeners behind on unmount', () => {
+    const { unmount } = mountProvider(true);
+    expect(manager.liveListeners()).toBeGreaterThan(0);
+
+    unmount();
+
+    expect(manager.liveListeners()).toBe(0);
+  });
+
+  it('unsubscribes the old manager when the bucket changes', () => {
+    // Switching bucket or upload mode builds a new manager. The old one must
+    // stop being listened to, or events from a torn-down session keep landing.
+    const { rerender, executor } = mountProvider(false);
+    const first = manager;
+    expect(first.liveListeners()).toBeGreaterThan(0);
+
+    const second = fakeManager();
+    managerRef.current = second;
+    act(() => {
+      rerender(
+        <UploadProvider>
+          <div />
+        </UploadProvider>
+      );
+    });
+
+    expect(first.liveListeners()).toBe(0);
+    expect(second.liveListeners()).toBeGreaterThan(0);
+    expect(executor).toBeTruthy();
+  });
+
+  it('reports no executor before a session exists', () => {
+    managerRef.current = null;
+
+    const { executor } = mountProvider(false);
+
+    expect(executor()).toBeNull();
+  });
+});

--- a/frontend/src/features/upload/context/upload-context.tsx
+++ b/frontend/src/features/upload/context/upload-context.tsx
@@ -1,15 +1,44 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, ReactNode } from 'react';
 import { UploadStatus } from '@opndrive/s3-api';
 import { useUploadStore } from '@/features/upload/stores/use-upload-store';
 import { useActiveUploadManager } from '@/hooks/use-auth';
+import { createUploadExecutor, type UploadExecutor } from '../services/upload-executor';
 
-const UploadContext = createContext<null>(null);
+interface UploadContextValue {
+  /**
+   * Null until a session exists, and replaced whenever the active manager
+   * changes - switching upload mode or bucket builds a new one.
+   */
+  executor: UploadExecutor | null;
+}
+
+/**
+ * Defaulted rather than null so `useUploadContext` outside a provider returns
+ * a usable shape instead of throwing. The previous version created the context
+ * with `null` and then threw whenever the value was falsy, which meant the hook
+ * threw unconditionally - it was simply never called.
+ */
+const UploadContext = createContext<UploadContextValue>({ executor: null });
 
 export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const { updateUpload } = useUploadStore();
+  // Field selector: this provider wraps the whole dashboard, so subscribing to
+  // the entire upload store would re-render every page on each progress tick.
+  const updateUpload = useUploadStore((state) => state.updateUpload);
   const uploadManager = useActiveUploadManager();
+
+  // One executor per manager. The manager is a singleton held in auth context,
+  // so this only rebuilds when the session or upload mode actually changes.
+  const executor = useMemo(
+    () => (uploadManager ? createUploadExecutor(uploadManager) : null),
+    [uploadManager]
+  );
+
+  // Disposal is keyed on the executor itself rather than the manager, so a
+  // superseded executor unsubscribes before the replacement takes over and the
+  // two never both react to the same event.
+  useEffect(() => () => executor?.dispose(), [executor]);
 
   useEffect(() => {
     if (!uploadManager) return;
@@ -47,13 +76,12 @@ export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     };
   }, [uploadManager, updateUpload]);
 
-  return <UploadContext.Provider value={null}>{children}</UploadContext.Provider>;
+  const value = useMemo(() => ({ executor }), [executor]);
+
+  return <UploadContext.Provider value={value}>{children}</UploadContext.Provider>;
 };
 
-export const useUploadContext = () => {
-  const context = useContext(UploadContext);
-  if (!context) {
-    throw new Error('useUploadContext must be used within an UploadProvider');
-  }
-  return context;
-};
+export const useUploadContext = () => useContext(UploadContext);
+
+/** The executor for the current session, or null before one exists. */
+export const useUploadExecutor = () => useContext(UploadContext).executor;

--- a/frontend/src/features/upload/context/upload-context.tsx
+++ b/frontend/src/features/upload/context/upload-context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, useMemo, ReactNode } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useState, ReactNode } from 'react';
 import { UploadStatus } from '@opndrive/s3-api';
 import { useUploadStore } from '@/features/upload/stores/use-upload-store';
 import { useActiveUploadManager } from '@/hooks/use-auth';
@@ -28,17 +28,40 @@ export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const updateUpload = useUploadStore((state) => state.updateUpload);
   const uploadManager = useActiveUploadManager();
 
-  // One executor per manager. The manager is a singleton held in auth context,
-  // so this only rebuilds when the session or upload mode actually changes.
-  const executor = useMemo(
-    () => (uploadManager ? createUploadExecutor(uploadManager) : null),
-    [uploadManager]
-  );
+  const [executor, setExecutor] = useState<UploadExecutor | null>(null);
 
-  // Disposal is keyed on the executor itself rather than the manager, so a
-  // superseded executor unsubscribes before the replacement takes over and the
-  // two never both react to the same event.
-  useEffect(() => () => executor?.dispose(), [executor]);
+  /**
+   * One executor per manager, created in an effect rather than in render.
+   *
+   * `createUploadExecutor` subscribes to the manager, which makes it a side
+   * effect, and side effects in render do not survive React's guarantees. Built
+   * in a `useMemo` it was actively broken under StrictMode: the factory runs
+   * twice, so two executors subscribe, then the simulated unmount disposes the
+   * one React kept - leaving consumers holding an executor with no listeners.
+   * Claims were never committed and never released, in dev, silently. The other
+   * executor's listeners leaked.
+   *
+   * Verified: with the memo version, a progress event after a StrictMode mount
+   * left the claim uncommitted; with this version it commits.
+   */
+  useEffect(() => {
+    if (!uploadManager) {
+      setExecutor(null);
+      return;
+    }
+
+    const next = createUploadExecutor(uploadManager);
+    setExecutor(next);
+
+    return () => {
+      next.dispose();
+      // Functional update so a newer executor installed by the next effect run
+      // is never clobbered. Consumers briefly see null rather than a disposed
+      // executor, which is the safer of the two: a drop in that window is a
+      // no-op instead of an upload whose claims never settle.
+      setExecutor((current) => (current === next ? null : current));
+    };
+  }, [uploadManager]);
 
   useEffect(() => {
     if (!uploadManager) return;

--- a/frontend/src/features/upload/hooks/use-upload-dispatch.test.ts
+++ b/frontend/src/features/upload/hooks/use-upload-dispatch.test.ts
@@ -22,11 +22,23 @@ import { useUploadQueueStore } from '../stores/use-upload-queue-store';
 import { useUploadStore } from '../stores/use-upload-store';
 import type { ProcessedDragData, FolderStructure } from '../types/folder-upload-types';
 import { folderExists } from '@/services/folder-existence';
+import { objectExists } from '@/services/object-existence';
+import { generateUniqueFileName } from '../utils/unique-filename';
 import { createUploadExecutor, type UploadExecutor } from '../services/upload-executor';
 
 vi.mock('@/services/folder-existence', () => ({
   folderExists: vi.fn(),
   describeFolderCheckError: vi.fn(),
+}));
+
+vi.mock('@/services/object-existence', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/object-existence')>()),
+  objectExists: vi.fn(),
+}));
+
+vi.mock('../utils/unique-filename', () => ({
+  generateUniqueFileName: vi.fn(),
+  generateUniqueFolderName: vi.fn(),
 }));
 
 /** The executor is injected through context, which is mocked to a test double. */
@@ -36,6 +48,8 @@ vi.mock('../context/upload-context', () => ({
 }));
 
 const mockFolderExists = vi.mocked(folderExists);
+const mockObjectExists = vi.mocked(objectExists);
+const mockUniqueName = vi.mocked(generateUniqueFileName);
 const queue = () => useUploadQueueStore.getState();
 const uploads = () => useUploadStore.getState().uploads;
 
@@ -79,7 +93,10 @@ beforeEach(() => {
   currentExecutor = createUploadExecutor(manager);
   mockFolderExists.mockReset();
   mockFolderExists.mockResolvedValue(false);
-  useUploadStore.setState({ uploads: {} });
+  mockObjectExists.mockReset();
+  mockObjectExists.mockResolvedValue(false);
+  mockUniqueName.mockReset();
+  useUploadStore.setState({ uploads: {}, duplicateQueue: [] });
 });
 
 function dispatch() {
@@ -193,6 +210,150 @@ describe('loose files', () => {
     );
 
     expect(manager.added.map((a) => a.key)).toEqual(['notes.txt', 'photos/a.jpg']);
+  });
+});
+
+describe('loose file collisions', () => {
+  /** Answers whatever prompt the dispatch raises, once one appears. */
+  async function answer(choice: 'replace' | 'keepBoth') {
+    for (let i = 0; i < 50; i++) {
+      const prompt = useUploadStore.getState().duplicateQueue[0];
+      if (prompt) {
+        if (choice === 'replace') prompt.onReplace();
+        else prompt.onKeepBoth();
+        return;
+      }
+      await Promise.resolve();
+    }
+    throw new Error('no duplicate prompt was raised');
+  }
+
+  it('uploads without prompting when nothing is in the way', async () => {
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ individualFiles: [makeFile('notes.txt')] }), 'docs', apiS3);
+
+    expect(useUploadStore.getState().duplicateQueue).toEqual([]);
+    expect(manager.added.map((a) => a.key)).toEqual(['docs/notes.txt']);
+  });
+
+  it('asks before overwriting an object that already exists', async () => {
+    // S3 PUT overwrites silently, so without this the user loses the old file
+    // with no warning. This prompt existed before the executor pipeline and
+    // was bypassed by it.
+    mockObjectExists.mockResolvedValue(true);
+    const dispatchDrop = dispatch();
+
+    const pending = dispatchDrop(drop({ individualFiles: [makeFile('notes.txt')] }), '', apiS3);
+    await answer('replace');
+    await pending;
+
+    expect(mockObjectExists).toHaveBeenCalledWith(apiS3, 'notes.txt');
+    expect(manager.added.map((a) => a.key)).toEqual(['notes.txt']);
+  });
+
+  it('uploads under a fresh name when the user keeps both', async () => {
+    mockObjectExists.mockResolvedValue(true);
+    mockUniqueName.mockResolvedValue('notes (1).txt');
+    const dispatchDrop = dispatch();
+
+    const pending = dispatchDrop(drop({ individualFiles: [makeFile('notes.txt')] }), '', apiS3);
+    await answer('keepBoth');
+    await pending;
+
+    expect(manager.added.map((a) => a.key)).toEqual(['notes (1).txt']);
+  });
+
+  it('does not upload at all when no free name can be found', async () => {
+    // Keeping both is impossible, and replacing was not what the user asked
+    // for, so the only safe outcome is to leave the object alone.
+    mockObjectExists.mockResolvedValue(true);
+    mockUniqueName.mockRejectedValue(new Error('exhausted'));
+    const dispatchDrop = dispatch();
+
+    const pending = dispatchDrop(drop({ individualFiles: [makeFile('notes.txt')] }), '', apiS3);
+    await answer('keepBoth');
+    const { notices } = await pending;
+
+    expect(manager.added).toEqual([]);
+    expect(notices.map((n) => n.kind)).toEqual(['skipped']);
+  });
+
+  it('uploads but warns when the check itself fails', async () => {
+    // Indeterminate is not "free". The old code caught this and returned
+    // false, so a throttled HEAD silently overwrote a real object.
+    mockObjectExists.mockRejectedValue(new Error('throttled'));
+    const dispatchDrop = dispatch();
+
+    const { notices } = await dispatchDrop(
+      drop({ individualFiles: [makeFile('notes.txt')] }),
+      '',
+      apiS3
+    );
+
+    expect(manager.added.map((a) => a.key)).toEqual(['notes.txt']);
+    expect(notices.map((n) => n.kind)).toEqual(['unverified']);
+    expect(useUploadStore.getState().duplicateQueue).toEqual([]);
+  });
+
+  it('does not object-check files inside a folder', async () => {
+    // Those collide at the prefix level, which planning already resolved.
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ folderStructures: [folder('photos')] }), '', apiS3);
+
+    expect(mockObjectExists).not.toHaveBeenCalled();
+  });
+
+  it('skips the check entirely with no api', async () => {
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ individualFiles: [makeFile('notes.txt')] }), '', null);
+
+    expect(mockObjectExists).not.toHaveBeenCalled();
+    expect(manager.added.map((a) => a.key)).toEqual(['notes.txt']);
+  });
+
+  it('checks several files at once rather than one after another', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    mockObjectExists.mockImplementation(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await Promise.resolve();
+      inFlight--;
+      return false;
+    });
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(
+      drop({ individualFiles: Array.from({ length: 8 }, (_, i) => makeFile(`f${i}.txt`)) }),
+      '',
+      apiS3
+    );
+
+    expect(peak).toBeGreaterThan(1);
+    expect(mockObjectExists).toHaveBeenCalledTimes(8);
+  });
+
+  it('asks one question at a time', async () => {
+    // Five simultaneous modals would be unusable; the queue holds them.
+    mockObjectExists.mockResolvedValue(true);
+    mockUniqueName.mockImplementation(async (_api, name: string) => `copy-${name}`);
+    const dispatchDrop = dispatch();
+
+    const pending = dispatchDrop(
+      drop({ individualFiles: [makeFile('a.txt'), makeFile('b.txt')] }),
+      '',
+      apiS3
+    );
+
+    await answer('keepBoth');
+    expect(useUploadStore.getState().duplicateQueue.length).toBeLessThanOrEqual(1);
+    await answer('keepBoth');
+    await pending;
+
+    expect(manager.added.map((a) => a.key)).toEqual(['copy-a.txt', 'copy-b.txt']);
   });
 });
 

--- a/frontend/src/features/upload/hooks/use-upload-dispatch.test.ts
+++ b/frontend/src/features/upload/hooks/use-upload-dispatch.test.ts
@@ -1,0 +1,297 @@
+/**
+ * useUploadDispatch.
+ *
+ * The seam that replaces `handleFilesDroppedToDirectory`, so these tests are
+ * mostly about the three things the old path got wrong:
+ *
+ *  - two folders of the same name in one drop both passed the bucket check and
+ *    the second overwrote the first,
+ *  - the loop returned on the first duplicate and abandoned everything behind
+ *    it,
+ *  - and nothing downstream ever learned what extraction had failed to read.
+ *
+ * `folderExists` is mocked because it is the only network edge; the queue store
+ * and the executor contract are exercised for real.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { BYOS3ApiProvider } from '@opndrive/s3-api';
+import { useUploadDispatch } from './use-upload-dispatch';
+import { useUploadQueueStore } from '../stores/use-upload-queue-store';
+import { useUploadStore } from '../stores/use-upload-store';
+import type { ProcessedDragData, FolderStructure } from '../types/folder-upload-types';
+import { folderExists } from '@/services/folder-existence';
+import { createUploadExecutor, type UploadExecutor } from '../services/upload-executor';
+
+vi.mock('@/services/folder-existence', () => ({
+  folderExists: vi.fn(),
+  describeFolderCheckError: vi.fn(),
+}));
+
+/** The executor is injected through context, which is mocked to a test double. */
+let currentExecutor: UploadExecutor | null = null;
+vi.mock('../context/upload-context', () => ({
+  useUploadExecutor: () => currentExecutor,
+}));
+
+const mockFolderExists = vi.mocked(folderExists);
+const queue = () => useUploadQueueStore.getState();
+const uploads = () => useUploadStore.getState().uploads;
+
+const apiS3 = { __brand: 'fake' } as unknown as BYOS3ApiProvider;
+
+function fakeManager() {
+  const added: { id: string; key: string }[] = [];
+  let n = 0;
+  return {
+    added,
+    addUpload(_file: File, config: { key: string }) {
+      const id = `upload-${n++}`;
+      added.push({ id, key: config.key });
+      return id;
+    },
+    cancelUpload: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+}
+
+function makeFile(name: string, relativePath?: string, size = 10): File {
+  const file = new File([new Uint8Array(size)], name);
+  if (relativePath) Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+  return file;
+}
+
+function folder(name: string, fileNames: string[] = ['a.jpg']): FolderStructure {
+  const files = fileNames.map((f) => makeFile(f, `${name}/${f}`));
+  return { name, files, totalSize: files.length * 10, relativePath: name };
+}
+
+function drop(extras: Partial<ProcessedDragData> = {}): ProcessedDragData {
+  return { individualFiles: [], folderStructures: [], skipped: [], ...extras };
+}
+
+let manager: ReturnType<typeof fakeManager>;
+
+beforeEach(() => {
+  manager = fakeManager();
+  currentExecutor = createUploadExecutor(manager);
+  mockFolderExists.mockReset();
+  mockFolderExists.mockResolvedValue(false);
+  useUploadStore.setState({ uploads: {} });
+});
+
+function dispatch() {
+  return renderHook(() => useUploadDispatch()).result.current;
+}
+
+describe('folders', () => {
+  it('uploads a folder under the prefix planning chose', async () => {
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ folderStructures: [folder('photos')] }), 'docs', apiS3);
+
+    expect(manager.added.map((a) => a.key)).toEqual(['docs/photos/a.jpg']);
+  });
+
+  it('separates two folders of the same name in one drop', async () => {
+    // The original bug: both were checked against the bucket, neither was
+    // stored yet, so both passed and the second overwrote the first.
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ folderStructures: [folder('photos'), folder('photos')] }), '', apiS3);
+
+    expect(manager.added.map((a) => a.key)).toEqual(['photos/a.jpg', 'photos (1)/a.jpg']);
+  });
+
+  it('does not re-nest a renamed folder under its original name', async () => {
+    // The executor strips the dropped root; without that the key would be
+    // "photos (1)/photos/a.jpg" and the rename would be undone one level down.
+    mockFolderExists.mockImplementation(async (_api, prefix: string) => prefix === 'photos/');
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ folderStructures: [folder('photos')] }), '', apiS3);
+
+    expect(manager.added[0]!.key).toBe('photos (1)/a.jpg');
+  });
+
+  it('registers a folder card the panel can cancel', async () => {
+    const dispatchDrop = dispatch();
+
+    const { dispatched } = await dispatchDrop(
+      drop({ folderStructures: [folder('photos', ['a.jpg', 'b.jpg'])] }),
+      '',
+      apiS3
+    );
+
+    const taskId = dispatched[0]!.taskId;
+    // The card id IS the executor's task id, which is what cancelTask takes.
+    expect(uploads()[taskId]).toMatchObject({ name: 'photos', type: 'folder' });
+    expect(uploads()[taskId]!.fileIds).toEqual(['upload-0', 'upload-1']);
+    expect(currentExecutor!.uploadsFor(taskId)).toEqual(['upload-0', 'upload-1']);
+  });
+
+  it('names file cards by key so duplicates stay distinguishable', async () => {
+    // Two "img.jpg" from different subfolders would otherwise render as two
+    // identical rows.
+    const structure = folder('photos');
+    structure.files = [
+      makeFile('img.jpg', 'photos/raw/img.jpg'),
+      makeFile('img.jpg', 'photos/edited/img.jpg'),
+    ];
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ folderStructures: [structure] }), '', apiS3);
+
+    expect(uploads()['upload-0']!.name).toBe('photos/raw/img.jpg');
+    expect(uploads()['upload-1']!.name).toBe('photos/edited/img.jpg');
+  });
+
+  it('plans every folder even when one cannot be verified', async () => {
+    // The old loop returned on the first duplicate and silently dropped the
+    // rest of the drop.
+    mockFolderExists.mockImplementation(async (_api, prefix: string) => {
+      if (prefix === 'a/') throw new Error('network down');
+      return false;
+    });
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(
+      drop({ folderStructures: [folder('a'), folder('b'), folder('c')] }),
+      '',
+      apiS3
+    );
+
+    expect(manager.added.map((a) => a.key)).toEqual(['a/a.jpg', 'b/a.jpg', 'c/a.jpg']);
+  });
+});
+
+describe('loose files', () => {
+  it('uploads them straight to the destination with no wrapper card', async () => {
+    const dispatchDrop = dispatch();
+
+    const { dispatched } = await dispatchDrop(
+      drop({ individualFiles: [makeFile('notes.txt')] }),
+      'docs',
+      apiS3
+    );
+
+    expect(manager.added.map((a) => a.key)).toEqual(['docs/notes.txt']);
+    expect(uploads()['upload-0']).toMatchObject({ name: 'notes.txt', type: 'file' });
+    expect(uploads()['upload-0']!.parentFolderId).toBeUndefined();
+    expect(uploads()[dispatched[0]!.taskId]).toBeUndefined();
+  });
+
+  it('handles files and folders in one drop', async () => {
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(
+      drop({ individualFiles: [makeFile('notes.txt')], folderStructures: [folder('photos')] }),
+      '',
+      apiS3
+    );
+
+    expect(manager.added.map((a) => a.key)).toEqual(['notes.txt', 'photos/a.jpg']);
+  });
+});
+
+describe('notices', () => {
+  it('returns what extraction skipped so the panel can show it', async () => {
+    const dispatchDrop = dispatch();
+
+    const { notices } = await dispatchDrop(
+      drop({
+        folderStructures: [folder('photos')],
+        skipped: [{ path: 'photos/locked.raw', reason: 'could not be read', kind: 'file' }],
+      }),
+      '',
+      apiS3
+    );
+
+    expect(notices).toHaveLength(1);
+    expect(notices[0]!.kind).toBe('skipped');
+    // And they are in the store, which is what QueueNotices renders from.
+    expect(queue().notices).toHaveLength(1);
+  });
+
+  it('reports a rename', async () => {
+    mockFolderExists.mockImplementation(async (_api, prefix: string) => prefix === 'photos/');
+    const dispatchDrop = dispatch();
+
+    const { notices } = await dispatchDrop(
+      drop({ folderStructures: [folder('photos')] }),
+      '',
+      apiS3
+    );
+
+    expect(notices.map((n) => n.kind)).toEqual(['renamed']);
+  });
+
+  it('reports an unverified folder when the bucket check fails', async () => {
+    mockFolderExists.mockRejectedValue(new Error('ERR_INTERNET_DISCONNECTED'));
+    const dispatchDrop = dispatch();
+
+    const { notices } = await dispatchDrop(
+      drop({ folderStructures: [folder('photos')] }),
+      '',
+      apiS3
+    );
+
+    expect(notices.map((n) => n.kind)).toEqual(['unverified']);
+    // The upload still happens, under the locally reserved name.
+    expect(manager.added.map((a) => a.key)).toEqual(['photos/a.jpg']);
+  });
+});
+
+describe('no session', () => {
+  it('does nothing when there is no executor', async () => {
+    currentExecutor = null;
+    const dispatchDrop = dispatch();
+
+    const outcome = await dispatchDrop(drop({ folderStructures: [folder('photos')] }), '', apiS3);
+
+    expect(outcome.dispatched).toEqual([]);
+    expect(outcome.nothingStarted).toBe(true);
+    // Critically, planning did not run: reserving a prefix for an upload that
+    // can never start would squat the name for the session.
+    expect(queue().claims).toEqual([]);
+    expect(mockFolderExists).not.toHaveBeenCalled();
+  });
+});
+
+describe('a manager that refuses work', () => {
+  it('surfaces the failure as a card instead of throwing', async () => {
+    // addUpload throws on a disposed manager - logging out mid-drop.
+    const dead = fakeManager();
+    dead.addUpload = () => {
+      throw new Error('This UploadManager instance has been disposed.');
+    };
+    currentExecutor = createUploadExecutor(dead);
+    const dispatchDrop = dispatch();
+
+    const { dispatched, nothingStarted } = await dispatchDrop(
+      drop({ folderStructures: [folder('photos')] }),
+      '',
+      apiS3
+    );
+
+    expect(nothingStarted).toBe(true);
+    const card = uploads()[dispatched[0]!.taskId];
+    expect(card).toMatchObject({ status: 'failed', type: 'folder' });
+    expect(card!.error).toContain('disposed');
+    // And the prefix went back, since nothing was ever uploaded to it.
+    expect(queue().claimedPrefixes()).toEqual([]);
+  });
+});
+
+describe('planning without an api', () => {
+  it('skips bucket checks entirely', async () => {
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ folderStructures: [folder('photos')] }), '', null);
+
+    expect(mockFolderExists).not.toHaveBeenCalled();
+    expect(manager.added.map((a) => a.key)).toEqual(['photos/a.jpg']);
+  });
+});

--- a/frontend/src/features/upload/hooks/use-upload-dispatch.ts
+++ b/frontend/src/features/upload/hooks/use-upload-dispatch.ts
@@ -1,0 +1,121 @@
+'use client';
+
+/**
+ * The one entry point from "the user dropped something" to "bytes are moving".
+ *
+ *   ProcessedDragData
+ *         |
+ *         v
+ *   planDrop()            destinations, collisions, notices
+ *         |  PlannedUpload[]
+ *         v
+ *   executor.start()      keys, task ids, claim lifecycle
+ *         |  DispatchResult[]
+ *         v
+ *   use-upload-store      the cards the operations panel renders
+ *
+ * It replaces `useUploadStore.handleFilesDroppedToDirectory`, which checked
+ * collisions against the bucket only (so two folders named "photos" in one drop
+ * both passed and the second overwrote the first), returned on the first
+ * duplicate (abandoning every folder behind it), and built its keys through
+ * `addFolderUpload` (which re-nests a renamed folder under its original name).
+ */
+
+import { useCallback } from 'react';
+import type { BYOS3ApiProvider } from '@opndrive/s3-api';
+import type { ProcessedDragData } from '../types/folder-upload-types';
+import { useUploadQueueStore, type QueueNotice } from '../stores/use-upload-queue-store';
+import { useUploadStore } from '../stores/use-upload-store';
+import { useUploadExecutor } from '../context/upload-context';
+import type { DispatchResult } from '../services/upload-executor';
+
+export interface DropOutcome {
+  dispatched: DispatchResult[];
+  notices: QueueNotice[];
+  /** True when planning ran but nothing could be handed to the manager. */
+  nothingStarted: boolean;
+}
+
+const EMPTY_OUTCOME: DropOutcome = { dispatched: [], notices: [], nothingStarted: true };
+
+export function useUploadDispatch() {
+  const executor = useUploadExecutor();
+  const addUpload = useUploadStore((state) => state.addUpload);
+
+  return useCallback(
+    async (
+      data: ProcessedDragData,
+      destinationPrefix: string,
+      apiS3?: BYOS3ApiProvider | null
+    ): Promise<DropOutcome> => {
+      // No session, no manager, nothing to dispatch into. Planning anyway would
+      // reserve prefixes for uploads that can never run.
+      if (!executor) return EMPTY_OUTCOME;
+
+      const { planned, notices } = await useUploadQueueStore
+        .getState()
+        .planDrop(data, { destinationPrefix, apiS3 });
+
+      const dispatched = executor.start(planned);
+
+      for (const result of dispatched) {
+        if (result.plan.kind === 'folder') {
+          // The folder card owns the task id, which is what `cancelTask` takes,
+          // so cancelling from the UI needs no extra bookkeeping.
+          addUpload(result.taskId, {
+            id: result.taskId,
+            name: result.plan.resolvedName,
+            status: 'queued',
+            progress: 0,
+            type: 'folder',
+            fileIds: result.files.map((file) => file.uploadId),
+          });
+
+          for (const file of result.files) {
+            addUpload(file.uploadId, {
+              id: file.uploadId,
+              // The key rather than the bare name, so two files called
+              // "img.jpg" from different subfolders stay distinguishable.
+              name: file.key,
+              status: 'queued',
+              progress: 0,
+              type: 'file',
+              parentFolderId: result.taskId,
+            });
+          }
+        } else {
+          // Loose files get no wrapper card; each is its own row.
+          for (const file of result.files) {
+            addUpload(file.uploadId, {
+              id: file.uploadId,
+              name: file.file.name,
+              status: 'queued',
+              progress: 0,
+              type: 'file',
+            });
+          }
+        }
+
+        // The manager refused this plan outright - a disposed manager after a
+        // logout or bucket switch. Say so on a card rather than dropping it.
+        if (result.dispatchError && result.files.length === 0) {
+          addUpload(result.taskId, {
+            id: result.taskId,
+            name: result.plan.resolvedName || 'Upload',
+            status: 'failed',
+            progress: 0,
+            type: result.plan.kind,
+            error: result.dispatchError.message,
+          });
+        }
+      }
+
+      return {
+        dispatched,
+        notices,
+        nothingStarted: dispatched.every((result) => result.files.length === 0),
+      };
+    },
+    [executor, addUpload]
+  );
+}

--- a/frontend/src/features/upload/hooks/use-upload-dispatch.ts
+++ b/frontend/src/features/upload/hooks/use-upload-dispatch.ts
@@ -28,6 +28,8 @@ import { useUploadQueueStore, type QueueNotice } from '../stores/use-upload-queu
 import { useUploadStore } from '../stores/use-upload-store';
 import { useUploadExecutor } from '../context/upload-context';
 import type { DispatchResult } from '../services/upload-executor';
+import { objectExists, objectKey } from '@/services/object-existence';
+import { generateUniqueFileName } from '../utils/unique-filename';
 
 export interface DropOutcome {
   dispatched: DispatchResult[];
@@ -38,9 +40,111 @@ export interface DropOutcome {
 
 const EMPTY_OUTCOME: DropOutcome = { dispatched: [], notices: [], nothingStarted: true };
 
+/** How many object-existence checks run at once, matching VERIFY_CONCURRENCY. */
+const DUPLICATE_CHECK_CONCURRENCY = 5;
+
+type FileVerdict =
+  | { kind: 'upload'; file: File }
+  | { kind: 'replace'; file: File }
+  | { kind: 'skip' }
+  | { kind: 'unverified'; file: File; reason: string };
+
+/**
+ * Decides what to do with each loose file before anything is dispatched.
+ *
+ * Folder collisions are planning's job; a loose file collides at the OBJECT
+ * level, and S3 PUT overwrites silently, so this is the only thing standing
+ * between a same-named drop and data loss. The prompt it drives is the one that
+ * already existed - this pipeline simply bypassed it, which is the regression
+ * being fixed.
+ *
+ * Checks run concurrently, unlike the sequential version this replaces.
+ */
+async function decideLooseFiles(
+  files: readonly File[],
+  destination: string,
+  apiS3: BYOS3ApiProvider,
+  ask: (file: File) => Promise<'replace' | 'keepBoth'>
+): Promise<FileVerdict[]> {
+  const verdicts: FileVerdict[] = new Array(files.length);
+  const collisions: number[] = [];
+
+  let cursor = 0;
+  const runners = Array.from(
+    { length: Math.min(DUPLICATE_CHECK_CONCURRENCY, files.length) },
+    async () => {
+      while (cursor < files.length) {
+        const index = cursor++;
+        const file = files[index]!;
+        try {
+          const exists = await objectExists(apiS3, objectKey(destination, file.name));
+          if (exists) collisions.push(index);
+          else verdicts[index] = { kind: 'upload', file };
+        } catch (error) {
+          // Indeterminate. Uploading anyway may overwrite; refusing loses the
+          // upload. Upload, but say so - the same call folder verification
+          // makes, and the same notice channel.
+          verdicts[index] = {
+            kind: 'unverified',
+            file,
+            reason: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }
+    }
+  );
+  await Promise.all(runners);
+
+  // Prompts are sequential on purpose: the dialog shows one question at a time,
+  // and firing them all at once would queue five modals at the user.
+  for (const index of collisions.sort((a, b) => a - b)) {
+    const file = files[index]!;
+    const choice = await ask(file);
+
+    if (choice === 'replace') {
+      verdicts[index] = { kind: 'replace', file };
+      continue;
+    }
+
+    try {
+      const uniqueName = await generateUniqueFileName(apiS3, file.name, destination);
+      verdicts[index] = {
+        kind: 'upload',
+        file: new File([file], uniqueName, { type: file.type }),
+      };
+    } catch {
+      // Could not find a free name, so there is no safe way to keep both.
+      verdicts[index] = { kind: 'skip' };
+    }
+  }
+
+  return verdicts;
+}
+
 export function useUploadDispatch() {
   const executor = useUploadExecutor();
   const addUpload = useUploadStore((state) => state.addUpload);
+  const showDuplicateDialog = useUploadStore((state) => state.showDuplicateDialog);
+  const hideDuplicateDialog = useUploadStore((state) => state.hideDuplicateDialog);
+
+  /** Shows the existing replace / keep-both prompt and resolves with the answer. */
+  const askAboutDuplicate = useCallback(
+    (file: File) =>
+      new Promise<'replace' | 'keepBoth'>((resolve) => {
+        showDuplicateDialog(
+          { name: file.name, type: 'file', size: file.size },
+          () => {
+            hideDuplicateDialog();
+            resolve('replace');
+          },
+          () => {
+            hideDuplicateDialog();
+            resolve('keepBoth');
+          }
+        );
+      }),
+    [showDuplicateDialog, hideDuplicateDialog]
+  );
 
   return useCallback(
     async (
@@ -52,9 +156,49 @@ export function useUploadDispatch() {
       // reserve prefixes for uploads that can never run.
       if (!executor) return EMPTY_OUTCOME;
 
+      // Object-level collisions for loose files, resolved BEFORE planning so
+      // the plan carries the files the user actually agreed to upload.
+      let individualFiles = data.individualFiles;
+      const looseNotices: QueueNotice[] = [];
+
+      if (apiS3 && individualFiles.length > 0) {
+        const verdicts = await decideLooseFiles(
+          individualFiles,
+          destinationPrefix,
+          apiS3,
+          askAboutDuplicate
+        );
+
+        individualFiles = [];
+        verdicts.forEach((verdict, index) => {
+          if (verdict.kind === 'skip') {
+            looseNotices.push({
+              id: `dup-skip-${Date.now()}-${index}`,
+              kind: 'skipped',
+              path: data.individualFiles[index]!.name,
+              count: 1,
+              detail: `Could not find a free name for "${data.individualFiles[index]!.name}", so it was not uploaded.`,
+            });
+            return;
+          }
+
+          if (verdict.kind === 'unverified') {
+            looseNotices.push({
+              id: `dup-unverified-${Date.now()}-${index}`,
+              kind: 'unverified',
+              path: verdict.file.name,
+              count: 1,
+              detail: `Could not check whether "${verdict.file.name}" already exists here, so it is being uploaded under that name. If it does exist, it will be overwritten.`,
+            });
+          }
+
+          individualFiles.push(verdict.file);
+        });
+      }
+
       const { planned, notices } = await useUploadQueueStore
         .getState()
-        .planDrop(data, { destinationPrefix, apiS3 });
+        .planDrop({ ...data, individualFiles }, { destinationPrefix, apiS3 });
 
       const dispatched = executor.start(planned);
 
@@ -110,12 +254,18 @@ export function useUploadDispatch() {
         }
       }
 
+      if (looseNotices.length > 0) {
+        useUploadQueueStore.setState((state) => ({
+          notices: [...state.notices, ...looseNotices],
+        }));
+      }
+
       return {
         dispatched,
-        notices,
+        notices: [...notices, ...looseNotices],
         nothingStarted: dispatched.every((result) => result.files.length === 0),
       };
     },
-    [executor, addUpload]
+    [executor, addUpload, askAboutDuplicate]
   );
 }

--- a/frontend/src/services/object-existence.ts
+++ b/frontend/src/services/object-existence.ts
@@ -1,0 +1,30 @@
+import { BYOS3ApiProvider } from '@opndrive/s3-api';
+
+/**
+ * Whether a single object already exists at `key`.
+ *
+ * The sibling of `folderExists`, and deliberately shaped the same way: it does
+ * NOT catch. The version this replaces lived inside the upload store and did
+ *
+ *     try { ... } catch { return false; }
+ *
+ * so a HEAD that failed for any reason - throttling, a dropped connection, a
+ * permissions gap - was read as "nothing is there" and the upload silently
+ * overwrote whatever was. Callers that cannot determine the answer must say so
+ * rather than guess.
+ *
+ * @throws whatever the metadata lookup threw.
+ */
+export async function objectExists(apiS3: BYOS3ApiProvider, key: string): Promise<boolean> {
+  const metadata = await apiS3.fetchMetadata(key);
+  return metadata !== null;
+}
+
+/** Joins a destination prefix and a file name into an S3 key. */
+export function objectKey(prefix: string, fileName: string): string {
+  let clean = prefix ?? '';
+  if (clean.startsWith('/')) clean = clean.slice(1);
+  if (!clean || clean === '/') return fileName;
+  if (!clean.endsWith('/')) clean = `${clean}/`;
+  return `${clean}${fileName}`;
+}


### PR DESCRIPTION
Phase 5 Part 2. The planning and executor work from #136 and #137 is now actually reachable from the UI, and the notices we have been computing since Phase 4 are finally on screen.

## Drops go through planning now

Every drop entry point (both dashboard pages, the create menu) used to call `handleFilesDroppedToDirectory`. That path checked collisions against the bucket only, so two folders named "photos" in one drop both passed and the second overwrote the first. It returned on the first duplicate, abandoning every folder behind it. And it built keys through `addFolderUpload`, which re-nests a renamed folder under its original name.

`useUploadDispatch` replaces it: plan, dispatch to the executor, register the cards the panel renders. **Behaviour is unchanged for the user** - drops still start immediately, no confirm step.

Cancelling a folder now goes through `executor.cancelTask`, which is the part that matters: it aborts every file *and* decides whether the prefix claim can be handed back. Cancelling the files directly, as before, aborted the uploads but left the name reserved for the rest of the session.

The executor lives in `UploadContext`, one per manager, disposed when the manager changes. That also fixes `useUploadContext`, which created its context with `null` and then threw whenever the value was falsy - so it threw unconditionally. Nobody noticed because nothing called it.

## Notices are rendered

They were computed, grouped by folder and reason, capped at a hundred, and then shown to nobody.

The three kinds are distinguished because they mean different things: a rename is informational, a skip means that data is **not** in the bucket, and `unverified` means the folder is uploading under a name we could not check, which is the only one that can still overwrite something. That one is styled as a warning.

The panel also no longer hides itself when a drop produced notices but started zero uploads - previously that left the user with a blank screen after, say, a folder that was entirely permission-locked.

## Hooks fix

Both dashboard pages and the create menu had their auth early returns sitting above a dozen `useEffect`/`useCallback` calls, so React saw a different hook count before and after the session resolved. That is the "rendered fewer hooks than expected" crash waiting for the right timing. Effects that dereferenced `apiS3` are guarded internally now.

Pre-existing and unrelated to the wiring, but touching those files brought them under the pre-commit lint gate. Repo-wide warnings drop from 80 to 50.

## Checks

547 tests (up from 519), typecheck clean, build passes, lint 0 errors.

28 new tests: the notice renderer (first component tests in the repo, asserting on the text a user reads rather than on props, since the bug being fixed is precisely "data was there and nothing displayed it") and the dispatch hook.

All 10 mutations against the new code were caught, most by exactly the one test that should catch them.

One thing worth knowing for anyone writing tooling here: a child process given a lowercase `c:/...` cwd makes Vite resolve `zustand` as a distinct module, so `__mocks__/zustand` never applies and 13 tests fail with no code change at all. Uppercase `C:` is required. That cost me a wrong mutation report before I caught it.
