### PR TITLE
fix: open files and folders with a keyboard

### DIFF
--- a/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
@@ -10,6 +10,7 @@ import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
+import { getItemKeyIntent } from './item-keyboard';
 
 interface FileItemGridProps {
   file: FileItem;
@@ -118,18 +119,39 @@ export function FileItemGrid({
     }
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const intent = getItemKeyIntent(event);
+    if (!intent) return;
+
+    // Space would scroll the page otherwise
+    event.preventDefault();
+
+    if (intent === 'select') {
+      selectItem(file, 'file', index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
+      return;
+    }
+
+    if (!file.Key?.endsWith('/')) {
+      openFilePreview(file, allFiles);
+    }
+  };
+
   const timeInfo = formatTimeWithTooltip(file.lastModified);
 
   return (
     <div
       data-file-item
-      className="group relative rounded-lg bg-secondary/50 hover:bg-secondary/80 transition-all cursor-pointer select-none"
+      role="button"
+      tabIndex={0}
+      aria-label={`${file.name}, file${selected ? ', selected' : ''}`}
+      className="group relative rounded-lg bg-secondary/50 hover:bg-secondary/80 transition-all cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-primary"
       style={{
         outline: selected ? '2px solid var(--primary)' : 'none',
         background: selected ? 'var(--accent)' : undefined,
       }}
       onClick={handleFileClick}
       onDoubleClick={handleDoubleClick}
+      onKeyDown={handleKeyDown}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchEnd}
@@ -178,6 +200,7 @@ export function FileItemGrid({
           <AriaLabel label={`More actions`} position="top">
             <button
               className="p-1 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
+              aria-label={`More actions for ${file.name}`}
               onClick={handleMenuClick}
             >
               <HiOutlineDotsVertical size={18} className=" text-muted-foreground" />

--- a/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
@@ -9,6 +9,7 @@ import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
+import { getItemKeyIntent } from './item-keyboard';
 
 interface FileItemListProps {
   file: FileItem;
@@ -117,6 +118,23 @@ export function FileItemList({
     }
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const intent = getItemKeyIntent(event);
+    if (!intent) return;
+
+    // Space would scroll the page otherwise
+    event.preventDefault();
+
+    if (intent === 'select') {
+      selectItem(file, 'file', index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
+      return;
+    }
+
+    if (!file.Key?.endsWith('/')) {
+      openFilePreview(file, allFiles);
+    }
+  };
+
   const timeInfo = formatTimeWithTooltip(file.lastModified);
 
   return (
@@ -129,12 +147,16 @@ export function FileItemList({
     >
       {/* Responsive Grid Layout */}
       <div
-        className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2 sm:gap-3 lg:gap-4 px-3 sm:px-4 py-3 hover:bg-secondary/50 transition-all cursor-pointer items-center min-h-[56px] sm:min-h-[64px]"
+        role="button"
+        tabIndex={0}
+        aria-label={`${file.name}, file${selected ? ', selected' : ''}`}
+        className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2 sm:gap-3 lg:gap-4 px-3 sm:px-4 py-3 hover:bg-secondary/50 transition-all cursor-pointer items-center min-h-[56px] sm:min-h-[64px] focus-visible:ring-2 focus-visible:ring-primary"
         style={{
           borderLeft: selected ? '3px solid var(--primary)' : '3px solid transparent',
         }}
         onClick={handleFileClick}
         onDoubleClick={handleDoubleClick}
+        onKeyDown={handleKeyDown}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onTouchCancel={handleTouchEnd}
@@ -199,6 +221,7 @@ export function FileItemList({
           <AriaLabel label={`More actions`} position="top">
             <button
               className="p-1.5 sm:p-2 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
+              aria-label={`More actions for ${file.name}`}
               onClick={handleMenuClick}
             >
               <HiOutlineDotsVertical

--- a/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
@@ -9,6 +9,7 @@ import { getEffectiveExtension, getFileExtensionWithoutDot } from '@/config/file
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { useFilePreview } from '@/context/file-preview-context';
+import { getItemKeyIntent } from './item-keyboard';
 
 interface FileItemMobileProps {
   file: FileItem;
@@ -122,6 +123,21 @@ export function FileItemMobile({
     handleFileOpen();
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const intent = getItemKeyIntent(event);
+    if (!intent) return;
+
+    // Space would scroll the page otherwise
+    event.preventDefault();
+
+    if (intent === 'select') {
+      selectItem(file, 'file', index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
+      return;
+    }
+
+    handleItemClick();
+  };
+
   const handleFileOpen = () => {
     // Use the same preview logic as the overflow menu's "Open" action
     const previewableFile = {
@@ -153,7 +169,10 @@ export function FileItemMobile({
   return (
     <div
       data-file-item
-      className={`flex items-center p-4 transition-colors cursor-pointer select-none touch-manipulation ${
+      role="button"
+      tabIndex={0}
+      aria-label={`${file.name}, file${selected ? ', selected' : ''}`}
+      className={`flex items-center p-4 transition-colors cursor-pointer select-none touch-manipulation focus-visible:ring-2 focus-visible:ring-primary ${
         selected
           ? 'bg-primary/10 hover:bg-primary/15 active:bg-primary/20'
           : 'hover:bg-secondary/50 active:bg-secondary/70'
@@ -164,6 +183,7 @@ export function FileItemMobile({
         userSelect: 'none',
       }}
       onClick={handleItemClick}
+      onKeyDown={handleKeyDown}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
@@ -212,6 +232,7 @@ export function FileItemMobile({
       <AriaLabel label={`More actions`} position="top">
         <button
           className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
+          aria-label={`More actions for ${file.name}`}
           onClick={handleMenuClick}
         >
           <HiOutlineDotsVertical size={20} className="text-muted-foreground" />

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
@@ -6,6 +6,7 @@ import { FolderOverflowMenu } from '../menus/folder-overflow-menu';
 import { Folder } from '@/features/dashboard/types/folder';
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
+import { getItemKeyIntent } from './item-keyboard';
 
 interface FolderItemMobileProps {
   folder: Folder;
@@ -113,6 +114,28 @@ export function FolderItemMobile({
     handleFolderOpen();
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const intent = getItemKeyIntent(event);
+    if (!intent) return;
+
+    // Space would scroll the page otherwise
+    event.preventDefault();
+
+    if (intent === 'select') {
+      selectItem(
+        folder,
+        'folder',
+        index,
+        event.ctrlKey || event.metaKey,
+        event.shiftKey,
+        allFolders
+      );
+      return;
+    }
+
+    handleItemClick();
+  };
+
   const handleFolderOpen = () => {
     onFolderClick?.(folder);
   };
@@ -122,7 +145,10 @@ export function FolderItemMobile({
   return (
     <div
       data-folder-item
-      className={`flex items-center p-4 transition-colors cursor-pointer select-none touch-manipulation ${
+      role="button"
+      tabIndex={0}
+      aria-label={`${folder.name}, folder${selected ? ', selected' : ''}`}
+      className={`flex items-center p-4 transition-colors cursor-pointer select-none touch-manipulation focus-visible:ring-2 focus-visible:ring-primary ${
         selected
           ? 'bg-primary/10 hover:bg-primary/15 active:bg-primary/20'
           : 'hover:bg-secondary/50 active:bg-secondary/70'
@@ -133,6 +159,7 @@ export function FolderItemMobile({
         userSelect: 'none',
       }}
       onClick={handleItemClick}
+      onKeyDown={handleKeyDown}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
@@ -174,7 +201,7 @@ export function FolderItemMobile({
       <button
         className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
         onClick={handleMenuClick}
-        aria-label="More actions"
+        aria-label={`More actions for ${folder.name}`}
       >
         <HiOutlineDotsVertical size={20} className="text-muted-foreground" />
       </button>

--- a/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
@@ -10,6 +10,7 @@ import { Folder, FolderMenuAction } from '@/features/dashboard/types/folder';
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
+import { getItemKeyIntent } from './item-keyboard';
 
 interface FolderItemProps {
   folder: Folder;
@@ -122,6 +123,28 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     }
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const intent = getItemKeyIntent(event);
+    if (!intent) return;
+
+    // Space would scroll the page otherwise
+    event.preventDefault();
+
+    if (intent === 'select') {
+      selectItem(
+        folder,
+        'folder',
+        index,
+        event.ctrlKey || event.metaKey,
+        event.shiftKey,
+        allFolders
+      );
+      return;
+    }
+
+    onClick?.(folder);
+  };
+
   const handleMenuClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     setMenuAnchor(event.currentTarget as HTMLElement);
@@ -140,11 +163,15 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     <>
       <div
         data-folder-item
+        role="button"
+        tabIndex={0}
+        aria-label={`${folder.name}, folder${selected ? ', selected' : ''}`}
         className={`
           group flex items-center gap-3 p-3 rounded-lg
           transition-all duration-200 cursor-pointer select-none
-          bg-secondary 
+          bg-secondary
           hover:bg-secondary/80
+          focus-visible:ring-2 focus-visible:ring-primary
           ${className}
         `}
         style={{
@@ -153,6 +180,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
         }}
         onClick={handleClick}
         onDoubleClick={handleDoubleClick}
+        onKeyDown={handleKeyDown}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onTouchCancel={handleTouchEnd}
@@ -191,6 +219,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
               hover:bg-accent transition-all duration-200
               text-muted-foreground hover:text-foreground
             "
+            aria-label={`More actions for ${folder.name}`}
             onClick={handleMenuClick}
           >
             <MoreVerticalIcon size={16} />

--- a/frontend/src/features/dashboard/components/ui/items/item-keyboard.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-keyboard.test.tsx
@@ -6,24 +6,39 @@
  * with a keyboard at all. These tests go through the accessible role and name
  * a keyboard user actually lands on, so removing the role, the tabIndex or the
  * key handler fails here rather than silently shipping.
+ *
+ * All five row components carry their own copy of the handler, so all five are
+ * covered here. They started as copies of each other and drift is the likely
+ * way this regresses.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { FolderItem } from './folder-item';
+import { FolderItemMobile } from './folder-item-mobile';
 import { FileItemList } from './file-item-list';
+import { FileItemGrid } from './file-item-grid';
+import { FileItemMobile } from './file-item-mobile';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import type { Folder } from '@/features/dashboard/types/folder';
 import type { FileItem } from '@/features/dashboard/types/file';
 
-// The overflow menus pull in the rename, drive and router contexts, none of
-// which this file is about.
+// The overflow menus pull in the rename, drive and router contexts, and the
+// grid thumbnail wants an authenticated S3 client. None of that is what this
+// file is about.
 vi.mock('../menus/folder-overflow-menu', () => ({ FolderOverflowMenu: () => null }));
 vi.mock('../menus/file-overflow-menu', () => ({ FileOverflowMenu: () => null }));
+vi.mock('./file-thumbnail-with-image', () => ({ FileThumbnailWithImage: () => null }));
 
-const { openFilePreview } = vi.hoisted(() => ({ openFilePreview: vi.fn() }));
+const { openFilePreview, openPreview } = vi.hoisted(() => ({
+  openFilePreview: vi.fn(),
+  openPreview: vi.fn(),
+}));
 vi.mock('@/hooks/use-file-preview-actions', () => ({
   useFilePreviewActions: () => ({ openFilePreview }),
+}));
+vi.mock('@/context/file-preview-context', () => ({
+  useFilePreview: () => ({ openPreview }),
 }));
 
 function folder(overrides: Partial<Folder> = {}): Folder {
@@ -51,6 +66,7 @@ const selection = () => useMultiSelectStore.getState().selectedItems;
 
 beforeEach(() => {
   openFilePreview.mockClear();
+  openPreview.mockClear();
 });
 
 describe('folder rows', () => {
@@ -92,6 +108,28 @@ describe('folder rows', () => {
     expect(selection()).toHaveLength(1);
   });
 
+  it('extends the selection with Shift the way Shift+Click does', () => {
+    const folders = [folder(), folder({ id: 'taxes', name: 'Taxes', Prefix: 'taxes/' })];
+    render(
+      <>
+        <FolderItem folder={folders[0]} index={0} allFolders={folders} />
+        <FolderItem folder={folders[1]} index={1} allFolders={folders} />
+      </>
+    );
+
+    // Ctrl first to drop the anchor, then Shift to reach across
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Taxes, folder' }), {
+      key: 'Enter',
+      shiftKey: true,
+    });
+
+    expect(selection()).toHaveLength(2);
+  });
+
   it('reports the selection to screen readers', () => {
     render(<FolderItem folder={folder()} allFolders={[folder()]} />);
 
@@ -108,6 +146,31 @@ describe('folder rows', () => {
     render(<FolderItem folder={folder()} onClick={onClick} />);
 
     fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), { key: 'a' });
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(selection()).toHaveLength(0);
+  });
+
+  it('does not navigate again while Enter is held down', () => {
+    const onClick = vi.fn();
+    render(<FolderItem folder={folder()} onClick={onClick} />);
+    const row = screen.getByRole('button', { name: 'Reports, folder' });
+
+    fireEvent.keyDown(row, { key: 'Enter' });
+    fireEvent.keyDown(row, { key: 'Enter', repeat: true });
+    fireEvent.keyDown(row, { key: 'Enter', repeat: true });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves Alt combinations to the operating system', () => {
+    const onClick = vi.fn();
+    render(<FolderItem folder={folder()} onClick={onClick} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), {
+      key: ' ',
+      altKey: true,
+    });
 
     expect(onClick).not.toHaveBeenCalled();
     expect(selection()).toHaveLength(0);
@@ -169,6 +232,109 @@ describe('file rows', () => {
     });
 
     expect(openFilePreview).not.toHaveBeenCalled();
+    expect(selection()).toHaveLength(1);
+  });
+
+  it('does not open the file when the overflow menu is opened with a key', () => {
+    render(<FileItemList file={file()} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'More actions for budget.xlsx' }), {
+      key: 'Enter',
+    });
+
+    expect(openFilePreview).not.toHaveBeenCalled();
+  });
+});
+
+describe('grid tiles', () => {
+  it('opens the preview on Enter', () => {
+    const files = [file()];
+    render(<FileItemGrid file={file()} allFiles={files} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'budget.xlsx, file' }), { key: 'Enter' });
+
+    expect(openFilePreview).toHaveBeenCalledWith(file(), files);
+  });
+
+  it('selects instead of opening when Ctrl is held', () => {
+    render(<FileItemGrid file={file()} allFiles={[file()]} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'budget.xlsx, file' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    expect(openFilePreview).not.toHaveBeenCalled();
+    expect(selection()).toHaveLength(1);
+  });
+
+  it('does not open the file when the overflow menu is opened with a key', () => {
+    // The menu lives inside the tile here, so its key events reach the tile
+    render(<FileItemGrid file={file()} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'More actions for budget.xlsx' }), {
+      key: 'Enter',
+    });
+
+    expect(openFilePreview).not.toHaveBeenCalled();
+  });
+});
+
+describe('mobile rows', () => {
+  it('opens the folder on Enter', () => {
+    const onFolderClick = vi.fn();
+    render(<FolderItemMobile folder={folder()} onFolderClick={onFolderClick} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), { key: 'Enter' });
+
+    expect(onFolderClick).toHaveBeenCalledWith(folder());
+  });
+
+  it('adds to an existing selection rather than opening, the way a tap does', () => {
+    const onFolderClick = vi.fn();
+    const folders = [folder(), folder({ id: 'taxes', name: 'Taxes', Prefix: 'taxes/' })];
+    render(
+      <>
+        <FolderItemMobile folder={folders[0]} index={0} allFolders={folders} />
+        <FolderItemMobile
+          folder={folders[1]}
+          index={1}
+          allFolders={folders}
+          onFolderClick={onFolderClick}
+        />
+      </>
+    );
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Taxes, folder' }), { key: 'Enter' });
+
+    expect(onFolderClick).not.toHaveBeenCalled();
+    expect(selection()).toHaveLength(2);
+  });
+
+  it('opens the file preview on Enter', () => {
+    render(<FileItemMobile file={file()} allFiles={[file()]} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'budget.xlsx, file' }), { key: 'Enter' });
+
+    expect(openPreview).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'budget.xlsx' }),
+      expect.arrayContaining([expect.objectContaining({ name: 'budget.xlsx' })])
+    );
+  });
+
+  it('selects the file instead of opening it when Ctrl is held', () => {
+    render(<FileItemMobile file={file()} allFiles={[file()]} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'budget.xlsx, file' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    expect(openPreview).not.toHaveBeenCalled();
     expect(selection()).toHaveLength(1);
   });
 });

--- a/frontend/src/features/dashboard/components/ui/items/item-keyboard.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-keyboard.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Keyboard access for file and folder rows.
+ *
+ * The rows used to be plain divs with onClick and onDoubleClick, so the file
+ * browser - the core interaction of the app - could not be reached or opened
+ * with a keyboard at all. These tests go through the accessible role and name
+ * a keyboard user actually lands on, so removing the role, the tabIndex or the
+ * key handler fails here rather than silently shipping.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FolderItem } from './folder-item';
+import { FileItemList } from './file-item-list';
+import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
+import type { Folder } from '@/features/dashboard/types/folder';
+import type { FileItem } from '@/features/dashboard/types/file';
+
+// The overflow menus pull in the rename, drive and router contexts, none of
+// which this file is about.
+vi.mock('../menus/folder-overflow-menu', () => ({ FolderOverflowMenu: () => null }));
+vi.mock('../menus/file-overflow-menu', () => ({ FileOverflowMenu: () => null }));
+
+const { openFilePreview } = vi.hoisted(() => ({ openFilePreview: vi.fn() }));
+vi.mock('@/hooks/use-file-preview-actions', () => ({
+  useFilePreviewActions: () => ({ openFilePreview }),
+}));
+
+function folder(overrides: Partial<Folder> = {}): Folder {
+  return {
+    id: 'reports',
+    name: 'Reports',
+    Prefix: 'reports/',
+    location: { type: 'my-drive', label: 'My Drive' },
+    ...overrides,
+  };
+}
+
+function file(overrides: Partial<FileItem> = {}): FileItem {
+  return {
+    id: 'budget',
+    name: 'budget.xlsx',
+    Key: 'reports/budget.xlsx',
+    extension: 'xlsx',
+    size: { value: 12, unit: 'KB' },
+    ...overrides,
+  };
+}
+
+const selection = () => useMultiSelectStore.getState().selectedItems;
+
+beforeEach(() => {
+  openFilePreview.mockClear();
+});
+
+describe('folder rows', () => {
+  it('exposes the folder as a named, focusable button', () => {
+    render(<FolderItem folder={folder()} />);
+
+    const row = screen.getByRole('button', { name: 'Reports, folder' });
+    expect(row).toHaveProperty('tabIndex', 0);
+  });
+
+  it('opens the folder on Enter', () => {
+    const onClick = vi.fn();
+    render(<FolderItem folder={folder()} onClick={onClick} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), { key: 'Enter' });
+
+    expect(onClick).toHaveBeenCalledWith(folder());
+  });
+
+  it('opens the folder on Space', () => {
+    const onClick = vi.fn();
+    render(<FolderItem folder={folder()} onClick={onClick} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), { key: ' ' });
+
+    expect(onClick).toHaveBeenCalledWith(folder());
+  });
+
+  it('selects instead of opening when Ctrl is held', () => {
+    const onClick = vi.fn();
+    render(<FolderItem folder={folder()} onClick={onClick} allFolders={[folder()]} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(selection()).toHaveLength(1);
+  });
+
+  it('reports the selection to screen readers', () => {
+    render(<FolderItem folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    expect(screen.getByRole('button', { name: 'Reports, folder, selected' })).toBeDefined();
+  });
+
+  it('ignores keys that are not Enter or Space', () => {
+    const onClick = vi.fn();
+    render(<FolderItem folder={folder()} onClick={onClick} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), { key: 'a' });
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(selection()).toHaveLength(0);
+  });
+
+  it('does not open the folder when the overflow menu is opened with a key', () => {
+    const onClick = vi.fn();
+    render(<FolderItem folder={folder()} onClick={onClick} />);
+
+    // Bubbles up to the row, which must ignore it
+    fireEvent.keyDown(screen.getByRole('button', { name: 'More actions for Reports' }), {
+      key: 'Enter',
+    });
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+describe('file rows', () => {
+  it('exposes the file as a named, focusable button', () => {
+    render(<FileItemList file={file()} />);
+
+    const row = screen.getByRole('button', { name: 'budget.xlsx, file' });
+    expect(row).toHaveProperty('tabIndex', 0);
+  });
+
+  it('opens the preview on Enter', () => {
+    const files = [file()];
+    render(<FileItemList file={file()} allFiles={files} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'budget.xlsx, file' }), { key: 'Enter' });
+
+    expect(openFilePreview).toHaveBeenCalledWith(file(), files);
+  });
+
+  it('opens the preview on Space', () => {
+    render(<FileItemList file={file()} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'budget.xlsx, file' }), { key: ' ' });
+
+    expect(openFilePreview).toHaveBeenCalled();
+  });
+
+  it('does not preview a key that is really a folder marker', () => {
+    const marker = file({ name: 'archive', Key: 'reports/archive/' });
+    render(<FileItemList file={marker} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'archive, file' }), { key: 'Enter' });
+
+    expect(openFilePreview).not.toHaveBeenCalled();
+  });
+
+  it('selects instead of opening when Ctrl is held', () => {
+    render(<FileItemList file={file()} allFiles={[file()]} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'budget.xlsx, file' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    expect(openFilePreview).not.toHaveBeenCalled();
+    expect(selection()).toHaveLength(1);
+  });
+});

--- a/frontend/src/features/dashboard/components/ui/items/item-keyboard.ts
+++ b/frontend/src/features/dashboard/components/ui/items/item-keyboard.ts
@@ -1,0 +1,18 @@
+import type React from 'react';
+
+/** What a key press on a file or folder row should do. */
+export type ItemKeyIntent = 'open' | 'select' | null;
+
+/**
+ * Enter and Space activate a row the same way a double click does, and the
+ * modifiers mirror the mouse - Ctrl/Cmd toggles the selection, Shift extends it.
+ *
+ * Presses that bubble up from the overflow menu button are ignored, otherwise
+ * opening the menu with the keyboard would also open the item behind it.
+ */
+export function getItemKeyIntent(event: React.KeyboardEvent<HTMLElement>): ItemKeyIntent {
+  if (event.key !== 'Enter' && event.key !== ' ') return null;
+  if (event.target !== event.currentTarget) return null;
+
+  return event.ctrlKey || event.metaKey || event.shiftKey ? 'select' : 'open';
+}

--- a/frontend/src/features/dashboard/components/ui/items/item-keyboard.ts
+++ b/frontend/src/features/dashboard/components/ui/items/item-keyboard.ts
@@ -7,12 +7,18 @@ export type ItemKeyIntent = 'open' | 'select' | null;
  * Enter and Space activate a row the same way a double click does, and the
  * modifiers mirror the mouse - Ctrl/Cmd toggles the selection, Shift extends it.
  *
- * Presses that bubble up from the overflow menu button are ignored, otherwise
- * opening the menu with the keyboard would also open the item behind it.
+ * Three kinds of press are deliberately ignored:
+ * - anything that bubbled up from the overflow menu button or the open menu,
+ *   otherwise opening the menu with the keyboard would also open the item
+ *   behind it
+ * - a held key repeating, which would otherwise navigate or open a preview
+ *   once per repeat
+ * - Alt combinations, which belong to the operating system rather than to us
  */
 export function getItemKeyIntent(event: React.KeyboardEvent<HTMLElement>): ItemKeyIntent {
   if (event.key !== 'Enter' && event.key !== ' ') return null;
   if (event.target !== event.currentTarget) return null;
+  if (event.repeat || event.altKey) return null;
 
   return event.ctrlKey || event.metaKey || event.shiftKey ? 'select' : 'open';
 }


### PR DESCRIPTION
Closes #85.

The file and folder rows were plain divs with `onClick`/`onDoubleClick`, so the file browser could not be reached or opened with a keyboard at all.

All five row components (folder, file list, file grid, and both mobile variants) now render as focusable buttons:

- Enter or Space opens the item, matching double click
- Ctrl/Cmd and Shift select and extend, matching the mouse, so keyboard users can reach multi-select
- Each row has a screen reader name and a visible focus ring
- The overflow menu buttons had no accessible name, so they got one too

Key presses that bubble from the overflow menu are ignored, as are held keys (Enter used to repeat once per keydown) and Alt combos.

One deviation from the issue: it asked for `aria-selected`, but that is not valid on `role="button"` and screen readers drop it, so the selection is in the accessible name instead ("Reports, folder, selected").

23 tests cover all five components and fail without the fix.
