### PR TITLE
feat: add error boundaries so a render error cannot blank the app

### DIFF
--- a/frontend/src/app/dashboard/error.tsx
+++ b/frontend/src/app/dashboard/error.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Button } from '@/shared/components/ui';
+
+/**
+ * Dashboard scoped boundary. It renders inside the dashboard layout, so the
+ * navbar and sidebar stay usable and only the content area is replaced. Errors
+ * thrown by the dashboard layout itself fall through to app/error.tsx.
+ */
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Dashboard render error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex h-full min-h-96 items-center justify-center p-6">
+      <div className="w-full max-w-md rounded-2xl border border-border bg-card p-8 text-center">
+        <div className="mx-auto mb-5 inline-flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+          <AlertTriangle className="h-7 w-7 text-primary" />
+        </div>
+
+        <h2 className="mb-2 text-xl font-semibold text-foreground">This view failed to load</h2>
+
+        <p className="mb-6 text-sm text-muted-foreground">
+          Something in this folder could not be displayed. Nothing was changed in your bucket.
+        </p>
+
+        {/* Retrying re-renders the same folder, so a broken one needs an exit
+            too rather than a button that fails the same way every time */}
+        <div className="flex flex-col justify-center gap-3 sm:flex-row">
+          <Button onClick={reset} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Try again
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/dashboard">Back to My Drive</Link>
+          </Button>
+        </div>
+
+        {error.digest && (
+          <p className="mt-6 text-xs text-muted-foreground">Reference: {error.digest}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/error.test.tsx
+++ b/frontend/src/app/error.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Route level error boundaries.
+ *
+ * These are the App Router's special files, so nothing imports them and a
+ * broken one only shows up when something has already gone wrong. The tests
+ * pin the two things that matter: the user is told what happened, and the
+ * recovery button is really wired to Next's reset callback.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AppError from './error';
+import DashboardError from './dashboard/error';
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('app error boundary', () => {
+  it('explains the failure and offers a way out', () => {
+    render(<AppError error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(screen.getByText('Something went wrong')).toBeDefined();
+    // Home, not the dashboard: this boundary also covers the landing page
+    expect(screen.getByRole('link', { name: 'Go to homepage' })).toHaveProperty(
+      'href',
+      expect.stringMatching(/\/$/)
+    );
+  });
+
+  it('retries through Next reset callback', () => {
+    const reset = vi.fn();
+    render(<AppError error={new Error('boom')} reset={reset} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(reset).toHaveBeenCalledOnce();
+  });
+
+  it('logs the error rather than swallowing it', () => {
+    const error = new Error('boom');
+    render(<AppError error={error} reset={vi.fn()} />);
+
+    expect(consoleError).toHaveBeenCalledWith('Unhandled render error:', error);
+  });
+
+  it('surfaces the digest so a report can be matched to a server log', () => {
+    const error = Object.assign(new Error('boom'), { digest: 'abc123' });
+    render(<AppError error={error} reset={vi.fn()} />);
+
+    expect(screen.getByText(/abc123/)).toBeDefined();
+  });
+});
+
+describe('dashboard error boundary', () => {
+  it('reassures the user that nothing was changed in the bucket', () => {
+    render(<DashboardError error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(screen.getByText('This view failed to load')).toBeDefined();
+    expect(screen.getByText(/Nothing was changed in your bucket/)).toBeDefined();
+  });
+
+  it('offers an escape when retrying the same folder keeps failing', () => {
+    render(<DashboardError error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(screen.getByRole('link', { name: 'Back to My Drive' })).toBeDefined();
+  });
+
+  it('retries through Next reset callback', () => {
+    const reset = vi.fn();
+    render(<DashboardError error={new Error('boom')} reset={reset} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Try again/ }));
+
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/app/error.test.tsx
+++ b/frontend/src/app/error.test.tsx
@@ -9,8 +9,13 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+// global-error carries its own stylesheet, since it replaces the root layout.
+// Vitest has no PostCSS pipeline, so the import is stubbed out here.
+vi.mock('@/app/globals.css', () => ({}));
+
 import AppError from './error';
 import DashboardError from './dashboard/error';
+import GlobalError from './global-error';
 
 let consoleError: ReturnType<typeof vi.spyOn>;
 
@@ -55,6 +60,60 @@ describe('app error boundary', () => {
     render(<AppError error={error} reset={vi.fn()} />);
 
     expect(screen.getByText(/abc123/)).toBeDefined();
+  });
+});
+
+/**
+ * global-error replaces the root layout, so it renders its own html and body.
+ * React warns about that nesting under a test container, which is noise here
+ * rather than a defect: the assertions are about behaviour, not the wrapper.
+ */
+describe('global error boundary', () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('tells the user the app could not start', () => {
+    render(<GlobalError error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(screen.getByText('Opndrive could not start')).toBeDefined();
+  });
+
+  it('retries through Next reset callback', () => {
+    const reset = vi.fn();
+    render(<GlobalError error={new Error('boom')} reset={reset} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(reset).toHaveBeenCalledOnce();
+  });
+
+  it('offers a hard reload, since retrying often hits the same broken layout', () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    render(<GlobalError error={new Error('boom')} reset={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reload the page' }));
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('restores an explicitly chosen theme, which the root layout script never got to set', () => {
+    localStorage.setItem('ui-theme', 'dark');
+
+    render(<GlobalError error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('leaves the theme to the system preference when none was chosen', () => {
+    render(<GlobalError error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBeNull();
   });
 });
 

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/shared/components/ui';
+
+/**
+ * Catches render errors from any page or nested layout below the root layout.
+ * Without this, App Router unmounts the tree and leaves a blank page that only
+ * a manual reload recovers from.
+ */
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Unhandled render error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-4 text-foreground">
+      <div className="w-full max-w-md text-center">
+        <div className="mx-auto mb-6 inline-flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+          <AlertTriangle className="h-8 w-8 text-primary" />
+        </div>
+
+        <h1 className="mb-3 text-2xl font-bold">Something went wrong</h1>
+
+        <p className="mb-8 text-muted-foreground">
+          This page ran into an unexpected problem. Trying again is usually enough. Your files are
+          untouched.
+        </p>
+
+        <div className="flex flex-col justify-center gap-3 sm:flex-row">
+          <Button onClick={reset} size="lg" className="px-8">
+            Try again
+          </Button>
+          {/* This boundary also covers the landing page and the blog, so home
+              is the safe destination rather than the dashboard */}
+          <Button asChild variant="outline" size="lg" className="px-8">
+            <Link href="/">Go to homepage</Link>
+          </Button>
+        </div>
+
+        {error.digest && (
+          <p className="mt-8 text-xs text-muted-foreground">Reference: {error.digest}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import '@/app/globals.css';
+import { useEffect } from 'react';
+
+/**
+ * Last resort. This one replaces the root layout, so it has to bring its own
+ * html, body and stylesheet, and it cannot rely on any provider - the root
+ * layout failing is exactly the case it exists for. Everything here is plain
+ * markup for that reason.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Root layout render error:', error);
+  }, [error]);
+
+  useEffect(() => {
+    // The theme script in the root layout never ran, so an explicit choice
+    // would otherwise be lost here. Without a stored one the stylesheet still
+    // follows prefers-color-scheme.
+    try {
+      const theme = localStorage.getItem('ui-theme');
+      if (theme === 'dark' || theme === 'light') {
+        document.documentElement.setAttribute('data-theme', theme);
+      }
+    } catch {
+      // Storage can be blocked, in which case the system preference is fine
+    }
+  }, []);
+
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <div className="flex min-h-screen flex-col items-center justify-center bg-background p-4 text-foreground">
+          <div className="w-full max-w-md text-center">
+            <h1 className="mb-3 text-2xl font-bold">Opndrive could not start</h1>
+
+            <p className="mb-8 text-muted-foreground">
+              The app hit an error while loading. Reloading usually clears it. Your files are
+              untouched.
+            </p>
+
+            {/* Retrying re-renders the same root layout, which is often still
+                broken, so a hard reload is offered next to it */}
+            <div className="flex flex-col justify-center gap-3 sm:flex-row">
+              <button
+                onClick={reset}
+                className="cursor-pointer rounded-md bg-primary px-8 py-2.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+              >
+                Try again
+              </button>
+              <button
+                onClick={() => window.location.reload()}
+                className="cursor-pointer rounded-md border border-border px-8 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+              >
+                Reload the page
+              </button>
+            </div>
+
+            {error.digest && (
+              <p className="mt-8 text-xs text-muted-foreground">Reference: {error.digest}</p>
+            )}
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/components/file-preview/preview-content.test.tsx
+++ b/frontend/src/components/file-preview/preview-content.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * PreviewContent error handling.
+ *
+ * The preview modal is rendered by the dashboard layout, which means no route
+ * level error.tsx covers it: before the boundary, a viewer that threw on a
+ * malformed pdf or spreadsheet took the whole dashboard down to a blank page.
+ * These tests drive a viewer that throws for real and check that the damage
+ * stops at the content panel.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PreviewContent } from './preview-content';
+import type { PreviewableFile } from '@/types/file-preview';
+
+const { pdfThrows } = vi.hoisted(() => ({ pdfThrows: { value: true } }));
+
+vi.mock('./viewers/pdf-viewer', () => ({
+  PDFViewer: () => {
+    if (pdfThrows.value) {
+      throw new Error('Invalid PDF structure');
+    }
+    return <div>pdf rendered</div>;
+  },
+}));
+vi.mock('./viewers/image-viewer', () => ({ ImageViewer: () => <div>image rendered</div> }));
+vi.mock('./viewers/video-viewer', () => ({ VideoViewer: () => <div>video rendered</div> }));
+vi.mock('./viewers/audio-viewer', () => ({ AudioViewer: () => <div>audio rendered</div> }));
+vi.mock('./viewers/excel-viewer', () => ({ ExcelViewer: () => <div>excel rendered</div> }));
+vi.mock('./viewers/code-viewer', () => ({ CodeViewer: () => <div>code rendered</div> }));
+
+vi.mock('@/features/dashboard/hooks/use-download', () => ({
+  useDownloadActions: () => ({ downloadFile: vi.fn() }),
+  useIsFileDownloading: () => false,
+}));
+
+function file(overrides: Partial<PreviewableFile> = {}): PreviewableFile {
+  return {
+    id: 'report',
+    name: 'report.pdf',
+    key: 'docs/report.pdf',
+    size: 1024,
+    ...overrides,
+  };
+}
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  pdfThrows.value = true;
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('a viewer that throws', () => {
+  it('shows the preview error instead of blanking the modal', () => {
+    render(<PreviewContent file={file()} />);
+
+    expect(screen.getByText('Preview Failed')).toBeDefined();
+    expect(screen.getByText(/report\.pdf could not be displayed/)).toBeDefined();
+  });
+
+  it('offers a retry that renders the viewer again', () => {
+    render(<PreviewContent file={file()} />);
+
+    pdfThrows.value = false;
+    fireEvent.click(screen.getByRole('button', { name: /Try Again/i }));
+
+    expect(screen.getByText('pdf rendered')).toBeDefined();
+  });
+
+  it('clears the failure when the user moves to another file', () => {
+    const { rerender } = render(<PreviewContent file={file()} />);
+    expect(screen.getByText('Preview Failed')).toBeDefined();
+
+    rerender(<PreviewContent file={file({ id: 'photo', name: 'photo.png' })} />);
+
+    expect(screen.getByText('image rendered')).toBeDefined();
+    expect(screen.queryByText('Preview Failed')).toBeNull();
+  });
+});
+
+describe('a viewer that works', () => {
+  it('renders normally with no fallback in the way', () => {
+    pdfThrows.value = false;
+    render(<PreviewContent file={file()} />);
+
+    expect(screen.getByText('pdf rendered')).toBeDefined();
+    expect(screen.queryByText('Preview Failed')).toBeNull();
+  });
+});

--- a/frontend/src/components/file-preview/preview-content.test.tsx
+++ b/frontend/src/components/file-preview/preview-content.test.tsx
@@ -92,3 +92,33 @@ describe('a viewer that works', () => {
     expect(screen.queryByText('Preview Failed')).toBeNull();
   });
 });
+
+// Wrapping the viewers meant reshaping the if chain that picks one, so every
+// branch of that choice is pinned here
+describe('picking a viewer', () => {
+  it.each([
+    ['photo.png', 'image rendered'],
+    ['clip.mp4', 'video rendered'],
+    ['song.mp3', 'audio rendered'],
+    ['sheet.xlsx', 'excel rendered'],
+    ['notes.csv', 'excel rendered'],
+    ['script.ts', 'code rendered'],
+  ])('routes %s to the right viewer', (name, expected) => {
+    render(<PreviewContent file={file({ name, id: name })} />);
+
+    expect(screen.getByText(expected)).toBeDefined();
+  });
+
+  it('still explains itself for a file no viewer handles', () => {
+    render(<PreviewContent file={file({ name: 'installer.exe', id: 'exe' })} />);
+
+    expect(screen.getByText('File Type Not Supported')).toBeDefined();
+  });
+
+  it('still refuses a file that is over the size limit', () => {
+    render(<PreviewContent file={file({ name: 'huge.png', id: 'huge', size: 5_000_000_000 })} />);
+
+    expect(screen.getByText('File Size Too Large')).toBeDefined();
+    expect(screen.queryByText('image rendered')).toBeNull();
+  });
+});

--- a/frontend/src/components/file-preview/preview-content.tsx
+++ b/frontend/src/components/file-preview/preview-content.tsx
@@ -16,6 +16,8 @@ import {
   getFileExtension,
   getFileExtensionWithoutDot,
 } from '@/config/file-extensions';
+import { ErrorBoundary } from '@/shared/components/error-boundary';
+import { PreviewError } from './preview-error';
 
 interface PreviewContentProps {
   file: PreviewableFile;
@@ -27,6 +29,35 @@ function isFileType(
   category: 'image' | 'video' | 'audio' | 'document' | 'spreadsheet' | 'code'
 ): boolean {
   return isFileInCategory(filename, category);
+}
+
+// Returns null when nothing here can render the file
+function selectViewer(file: PreviewableFile) {
+  if (isFileType(file.name, 'image')) {
+    return <ImageViewer file={file} />;
+  }
+
+  if (isFileType(file.name, 'video')) {
+    return <VideoViewer file={file} />;
+  }
+
+  if (isFileType(file.name, 'audio')) {
+    return <AudioViewer file={file} />;
+  }
+
+  if (getFileExtension(file.name) === '.pdf') {
+    return <PDFViewer file={file} />;
+  }
+
+  if (isFileType(file.name, 'spreadsheet')) {
+    return <ExcelViewer file={file} />;
+  }
+
+  if (isFileType(file.name, 'code')) {
+    return <CodeViewer file={file} />;
+  }
+
+  return null;
 }
 
 export function PreviewContent({ file }: PreviewContentProps) {
@@ -120,36 +151,28 @@ export function PreviewContent({ file }: PreviewContentProps) {
     );
   }
 
-  const isImage = isFileType(file.name, 'image');
-  const isVideo = isFileType(file.name, 'video');
-  const isAudio = isFileType(file.name, 'audio');
-  const isPdf = getFileExtension(file.name) === '.pdf';
-  const isSpreadsheet = isFileType(file.name, 'spreadsheet');
-  const isCode = isFileType(file.name, 'code');
-
   // Route to appropriate viewer component
-  if (isImage) {
-    return <ImageViewer file={file} />;
-  }
+  const viewer = selectViewer(file);
 
-  if (isVideo) {
-    return <VideoViewer file={file} />;
-  }
-
-  if (isAudio) {
-    return <AudioViewer file={file} />;
-  }
-
-  if (isPdf) {
-    return <PDFViewer file={file} />;
-  }
-
-  if (isSpreadsheet) {
-    return <ExcelViewer file={file} />;
-  }
-
-  if (isCode) {
-    return <CodeViewer file={file} />;
+  // The viewers parse file content we did not write - pdf, xlsx and the code
+  // editor most of all - and this modal is rendered by the dashboard layout,
+  // which no route level error.tsx covers. Without this boundary one malformed
+  // file takes the whole dashboard down instead of just the panel.
+  if (viewer) {
+    return (
+      <ErrorBoundary
+        resetKey={file.id}
+        fallback={(_error, reset) => (
+          <PreviewError
+            title="Preview Failed"
+            message={`${file.name} could not be displayed. The file may be corrupted or in an unexpected format.`}
+            onRetry={reset}
+          />
+        )}
+      >
+        {viewer}
+      </ErrorBoundary>
+    );
   }
 
   // Unsupported file type

--- a/frontend/src/shared/components/error-boundary.test.tsx
+++ b/frontend/src/shared/components/error-boundary.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Component, type ReactNode } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ErrorBoundary } from './error-boundary';
 
@@ -16,6 +17,21 @@ function Bomb({ shouldThrow = true }: { shouldThrow?: boolean }) {
     throw new Error('viewer exploded');
   }
   return <p>rendered fine</p>;
+}
+
+function Signal({ digest }: { digest: string }): ReactNode {
+  throw Object.assign(new Error('NEXT signal'), { digest });
+}
+
+/** Stands in for Next's own boundary, so a rethrow has somewhere to land. */
+class CatchAll extends Component<{ children: ReactNode }, { caught: boolean }> {
+  state = { caught: false };
+  static getDerivedStateFromError() {
+    return { caught: true };
+  }
+  render() {
+    return this.state.caught ? <p>Next handled it</p> : this.props.children;
+  }
 }
 
 let consoleError: ReturnType<typeof vi.spyOn>;
@@ -92,6 +108,55 @@ describe('when a child throws', () => {
       expect.objectContaining({ message: 'viewer exploded' }),
       expect.anything()
     );
+  });
+});
+
+describe('navigation signals', () => {
+  it.each([
+    ['redirect', 'NEXT_REDIRECT;replace;/connect;307;'],
+    ['notFound', 'NEXT_HTTP_ERROR_FALLBACK;404'],
+    ['older notFound', 'NEXT_NOT_FOUND'],
+  ])('passes %s back to Next rather than showing a fallback', (_name, digest) => {
+    render(
+      <CatchAll>
+        <ErrorBoundary fallback={<p>fallback</p>}>
+          <Signal digest={digest} />
+        </ErrorBoundary>
+      </CatchAll>
+    );
+
+    expect(screen.queryByText('fallback')).toBeNull();
+    expect(screen.getByText('Next handled it')).toBeDefined();
+  });
+
+  it('does not log a navigation signal as a failure', () => {
+    const onError = vi.fn();
+    render(
+      <CatchAll>
+        <ErrorBoundary fallback={<p>fallback</p>} onError={onError}>
+          <Signal digest="NEXT_REDIRECT;replace;/connect;307;" />
+        </ErrorBoundary>
+      </CatchAll>
+    );
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalledWith(
+      'Render error caught by boundary:',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('still catches a normal error that happens to carry a digest', () => {
+    render(
+      <CatchAll>
+        <ErrorBoundary fallback={<p>fallback</p>}>
+          <Signal digest="abc123" />
+        </ErrorBoundary>
+      </CatchAll>
+    );
+
+    expect(screen.getByText('fallback')).toBeDefined();
   });
 });
 

--- a/frontend/src/shared/components/error-boundary.test.tsx
+++ b/frontend/src/shared/components/error-boundary.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * ErrorBoundary.
+ *
+ * The point of this component is that a thrown render never reaches the top of
+ * the tree, so the tests deliberately throw for real rather than asserting on
+ * props. React logs caught errors itself, which is why console.error is stubbed
+ * here - the assertions still check that our own logging happened.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from './error-boundary';
+
+function Bomb({ shouldThrow = true }: { shouldThrow?: boolean }) {
+  if (shouldThrow) {
+    throw new Error('viewer exploded');
+  }
+  return <p>rendered fine</p>;
+}
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('when nothing throws', () => {
+  it('renders its children untouched', () => {
+    render(
+      <ErrorBoundary fallback={<p>fallback</p>}>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('rendered fine')).toBeDefined();
+    expect(screen.queryByText('fallback')).toBeNull();
+  });
+});
+
+describe('when a child throws', () => {
+  it('shows the fallback instead of unmounting the tree', () => {
+    render(
+      <div>
+        <p>sibling survives</p>
+        <ErrorBoundary fallback={<p>fallback</p>}>
+          <Bomb />
+        </ErrorBoundary>
+      </div>
+    );
+
+    expect(screen.getByText('fallback')).toBeDefined();
+    expect(screen.getByText('sibling survives')).toBeDefined();
+  });
+
+  it('logs the error so it is not swallowed in production', () => {
+    render(
+      <ErrorBoundary fallback={<p>fallback</p>}>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Render error caught by boundary:',
+      expect.objectContaining({ message: 'viewer exploded' }),
+      expect.anything()
+    );
+  });
+
+  it('hands the error and a reset callback to a function fallback', () => {
+    render(
+      <ErrorBoundary fallback={(error, reset) => <button onClick={reset}>{error.message}</button>}>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('button', { name: 'viewer exploded' })).toBeDefined();
+  });
+
+  it('reports the error through onError', () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary fallback={<p>fallback</p>} onError={onError}>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'viewer exploded' }),
+      expect.anything()
+    );
+  });
+});
+
+describe('recovering', () => {
+  it('retries the children when the fallback resets', () => {
+    // Flipped outside render, so the component itself stays side effect free
+    let stillBroken = true;
+    function Flaky() {
+      if (stillBroken) {
+        throw new Error('first attempt failed');
+      }
+      return <p>second attempt worked</p>;
+    }
+
+    render(
+      <ErrorBoundary fallback={(_error, reset) => <button onClick={reset}>Try again</button>}>
+        <Flaky />
+      </ErrorBoundary>
+    );
+
+    stillBroken = false;
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(screen.getByText('second attempt worked')).toBeDefined();
+  });
+
+  it('clears the error when the resetKey changes', () => {
+    const { rerender } = render(
+      <ErrorBoundary fallback={<p>fallback</p>} resetKey="file-a">
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('fallback')).toBeDefined();
+
+    // Moving to another file must not leave the previous file's error up
+    rerender(
+      <ErrorBoundary fallback={<p>fallback</p>} resetKey="file-b">
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('rendered fine')).toBeDefined();
+    expect(screen.queryByText('fallback')).toBeNull();
+  });
+
+  it('keeps the fallback up while the resetKey stays the same', () => {
+    const { rerender } = render(
+      <ErrorBoundary fallback={<p>fallback</p>} resetKey="file-a">
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    rerender(
+      <ErrorBoundary fallback={<p>fallback</p>} resetKey="file-a">
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('fallback')).toBeDefined();
+  });
+});

--- a/frontend/src/shared/components/error-boundary.tsx
+++ b/frontend/src/shared/components/error-boundary.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * What to show once something throws. The function form receives the error
+   * and a reset callback, so a fallback can offer a retry.
+   */
+  fallback: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+  /**
+   * Changing this clears the error. Pass whatever the subtree is about, such as
+   * a file id, so moving on from a bad item does not leave the fallback up.
+   */
+  resetKey?: unknown;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * React only catches render errors in class components, so this stays a class.
+ *
+ * The App Router error.tsx files cover whole route segments. This one is for
+ * the smaller surfaces inside a route - the preview viewers above all - where
+ * blanking the entire route would be a far worse answer than swapping a single
+ * panel for a message. It is also the only option for anything rendered by a
+ * layout, since a segment's error.tsx does not catch its own layout.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidUpdate(previousProps: ErrorBoundaryProps) {
+    if (this.state.error && previousProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // The dev overlay shows this anyway, but in production it would otherwise
+    // disappear with no trace of why the panel went blank.
+    console.error('Render error caught by boundary:', error, info.componentStack);
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+
+    if (!error) {
+      return this.props.children;
+    }
+
+    return typeof this.props.fallback === 'function'
+      ? this.props.fallback(error, this.reset)
+      : this.props.fallback;
+  }
+}

--- a/frontend/src/shared/components/error-boundary.tsx
+++ b/frontend/src/shared/components/error-boundary.tsx
@@ -22,6 +22,22 @@ interface ErrorBoundaryState {
 }
 
 /**
+ * redirect() and notFound() do their work by throwing, so a boundary that
+ * treated every throw as a failure would quietly break navigation for whatever
+ * it wraps. These get handed back to Next instead.
+ */
+function isNavigationSignal(error: unknown): boolean {
+  const digest = (error as { digest?: unknown } | null)?.digest;
+
+  return (
+    typeof digest === 'string' &&
+    (digest.startsWith('NEXT_REDIRECT') ||
+      digest.startsWith('NEXT_HTTP_ERROR_FALLBACK') ||
+      digest === 'NEXT_NOT_FOUND')
+  );
+}
+
+/**
  * React only catches render errors in class components, so this stays a class.
  *
  * The App Router error.tsx files cover whole route segments. This one is for
@@ -44,6 +60,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    if (isNavigationSignal(error)) {
+      return;
+    }
+
     // The dev overlay shows this anyway, but in production it would otherwise
     // disappear with no trace of why the panel went blank.
     console.error('Render error caught by boundary:', error, info.componentStack);
@@ -59,6 +79,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     if (!error) {
       return this.props.children;
+    }
+
+    // Rethrowing sends it up to Next's own boundary, which knows how to run
+    // the navigation this error is really asking for
+    if (isNavigationSignal(error)) {
+      throw error;
     }
 
     return typeof this.props.fallback === 'function'


### PR DESCRIPTION
Closes #83.

There were no error boundaries anywhere, so one uncaught render error unmounted the tree and left a blank page with only a manual reload to get back.

Adds three route boundaries (`app/error.tsx`, `app/dashboard/error.tsx`, `app/global-error.tsx`) and a reusable `ErrorBoundary` component. Each one logs the error and gives the user a way back.

The reusable one is needed because the preview modal is rendered by the dashboard layout, and a segment's `error.tsx` does not catch its own layout, so no route file can protect it. A bad pdf or spreadsheet now shows the existing preview error with a retry instead of taking the dashboard down.

The boundary deliberately rethrows `redirect()` and `notFound()`, since those work by throwing and catching them would break navigation.

37 tests, including real thrown renders rather than mocked ones.
