### PR TITLE
fix: stop duplicate and stale fetches in the drive store

### DIFF
--- a/frontend/src/context/data-context.test.ts
+++ b/frontend/src/context/data-context.test.ts
@@ -126,6 +126,29 @@ describe('returning to a folder whose request is still open', () => {
     expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
   });
 
+  it('does not dedupe two different folders against each other', async () => {
+    const rootPage = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(rootPage.promise);
+    const loadingRoot = store().fetchData({ sync: false });
+
+    // Open a subfolder while the root is still loading.
+    store().setCurrentPrefix('docs/');
+    const docsPage = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(docsPage.promise);
+    const loadingDocs = store().fetchData({ sync: false });
+
+    // The dedupe is per cache key. Sharing one would leave the second folder
+    // waiting on a request that answers for the first.
+    expect(fetchDirectoryStructure).toHaveBeenCalledTimes(2);
+
+    docsPage.resolve(page(['docs/a.txt']));
+    rootPage.resolve(page(['root.txt']));
+    await Promise.all([loadingRoot, loadingDocs]);
+
+    expect(useDriveStore.getState().cache['/']?.files.map((f) => f.id)).toEqual(['root.txt']);
+    expect(useDriveStore.getState().cache['docs/']?.files.map((f) => f.id)).toEqual(['docs/a.txt']);
+  });
+
   it('lets a forced sync run rather than joining a read already open', async () => {
     const initial = deferred();
     fetchDirectoryStructure.mockReturnValueOnce(initial.promise);
@@ -331,6 +354,52 @@ describe('ending the session', () => {
     // Writing here would repopulate the previous session's listing into a store
     // that logout had just emptied.
     expect(useDriveStore.getState().cache['/']).toBeUndefined();
+  });
+
+  it('does not append a page requested before the session ended', async () => {
+    fetchDirectoryStructure.mockResolvedValueOnce(
+      page(['old-a.txt'], { isTruncated: true, nextToken: 'token-1' })
+    );
+    await store().fetchData({ sync: false });
+
+    const nextPage = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(nextPage.promise);
+    const paging = store().loadMoreData();
+
+    // Log out and connect somewhere else, then open the same prefix. The cache
+    // is populated again by the time the old page lands, so checking that it
+    // exists is not enough to tell the two sessions apart.
+    store().clearAllData();
+    connect();
+    fetchDirectoryStructure.mockResolvedValueOnce(page(['new-a.txt']));
+    await store().fetchData({ sync: false });
+
+    nextPage.resolve(page(['old-b.txt']));
+    await paging;
+
+    // Appending here would list the previous bucket's objects inside the new one.
+    expect(cachedKeys()).toEqual(['new-a.txt']);
+  });
+
+  it('does not write paging status back into a cleared store', async () => {
+    fetchDirectoryStructure.mockResolvedValueOnce(
+      page(['a.txt'], { isTruncated: true, nextToken: 'token-1' })
+    );
+    await store().fetchData({ sync: false });
+
+    const nextPage = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(nextPage.promise);
+    const paging = store().loadMoreData();
+
+    store().clearAllData();
+
+    nextPage.resolve(page(['b.txt']));
+    await paging;
+
+    // Logout emptied these; a response landing afterwards must not put a stray
+    // entry back for a folder that no longer belongs to anyone.
+    expect(useDriveStore.getState().loadMoreStatus).toEqual({});
+    expect(useDriveStore.getState().cache).toEqual({});
   });
 
   it('does not let a new session join the previous session request', async () => {

--- a/frontend/src/context/data-context.test.ts
+++ b/frontend/src/context/data-context.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Drive store: the races around fetching a prefix and paging through it.
+ *
+ * Every test here drives real concurrency rather than asserting on a single
+ * settled call. The bugs only exist in the window between issuing a request and
+ * its response landing, so a test that awaits each call in turn would pass
+ * against the broken code as happily as against the fix.
+ *
+ * `deferred()` is the tool for that: it hands back a request whose resolution
+ * the test controls, so two calls can genuinely be open at once and be resolved
+ * in whichever order the scenario needs.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useDriveStore } from './data-context';
+
+vi.mock('@opndrive/s3-api', () => ({
+  BYOS3ApiProvider: class {},
+}));
+
+vi.mock('@/features/dashboard/stores/use-search-store', () => ({
+  useSearchStore: {
+    getState: () => ({
+      invalidatePrefix: vi.fn(),
+      clearCache: vi.fn(),
+    }),
+  },
+}));
+
+const store = () => useDriveStore.getState();
+
+type DirectoryStructure = {
+  files: { Key: string }[];
+  folders: { Prefix: string }[];
+  nextToken?: string;
+  isTruncated?: boolean;
+};
+
+/** A page of results whose resolution the test controls. */
+function deferred() {
+  let resolve!: (value: DirectoryStructure) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<DirectoryStructure>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function page(keys: string[], overrides: Partial<DirectoryStructure> = {}): DirectoryStructure {
+  return {
+    files: keys.map((Key) => ({ Key })),
+    folders: [],
+    isTruncated: false,
+    ...overrides,
+  };
+}
+
+const fetchDirectoryStructure = vi.fn();
+
+/** Mounts a store pointed at the bucket root, the way the browse page does. */
+function connect() {
+  store().setApiS3({ fetchDirectoryStructure } as never);
+  store().setRootPrefix('/');
+  store().setCurrentPrefix('/');
+}
+
+/** Object keys currently cached for the root prefix, in order. */
+function cachedKeys(): string[] {
+  return (useDriveStore.getState().cache['/']?.files ?? []).map((file) => file.id);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // clearAllData also resets the module-scope request bookkeeping, which the
+  // zustand auto-reset between tests cannot reach.
+  store().clearAllData();
+  connect();
+});
+
+describe('returning to a folder whose request is still open', () => {
+  it('does not issue a second identical request', async () => {
+    const first = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(first.promise);
+
+    // Navigate into A, away, and back before A's request has answered.
+    const navigateIn = store().fetchData({ sync: false });
+    const navigateBack = store().fetchData({ sync: false });
+
+    // 'loading' is not 'ready', and the cache is still empty, so both the
+    // status check and the data check used to wave the second call through.
+    expect(fetchDirectoryStructure).toHaveBeenCalledTimes(1);
+
+    first.resolve(page(['a.txt', 'b.txt']));
+    await Promise.all([navigateIn, navigateBack]);
+
+    expect(fetchDirectoryStructure).toHaveBeenCalledTimes(1);
+    expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
+    expect(store().status['/']).toBe('ready');
+  });
+
+  it('gives the second caller the first caller result', async () => {
+    const first = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(first.promise);
+
+    const navigateIn = store().fetchData({ sync: false });
+    const navigateBack = store().fetchData({ sync: false });
+
+    first.resolve(page(['a.txt']));
+    await Promise.all([navigateIn, navigateBack]);
+
+    // Joining the open request has to mean waiting for it, not returning early
+    // to a caller that then renders an empty folder.
+    expect(cachedKeys()).toEqual(['a.txt']);
+  });
+
+  it('starts a fresh request once the first one has finished', async () => {
+    fetchDirectoryStructure.mockResolvedValueOnce(page(['a.txt']));
+    await store().fetchData({ sync: false });
+
+    fetchDirectoryStructure.mockResolvedValueOnce(page(['a.txt', 'b.txt']));
+    await store().fetchData({ sync: true });
+
+    // The dedupe is per open request, not a permanent lock.
+    expect(fetchDirectoryStructure).toHaveBeenCalledTimes(2);
+    expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('lets a forced sync run rather than joining a read already open', async () => {
+    const initial = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(initial.promise);
+
+    const loading = store().fetchData({ sync: false });
+
+    const refresh = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(refresh.promise);
+    const refreshing = store().fetchData({ sync: true });
+
+    // The user asked for fresh data, not for whatever was already being read
+    // before they asked.
+    expect(fetchDirectoryStructure).toHaveBeenCalledTimes(2);
+
+    refresh.resolve(page(['fresh.txt']));
+    initial.resolve(page(['stale.txt']));
+    await Promise.all([loading, refreshing]);
+
+    // The refresh was issued last, so it wins even though it answered first.
+    // Letting the older read land here is how a rename or delete appeared to
+    // undo itself a moment after it succeeded.
+    expect(cachedKeys()).toEqual(['fresh.txt']);
+  });
+
+  it('does not let a superseded request report an error', async () => {
+    const initial = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(initial.promise);
+    const loading = store().fetchData({ sync: false });
+
+    fetchDirectoryStructure.mockResolvedValueOnce(page(['fresh.txt']));
+    await store().fetchData({ sync: true });
+
+    initial.reject(new Error('network down'));
+    await loading;
+
+    // A folder that loaded fine must not render as failed because an older
+    // request for it happened to give up afterwards.
+    expect(store().status['/']).toBe('ready');
+    expect(cachedKeys()).toEqual(['fresh.txt']);
+  });
+});
+
+describe('paging through a folder', () => {
+  /** Loads page one, leaving a continuation token behind. */
+  async function loadFirstPage() {
+    fetchDirectoryStructure.mockResolvedValueOnce(
+      page(['a.txt'], { isTruncated: true, nextToken: 'token-1' })
+    );
+    await store().fetchData({ sync: false });
+    fetchDirectoryStructure.mockClear();
+  }
+
+  it('fetches the next page once for two clicks in the same tick', async () => {
+    await loadFirstPage();
+
+    const next = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(next.promise);
+
+    const firstClick = store().loadMoreData();
+    const secondClick = store().loadMoreData();
+
+    expect(fetchDirectoryStructure).toHaveBeenCalledTimes(1);
+
+    next.resolve(page(['b.txt']));
+    await Promise.all([firstClick, secondClick]);
+
+    // Both clicks reading the same continuation token is what put every row of
+    // that page on screen twice.
+    expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('drops rows it already has rather than showing them twice', async () => {
+    await loadFirstPage();
+
+    // A page that overlaps what is already cached, however it arises.
+    fetchDirectoryStructure.mockResolvedValueOnce(page(['a.txt', 'b.txt']));
+    await store().loadMoreData();
+
+    expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('appends to the refreshed list, not to the copy it started with', async () => {
+    await loadFirstPage();
+
+    const nextPage = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(nextPage.promise);
+    const paging = store().loadMoreData();
+
+    // A delete or rename refreshes the folder while the page is still open.
+    fetchDirectoryStructure.mockResolvedValueOnce(
+      page(['a.txt'], { isTruncated: true, nextToken: 'token-1' })
+    );
+    await store().fetchData({ sync: true });
+
+    nextPage.resolve(page(['b.txt']));
+    await paging;
+
+    // Appending to the pre-refresh snapshot would have put back whatever that
+    // refresh removed.
+    expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('does nothing when there is no next page', async () => {
+    fetchDirectoryStructure.mockResolvedValueOnce(page(['a.txt'], { isTruncated: false }));
+    await store().fetchData({ sync: false });
+    fetchDirectoryStructure.mockClear();
+
+    await store().loadMoreData();
+
+    expect(fetchDirectoryStructure).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed page without losing what is already listed', async () => {
+    await loadFirstPage();
+
+    // The store logs this itself; capturing it keeps the suite output clean and
+    // pins that a failed page is actually reported somewhere.
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    fetchDirectoryStructure.mockRejectedValueOnce(new Error('network down'));
+    await store().loadMoreData();
+
+    expect(store().loadMoreStatus['/']).toBe('error');
+    expect(cachedKeys()).toEqual(['a.txt']);
+    expect(logged).toHaveBeenCalled();
+
+    logged.mockRestore();
+  });
+});
+
+describe('refreshing a folder that has been paged through', () => {
+  it('reloads from the top instead of just the last page', async () => {
+    fetchDirectoryStructure.mockResolvedValueOnce(
+      page(['a.txt'], { isTruncated: true, nextToken: 'token-1' })
+    );
+    await store().fetchData({ sync: false });
+
+    fetchDirectoryStructure.mockResolvedValueOnce(
+      page(['b.txt'], { isTruncated: true, nextToken: 'token-2' })
+    );
+    await store().loadMoreData();
+    expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
+
+    fetchDirectoryStructure.mockClear();
+    fetchDirectoryStructure.mockResolvedValueOnce(
+      page(['a.txt'], { isTruncated: true, nextToken: 'token-1' })
+    );
+    await store().fetchData({ sync: true });
+
+    // A sync replaces the cache wholesale, so it has to read from the top. It
+    // used to pass the stored continuation token, which replaced a fully paged
+    // folder with nothing but the page after the last one loaded.
+    expect(fetchDirectoryStructure).toHaveBeenCalledWith('', 1000);
+    expect(cachedKeys()).toEqual(['a.txt']);
+  });
+});
+
+describe('recent items on the home page', () => {
+  it('does not issue a second request when returning to the folder', async () => {
+    const first = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(first.promise);
+
+    const navigateIn = store().fetchRecentItems({ sync: false, itemsPerType: 10 });
+    const navigateBack = store().fetchRecentItems({ sync: false, itemsPerType: 10 });
+
+    expect(fetchDirectoryStructure).toHaveBeenCalledTimes(1);
+
+    first.resolve(page(['a.txt']));
+    await Promise.all([navigateIn, navigateBack]);
+
+    expect(store().recentCache['/']?.files.map((file) => file.id)).toEqual(['a.txt']);
+  });
+
+  it('tracks its requests separately from the folder listing', async () => {
+    const listing = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(listing.promise);
+    const loadingListing = store().fetchData({ sync: false });
+
+    // Same prefix, different cache. One must not be treated as superseding the
+    // other just because they were issued for the same folder.
+    fetchDirectoryStructure.mockResolvedValueOnce(page(['recent.txt']));
+    await store().fetchRecentItems({ sync: false, itemsPerType: 10 });
+
+    listing.resolve(page(['listed.txt']));
+    await loadingListing;
+
+    expect(cachedKeys()).toEqual(['listed.txt']);
+    expect(store().recentCache['/']?.files.map((file) => file.id)).toEqual(['recent.txt']);
+  });
+});
+
+describe('ending the session', () => {
+  it('ignores a response that arrives after the data was cleared', async () => {
+    const pending = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(pending.promise);
+    const loading = store().fetchData({ sync: false });
+
+    store().clearAllData();
+
+    pending.resolve(page(['a.txt']));
+    await loading;
+
+    // Writing here would repopulate the previous session's listing into a store
+    // that logout had just emptied.
+    expect(useDriveStore.getState().cache['/']).toBeUndefined();
+  });
+
+  it('does not let a new session join the previous session request', async () => {
+    const pending = deferred();
+    fetchDirectoryStructure.mockReturnValueOnce(pending.promise);
+    const loading = store().fetchData({ sync: false });
+
+    store().clearAllData();
+    connect();
+
+    fetchDirectoryStructure.mockResolvedValueOnce(page(['new-bucket.txt']));
+    await store().fetchData({ sync: false });
+
+    pending.resolve(page(['old-bucket.txt']));
+    await loading;
+
+    expect(cachedKeys()).toEqual(['new-bucket.txt']);
+  });
+});

--- a/frontend/src/context/data-context.tsx
+++ b/frontend/src/context/data-context.tsx
@@ -77,6 +77,7 @@ const inFlightLoadMores = new Map<string, Promise<void>>();
  */
 const latestRequestId = new Map<string, number>();
 const latestRecentRequestId = new Map<string, number>();
+const latestLoadMoreRequestId = new Map<string, number>();
 
 /**
  * Global rather than per key, and never reset. Counting from zero per key meant
@@ -246,6 +247,7 @@ export const useDriveStore = create<Store>((set, get) => ({
     inFlightLoadMores.clear();
     latestRequestId.clear();
     latestRecentRequestId.clear();
+    latestLoadMoreRequestId.clear();
 
     set({
       apiS3: null,
@@ -521,11 +523,19 @@ export const useDriveStore = create<Store>((set, get) => ({
     // on the same page from both fetching it even if that ever changes.
     return runDeduped(inFlightLoadMores, keyPrefix, true, async () => {
       const token = currentData.nextToken;
+      const requestId = claimRequestId(latestLoadMoreRequestId, keyPrefix);
 
       try {
         setLoadMoreStatus(keyPrefix, 'loading');
 
         const data = await apiS3.fetchDirectoryStructure(formattedPrefix, 1000, token);
+
+        // clearAllData drops these ids, so a page requested before a logout
+        // reads as superseded here. Checking the cache alone would not be
+        // enough: connect to a different bucket and open the same prefix, and
+        // the cache is populated again by the time this lands, so the previous
+        // bucket's page would be appended to the new bucket's listing.
+        if (isSuperseded(latestLoadMoreRequestId, keyPrefix, requestId)) return;
 
         data.folders = data.folders.filter((obj) => obj.Prefix != '');
         data.files = data.files.filter((obj) => obj.Key != formattedPrefix);
@@ -534,11 +544,7 @@ export const useDriveStore = create<Store>((set, get) => ({
         // the await. A refresh landing meanwhile replaces the cache, and
         // appending to the stale copy would put back whatever it removed.
         const latest = get().cache[keyPrefix];
-        if (!latest) {
-          // Logout or a folder change wiped it while this was open.
-          setLoadMoreStatus(keyPrefix, 'ready');
-          return;
-        }
+        if (!latest) return;
 
         setPrefixData(keyPrefix, {
           files: appendUnique(
@@ -554,6 +560,7 @@ export const useDriveStore = create<Store>((set, get) => ({
         });
         setLoadMoreStatus(keyPrefix, 'ready');
       } catch (error) {
+        if (isSuperseded(latestLoadMoreRequestId, keyPrefix, requestId)) return;
         setLoadMoreStatus(keyPrefix, 'error');
         console.error('Failed to load more data:', error);
       }

--- a/frontend/src/context/data-context.tsx
+++ b/frontend/src/context/data-context.tsx
@@ -57,6 +57,91 @@ type Store = {
   refreshAll: () => Promise<void>;
 };
 
+/**
+ * Requests currently open, keyed by the cache key they will write to.
+ *
+ * Module scope rather than store state on purpose: every store write re-renders
+ * subscribers, and a pending promise is not something any component renders.
+ * `clearAllData` resets them so a new session cannot join a request issued by
+ * the previous one.
+ */
+const inFlightFetches = new Map<string, Promise<void>>();
+const inFlightRecentFetches = new Map<string, Promise<void>>();
+const inFlightLoadMores = new Map<string, Promise<void>>();
+
+/**
+ * The newest request issued per cache key. A response is only written if it is
+ * still the newest, so a slow request cannot land on top of a faster one issued
+ * after it. Without this a refresh that overtakes an in-flight read gets undone
+ * by that read, putting back rows the refresh had just removed.
+ */
+const latestRequestId = new Map<string, number>();
+const latestRecentRequestId = new Map<string, number>();
+
+/**
+ * Global rather than per key, and never reset. Counting from zero per key meant
+ * clearAllData could hand a new session's first request the same id an old
+ * request was still holding, so the stale response read as current and wrote
+ * the previous bucket's listing into the new session.
+ */
+let requestCounter = 0;
+
+function claimRequestId(ids: Map<string, number>, key: string): number {
+  requestCounter += 1;
+  ids.set(key, requestCounter);
+  return requestCounter;
+}
+
+function isSuperseded(ids: Map<string, number>, key: string, id: number): boolean {
+  return ids.get(key) !== id;
+}
+
+/**
+ * Runs `work`, or joins the request already open for `key` when the caller is
+ * happy with an in-flight result. A forced sync passes `reuseInFlight: false`
+ * because the user asked for fresh data, not for whatever was already being
+ * read before they asked.
+ */
+function runDeduped(
+  inFlight: Map<string, Promise<void>>,
+  key: string,
+  reuseInFlight: boolean,
+  work: () => Promise<void>
+): Promise<void> {
+  if (reuseInFlight) {
+    const pending = inFlight.get(key);
+    if (pending) return pending;
+  }
+
+  const request = work().finally(() => {
+    // Only ever clear our own entry; a later request may have replaced it.
+    if (inFlight.get(key) === request) inFlight.delete(key);
+  });
+
+  inFlight.set(key, request);
+  return request;
+}
+
+/**
+ * Appends `incoming` to `existing`, skipping anything already present by id.
+ *
+ * S3 pages do not overlap, so a repeat here means the same page was appended
+ * twice. The visible symptom is every row of that page listed twice, with the
+ * item count doubled to match. Returns `existing` untouched when there is
+ * nothing to add, so an append that changes nothing does not re-render.
+ */
+function appendUnique<T extends { id: string }>(existing: T[], incoming: T[]): T[] {
+  const seen = new Set(existing.map((item) => item.id));
+
+  const additions = incoming.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+
+  return additions.length > 0 ? [...existing, ...additions] : existing;
+}
+
 function enrichFolder(obj: CommonPrefix): Folder {
   const temp = obj.Prefix?.split('/');
 
@@ -152,7 +237,16 @@ export const useDriveStore = create<Store>((set, get) => ({
 
   setCurrentPrefix: (prefix) => set({ currentPrefix: prefix }),
 
-  clearAllData: () =>
+  clearAllData: () => {
+    // Drop the request bookkeeping with the data it describes. A new session
+    // must not join a request issued by the previous one, and leaving the ids
+    // behind would let a response from the old session still count as current.
+    inFlightFetches.clear();
+    inFlightRecentFetches.clear();
+    inFlightLoadMores.clear();
+    latestRequestId.clear();
+    latestRecentRequestId.clear();
+
     set({
       apiS3: null,
       cache: {},
@@ -162,7 +256,8 @@ export const useDriveStore = create<Store>((set, get) => ({
       loadMoreStatus: {},
       currentPrefix: null,
       rootPrefix: null,
-    }),
+    });
+  },
 
   fetchData: async (opts = { sync: false }) => {
     const { apiS3, currentPrefix, rootPrefix, status, cache, setPrefixData, setStatus } = get();
@@ -184,49 +279,49 @@ export const useDriveStore = create<Store>((set, get) => ({
 
     const currentData = cache[keyPrefix];
 
-    // Decide whether we should fetch
-    // Only fetch if: no data exists, forced sync, or we need to load more (and user explicitly requested it)
-    // Don't auto-refetch just because isTruncated is true - let user decide with "Show More" button
-    if (!currentData || opts.sync) {
+    // Data already present and nobody asked for fresh; just reflect it.
+    // Don't auto-refetch just because isTruncated is true - let the user decide
+    // with the "Show More" button.
+    if (currentData && !opts.sync) {
+      if (currStatus !== 'ready') setStatus(keyPrefix, 'ready');
+      return;
+    }
+
+    // Join a request already open for this key rather than issuing a second
+    // identical one. Navigating A -> B -> A did exactly that: A's first request
+    // is still 'loading' rather than 'ready', so the status check above let it
+    // through, and cache[A] was still empty, so the data check did too.
+    return runDeduped(inFlightFetches, keyPrefix, !opts.sync, async () => {
+      const requestId = claimRequestId(latestRequestId, keyPrefix);
+
       try {
         setStatus(keyPrefix, 'loading');
 
-        const data = await apiS3.fetchDirectoryStructure(
-          formattedPrefix,
-          1000,
-          currentData?.nextToken
-        );
+        // Always read from the top. This branch only runs when there is no data
+        // yet or a sync was forced, and either way the result replaces the cache
+        // wholesale - so passing the stored continuation token would have
+        // replaced a fully paged folder with nothing but its last page.
+        const data = await apiS3.fetchDirectoryStructure(formattedPrefix, 1000);
+
+        if (isSuperseded(latestRequestId, keyPrefix, requestId)) return;
 
         data.folders = data.folders.filter((obj) => obj.Prefix != '');
         data.files = data.files.filter((obj) => obj.Key != formattedPrefix);
-        const folders = data.folders.map((obj) => enrichFolder(obj));
-        const files = data.files.map((obj) => enrichFile(obj));
 
-        const nextData =
-          currentData && !opts.sync
-            ? {
-                files: [...currentData.files, ...files],
-                folders: [...currentData.folders, ...folders],
-                nextToken: data.nextToken,
-                isTruncated: data.isTruncated,
-              }
-            : {
-                files: [...files],
-                folders: [...folders],
-                nextToken: data.nextToken,
-                isTruncated: data.isTruncated,
-              };
-        // Data loaded successfully
-        setPrefixData(keyPrefix, nextData);
+        setPrefixData(keyPrefix, {
+          files: data.files.map((obj) => enrichFile(obj)),
+          folders: data.folders.map((obj) => enrichFolder(obj)),
+          nextToken: data.nextToken,
+          isTruncated: data.isTruncated,
+        });
         setStatus(keyPrefix, 'ready');
       } catch {
-        // Handle fetch error
+        // A superseded request must not report an error over a newer request's
+        // result, or a folder that loaded fine renders as failed.
+        if (isSuperseded(latestRequestId, keyPrefix, requestId)) return;
         setStatus(keyPrefix, 'error');
       }
-    } else {
-      // Data already present; ensure status reflects it
-      if (currStatus !== 'ready') setStatus(keyPrefix, 'ready');
-    }
+    });
   },
 
   refreshCurrentData: async () => {
@@ -285,55 +380,65 @@ export const useDriveStore = create<Store>((set, get) => ({
     // Ensure itemsPerType has a default value
     const itemsPerType = opts.itemsPerType ?? 10;
 
-    try {
-      setRecentStatus(keyPrefix, 'loading');
+    // Same A -> B -> A race as fetchData: 'loading' is not 'ready', so
+    // returning to a folder whose recent-items request is still open used to
+    // fire a second identical one.
+    return runDeduped(inFlightRecentFetches, keyPrefix, !opts.sync, async () => {
+      const requestId = claimRequestId(latestRecentRequestId, keyPrefix);
 
-      // Fetch up to 1000 items from current directory
-      const data = await apiS3.fetchDirectoryStructure(formattedPrefix, 1000);
+      try {
+        setRecentStatus(keyPrefix, 'loading');
 
-      data.folders = data.folders.filter((obj) => obj.Prefix != '');
-      data.files = data.files.filter((obj) => obj.Key != formattedPrefix);
+        // Fetch up to 1000 items from current directory
+        const data = await apiS3.fetchDirectoryStructure(formattedPrefix, 1000);
 
-      const folders = data.folders.map((obj) => enrichFolder(obj));
-      const files = data.files.map((obj) => enrichFile(obj));
+        if (isSuperseded(latestRecentRequestId, keyPrefix, requestId)) return;
 
-      // Sort by lastModified in descending order (most recent first)
-      // Note: Folders from CommonPrefix don't have LastModified, so we'll use creation time as fallback
-      const sortedFolders = folders.sort((a, b) => {
-        const aTime = a.lastModified ? new Date(a.lastModified).getTime() : 0;
-        const bTime = b.lastModified ? new Date(b.lastModified).getTime() : 0;
-        return bTime - aTime;
-      });
+        data.folders = data.folders.filter((obj) => obj.Prefix != '');
+        data.files = data.files.filter((obj) => obj.Key != formattedPrefix);
 
-      const sortedFiles = files.sort((a, b) => {
-        const aTime = a.lastModified ? new Date(a.lastModified).getTime() : 0;
-        const bTime = b.lastModified ? new Date(b.lastModified).getTime() : 0;
-        return bTime - aTime;
-      });
+        const folders = data.folders.map((obj) => enrichFolder(obj));
+        const files = data.files.map((obj) => enrichFile(obj));
 
-      // Take only the requested number initially
-      const recentData: RecentDataWithCache = {
-        files: sortedFiles.slice(0, itemsPerType),
-        folders: sortedFolders.slice(0, itemsPerType),
-        hasMoreFiles: sortedFiles.length > itemsPerType,
-        hasMoreFolders: sortedFolders.length > itemsPerType,
-        fileOffset: itemsPerType,
-        folderOffset: itemsPerType,
-      };
+        // Sort by lastModified in descending order (most recent first)
+        // Note: Folders from CommonPrefix don't have LastModified, so we'll use creation time as fallback
+        const sortedFolders = folders.sort((a, b) => {
+          const aTime = a.lastModified ? new Date(a.lastModified).getTime() : 0;
+          const bTime = b.lastModified ? new Date(b.lastModified).getTime() : 0;
+          return bTime - aTime;
+        });
 
-      // Store all sorted data for pagination (keeping full sorted arrays in memory temporarily)
-      const existingCache = recentCache[keyPrefix];
-      if (!existingCache || opts.sync) {
-        // Store full sorted arrays for pagination access
-        recentData._allFiles = sortedFiles;
-        recentData._allFolders = sortedFolders;
+        const sortedFiles = files.sort((a, b) => {
+          const aTime = a.lastModified ? new Date(a.lastModified).getTime() : 0;
+          const bTime = b.lastModified ? new Date(b.lastModified).getTime() : 0;
+          return bTime - aTime;
+        });
+
+        // Take only the requested number initially
+        const recentData: RecentDataWithCache = {
+          files: sortedFiles.slice(0, itemsPerType),
+          folders: sortedFolders.slice(0, itemsPerType),
+          hasMoreFiles: sortedFiles.length > itemsPerType,
+          hasMoreFolders: sortedFolders.length > itemsPerType,
+          fileOffset: itemsPerType,
+          folderOffset: itemsPerType,
+        };
+
+        // Store all sorted data for pagination (keeping full sorted arrays in memory temporarily)
+        const existingCache = recentCache[keyPrefix];
+        if (!existingCache || opts.sync) {
+          // Store full sorted arrays for pagination access
+          recentData._allFiles = sortedFiles;
+          recentData._allFolders = sortedFolders;
+        }
+
+        setRecentData(keyPrefix, recentData);
+        setRecentStatus(keyPrefix, 'ready');
+      } catch {
+        if (isSuperseded(latestRecentRequestId, keyPrefix, requestId)) return;
+        setRecentStatus(keyPrefix, 'error');
       }
-
-      setRecentData(keyPrefix, recentData);
-      setRecentStatus(keyPrefix, 'ready');
-    } catch {
-      setRecentStatus(keyPrefix, 'error');
-    }
+    });
   },
 
   loadMoreRecentFiles: async () => {
@@ -411,33 +516,47 @@ export const useDriveStore = create<Store>((set, get) => ({
     // Don't load if already loading
     if (loadMoreStatus[keyPrefix] === 'loading') return;
 
-    try {
-      setLoadMoreStatus(keyPrefix, 'loading');
+    // The status check above only holds because nothing awaits between reading
+    // it and setting it below. Joining an open request keeps two clicks landing
+    // on the same page from both fetching it even if that ever changes.
+    return runDeduped(inFlightLoadMores, keyPrefix, true, async () => {
+      const token = currentData.nextToken;
 
-      const data = await apiS3.fetchDirectoryStructure(
-        formattedPrefix,
-        1000,
-        currentData.nextToken
-      );
+      try {
+        setLoadMoreStatus(keyPrefix, 'loading');
 
-      data.folders = data.folders.filter((obj) => obj.Prefix != '');
-      data.files = data.files.filter((obj) => obj.Key != formattedPrefix);
-      const folders = data.folders.map((obj) => enrichFolder(obj));
-      const files = data.files.map((obj) => enrichFile(obj));
+        const data = await apiS3.fetchDirectoryStructure(formattedPrefix, 1000, token);
 
-      // Append new data to existing data
-      const nextData = {
-        files: [...currentData.files, ...files],
-        folders: [...currentData.folders, ...folders],
-        nextToken: data.nextToken,
-        isTruncated: data.isTruncated,
-      };
+        data.folders = data.folders.filter((obj) => obj.Prefix != '');
+        data.files = data.files.filter((obj) => obj.Key != formattedPrefix);
 
-      setPrefixData(keyPrefix, nextData);
-      setLoadMoreStatus(keyPrefix, 'ready');
-    } catch (error) {
-      setLoadMoreStatus(keyPrefix, 'error');
-      console.error('Failed to load more data:', error);
-    }
+        // Append to what the cache holds now, not to the snapshot taken before
+        // the await. A refresh landing meanwhile replaces the cache, and
+        // appending to the stale copy would put back whatever it removed.
+        const latest = get().cache[keyPrefix];
+        if (!latest) {
+          // Logout or a folder change wiped it while this was open.
+          setLoadMoreStatus(keyPrefix, 'ready');
+          return;
+        }
+
+        setPrefixData(keyPrefix, {
+          files: appendUnique(
+            latest.files,
+            data.files.map((obj) => enrichFile(obj))
+          ),
+          folders: appendUnique(
+            latest.folders,
+            data.folders.map((obj) => enrichFolder(obj))
+          ),
+          nextToken: data.nextToken,
+          isTruncated: data.isTruncated,
+        });
+        setLoadMoreStatus(keyPrefix, 'ready');
+      } catch (error) {
+        setLoadMoreStatus(keyPrefix, 'error');
+        console.error('Failed to load more data:', error);
+      }
+    });
   },
 }));


### PR DESCRIPTION
Closes #95.

**Returning to a folder mid request fired a second one.** `fetchData` skipped work only on status `'ready'`, but a request in flight is `'loading'`, and the cache is still empty. So navigating A to B and back to A passed both checks and issued an identical second request. Requests are now tracked per cache key and a second caller joins the open one instead of starting another. Same fix for `fetchRecentItems`, which had the identical race on the home page.

**A slow response could undo a newer one.** Each request now carries an id and only writes if it is still the newest for that key. Without it a refresh triggered by a rename or delete could be overtaken by a read issued before it, putting the removed rows back a moment after they disappeared. A superseded request also no longer reports an error over a newer request's result.

**`loadMoreData` appended to a stale snapshot.** It captured the cache before awaiting and appended to that copy, so a refresh landing meanwhile got wiped out. It now re-reads the cache and dedupes by key on append, so a repeated page cannot show every row twice.

**A page requested before a logout could land in the next session.** Connect to a different bucket, reopen the same prefix, and the cache is populated again by the time the old page arrives, so it was appended to the new bucket's listing. Paging is now tied to the session the same way the other reads are.

**Also fixes a refresh bug found on the way.** `fetchData` passed the stored continuation token on a forced sync, but a sync replaces the cache wholesale. Refreshing a folder you had paged through replaced the whole list with nothing but the page after the last one loaded. It now always reads from the top.

Tests drive real concurrency rather than awaiting each call in turn, since these only exist in the window between issuing a request and its response landing. Each was checked to fail without its fix.
