### PR TITLE
feat: add docker ci and docker builds to ghcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       s3api: ${{ steps.filter.outputs.s3api }}
       root: ${{ steps.filter.outputs.root }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -45,6 +46,11 @@ jobs:
               - '.prettierignore'
               - '.nvmrc'
               - '.github/workflows/ci.yml'
+            docker:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '**/package.json'
+              - 'pnpm-lock.yaml'
 
   quality:
     name: Lint & format
@@ -162,18 +168,41 @@ jobs:
       - name: Build
         run: pnpm build
 
+  docker-build:
+    name: Docker build
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Build only, no push - this just checks the Dockerfile still builds.
+      # Same context/build-arg as release.yml so it exercises the real path.
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          platforms: linux/amd64
+          build-args: |
+            BLOG_STATUS=false
+          cache-from: type=gha,scope=ci
+          cache-to: type=gha,mode=max,scope=ci
+
   # Required-status-check target. Individual jobs are skipped by path
   # filtering, and GitHub treats "skipped" as never-satisfied for branch
   # protection, so branch protection must require this job, not the others.
   ci-ok:
     name: CI OK
-    needs: [quality, frontend, s3-api]
+    needs: [quality, frontend, s3-api, docker-build]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
         run: |
-          for result in "${{ needs.quality.result }}" "${{ needs.frontend.result }}" "${{ needs.s3-api.result }}"; do
+          for result in "${{ needs.quality.result }}" "${{ needs.frontend.result }}" "${{ needs.s3-api.result }}" "${{ needs.docker-build.result }}"; do
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "A required job did not succeed (result: $result)"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
               - '.dockerignore'
               - '**/package.json'
               - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
 
   quality:
     name: Lint & format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
   packages: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+# Triggered on the tag itself, not `release: published` - if this workflow
+# ever also creates the GitHub release, triggering on the release event would
+# create a loop where the workflow waits for a release it is supposed to make.
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/opndrive/opndrive
+          # From a `v2.2.0` tag this produces `2.2.0`, `2.2`, and `latest`.
+          # `latest` only moves for the highest-precedence non-prerelease tag,
+          # so a `v2.2.0-rc.1` push does not touch it.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      # Build context is the repository root, not frontend/ - the frontend
+      # depends on @opndrive/s3-api through the pnpm workspace and there is
+      # one lockfile at the root.
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            BLOG_STATUS=false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=release
+          cache-to: type=gha,mode=max,scope=release

--- a/README.md
+++ b/README.md
@@ -21,37 +21,11 @@ control, you connect your own storage backend - AWS S3.
 
 ## For Users (Just Want to Use It)
 
-### Option 1: Run Locally
-
-1. **Clone and Install**
-
-   ```bash
-   git clone https://github.com/Opndrive/opndrive.git
-   cd opndrive
-   pnpm install
-   ```
-
-2. **Start the App**
-
-   ```bash
-   pnpm dev:frontend
-   ```
-
-3. **Open Your Browser**
-   - Go to [http://localhost:3000](http://localhost:3000)
-   - Click **Get Started**
-   - Enter your AWS S3 credentials in the UI
-   - Start managing your files!
-
----
-
-### Option 2: Run with Docker
-
-From the repository root:
+### Run with Docker
 
 ```bash
-docker build -t opndrive .
-docker run -d --restart unless-stopped --name opndrive -p 3000:3000 opndrive
+docker pull ghcr.io/opndrive/opndrive:latest
+docker run -d --restart unless-stopped --name opndrive -p 3000:3000 ghcr.io/opndrive/opndrive:latest
 ```
 
 See [Deployment](./docs/content/getting-started/deployment.md) for build args
@@ -71,6 +45,18 @@ Then:
 
 **Ready to Contribute?** Check out our
 [Development Setup](./docs/content/development/setup.md)
+
+**Run Locally (from source)**
+
+```bash
+git clone https://github.com/Opndrive/opndrive.git
+cd opndrive
+pnpm install
+pnpm dev:frontend
+```
+
+Or build the Docker image yourself instead of pulling the published one - see
+[Deployment](./docs/content/getting-started/deployment.md).
 
 ## Architecture
 

--- a/docs/content/getting-started/deployment.md
+++ b/docs/content/getting-started/deployment.md
@@ -43,11 +43,17 @@ on its own isn't enough: the blog pages prerender against WordPress, so
 fails. Leave the default (`false`) unless you're deploying the marketing/blog
 surface.
 
-A pre-built image isn't published by this repository's CI today - there's no
-Docker build/push step in `.github/workflows/`. If you've seen a
-`docker run opndrive/opndrive:<tag>` command elsewhere, treat it as unverified
-until you've confirmed that tag is current; building locally from the Dockerfile
-above is the reliable path.
+A pre-built image is published to GHCR on every tagged release
+(`.github/workflows/release.yml`), tagged with the full version, the minor
+version, and `latest`:
+
+```bash
+docker pull ghcr.io/opndrive/opndrive:latest
+docker run -d --restart unless-stopped --name opndrive -p 3000:3000 ghcr.io/opndrive/opndrive:latest
+```
+
+Only `linux/amd64` is published. Building locally from the Dockerfile above
+still works if you need a different platform or want to change `BLOG_STATUS`.
 
 ## Environment at Build Time
 

--- a/docs/content/maintainers/release-process.md
+++ b/docs/content/maintainers/release-process.md
@@ -57,10 +57,13 @@ pnpm build:frontend
 
 ## Frontend Releases
 
-The frontend (`frontend/package.json`, currently `2.0.0`) doesn't publish
-anywhere - it's deployed directly (Vercel/Netlify) or built into a Docker image
-(see [Deployment](../getting-started/deployment.md)). Notable frontend changes
-go in the root `CHANGELOG.md`, which follows
+The frontend (`frontend/package.json`, currently `2.0.0`) isn't published to a
+package registry, but pushing a `v*` git tag triggers
+`.github/workflows/release.yml`, which builds and pushes a Docker image to
+`ghcr.io/opndrive/opndrive` (see
+[Deployment](../getting-started/deployment.md)). It's otherwise deployed
+directly (Vercel/Netlify). Notable frontend changes go in the root
+`CHANGELOG.md`, which follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and starts from the
 point it was added rather than backfilling history. `s3-api` keeps its own
 `s3-api/CHANGELOG.MD` because it's versioned and published separately.
@@ -75,7 +78,15 @@ assumed to mean the same thing in another.
 
 ## Open Improvement
 
-There's no scripted or CI-driven release for `s3-api` yet. If publish frequency
-increases, a `release.yml` workflow (triggered on a version tag, running build +
-`npm publish`) would remove the manual steps above and the risk of forgetting
-one.
+The Docker image is now released automatically: pushing a `v*` tag runs
+`.github/workflows/release.yml`, which builds the root `Dockerfile` and pushes
+it to GHCR tagged with the version, the minor version, and `latest`. A
+build-only check also runs in `ci.yml` on pull requests that touch the
+`Dockerfile`, `.dockerignore`, or a `package.json`/lockfile, so a broken
+Dockerfile is caught before merge instead of at release time.
+
+There's still no scripted or CI-driven release for `s3-api`. If publish
+frequency increases, extending `release.yml` (or a separate workflow) triggered
+on a version tag, running build + `npm publish`, would remove the manual steps
+above and the risk of forgetting one. This needs its own npm token and is
+tracked separately so it doesn't block the Docker release.


### PR DESCRIPTION
Fixes: #150 

Publishes a Docker image on every tagged release instead of leaving self-hosters to clone and build it themselves, and adds a CI check so the Dockerfile can't silently rot between releases.

- release.yml (new): on a v* tag push, builds the root Dockerfile and pushes to ghcr.io/opndrive/opndrive, tagged with the full version, the minor version, and latest. Triggered on the tag itself rather than release: published, so this can't create a release that then waits on itself if that gets added later.
- ci.yml: new docker-build job, gated by a path filter (Dockerfile, .dockerignore, any package.json, the lockfile) on the existing changes job, same pattern as the frontend/s3-api jobs. Build only, no push — it exists purely to catch a PR that breaks the Docker build path (e.g. a workspace rename or lockfile change) before it merges, since the existing frontend/s3-api jobs run on the host and don't exercise the Dockerfile's own install/build sequence. Added to ci-ok's required list.
- Docs: deployment.md and release-process.md no longer say "no image is published" — they now give the docker pull command and describe what release.yml does. README.md Quick Start now leads with docker pull for users; clone-and-build moved under the developer section.

Decisions
- Registry: GHCR, not Docker Hub — no extra account, auth is the built-in GITHUB_TOKEN, only needs packages: write. Docker Hub can be added later if requested (out of scope here).
- linux/amd64 only — matches the acceptance criteria, keeps build time down. Multi-arch can follow separately if needed.
- BLOG_STATUS stays at its false default in both workflows — the published image is the self-hosted app, not the marketing blog, and enabling it needs WORDPRESS_GRAPHQL_URL at build time too.
- s3-api npm publishing is explicitly out of scope (per the issue) — different failure modes, needs an npm token, kept as a separate follow-up so this PR stays reviewable.

## Acceptance criteria

- [x] Pushing a `v*` tag builds and pushes the image without anyone touching it
- [x] Image is tagged with the full version, the minor, and `latest`
- [x] Image runs with `docker run -p 3000:3000 <image>` and the app loads
- [x] `linux/amd64` should be published
- [x] Pull requests that change the Dockerfile build the image without pushing
- [x] `docs/content/getting-started/deployment.md` is updated to give the pull
      command, replacing the current "no pre-built image" wording and its warning
- [x] `docs/content/maintainers/release-process.md` is updated, since it lists
      this as an open improvement
- [x] README quick start leads with the Docker command for users, keeping the
      clone and build path for contributors
