### PR TITLE
Update community meetups to run every other day

### DIFF
--- a/docs/components/community-card.tsx
+++ b/docs/components/community-card.tsx
@@ -31,7 +31,7 @@ export function CommunityCard() {
         <div>
           <span className={styles.badge}>
             <span className={styles.pulse} />
-            Every Wed @ 5 PM UTC
+            Every other day @ 5 PM UTC
           </span>
 
           <h3 className={styles.heading}>Build Opndrive with us</h3>

--- a/frontend/src/shared/components/discord/bento-primitives.tsx
+++ b/frontend/src/shared/components/discord/bento-primitives.tsx
@@ -84,7 +84,7 @@ export function BuilderAvatars({ className }: { className?: string }) {
   );
 }
 
-/** The pulsing "we meet on Wednesdays" badge. */
+/** The pulsing "when we meet" badge. */
 export function LiveBadge({ className }: { className?: string }) {
   return (
     <div
@@ -98,7 +98,7 @@ export function LiveBadge({ className }: { className?: string }) {
         <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-community-live" />
       </span>
       <span className="whitespace-nowrap text-[10px] font-medium text-community-live">
-        Every Wed @ 5 PM UTC
+        Every other day @ 5 PM UTC
       </span>
     </div>
   );

--- a/frontend/src/shared/components/discord/discord-bento-card.tsx
+++ b/frontend/src/shared/components/discord/discord-bento-card.tsx
@@ -44,12 +44,12 @@ export function DiscordBentoCard({ className }: { className?: string }) {
           <LiveBadge className="mb-2.5" />
 
           <h3 className="text-sm font-semibold leading-snug text-foreground">
-            Wednesday Hangouts
+            Community Meetups
             <br />
             &amp; Live Demos
           </h3>
 
-          {/* calendar visualizer - the week, with Wednesday lit */}
+          {/* calendar visualizer - alternating days lit, matching the cadence */}
           <div className="mt-3 flex items-center gap-1">
             <Calendar className="mr-1 h-3 w-3 text-muted-foreground" />
             {['M', 'T', 'W', 'T', 'F', 'S', 'S'].map((day, i) => (
@@ -57,7 +57,7 @@ export function DiscordBentoCard({ className }: { className?: string }) {
                 key={i}
                 className={cn(
                   'flex h-4 w-4 items-center justify-center rounded text-[9px] font-medium',
-                  i === 2
+                  i % 2 === 0
                     ? 'bg-primary text-primary-foreground shadow-md shadow-primary/40'
                     : 'bg-foreground/10 text-muted-foreground'
                 )}


### PR DESCRIPTION
Meetups now run every other day instead of Wednesdays, so this updates the wording on the Discord cards across the landing page, dashboard and docs.
The Bento tile's week strip also lights alternating days now instead of a single one.