### PR TITLE
feat: move the overflow menus to Radix dropdowns (retarget of #163)

### DIFF
--- a/frontend/src/features/dashboard/components/layout/sidebar/sidebar-create-button.tsx
+++ b/frontend/src/features/dashboard/components/layout/sidebar/sidebar-create-button.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { Plus } from 'lucide-react';
 import { cn } from '@/shared/utils/utils';
 import { CreateMenu } from '../../ui';
@@ -14,9 +14,7 @@ interface SidebarCreateButtonProps {
 }
 
 export const SidebarCreateButton: React.FC<SidebarCreateButtonProps> = ({ onClick, className }) => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
   const { currentPrefix } = useDriveStore();
   const { success, error } = useNotification();
 
@@ -29,21 +27,13 @@ export const SidebarCreateButton: React.FC<SidebarCreateButtonProps> = ({ onClic
     },
   });
 
+  // The menu opens itself now; this only forwards the caller's callback.
   const handleClick = () => {
-    setIsMenuOpen(true);
-
-    if (onClick) {
-      onClick();
-    }
-  };
-
-  const handleMenuClose = () => {
-    setIsMenuOpen(false);
+    onClick?.();
   };
 
   const handleNewFolderClick = () => {
-    setIsMenuOpen(false); // Close menu
-    setShowCreateFolderDialog(true); // Open dialog
+    setShowCreateFolderDialog(true);
   };
 
   const handleCreateFolder = async (folderName: string) => {
@@ -76,28 +66,25 @@ export const SidebarCreateButton: React.FC<SidebarCreateButtonProps> = ({ onClic
 
   return (
     <>
-      <button
-        ref={buttonRef}
-        onClick={handleClick}
-        className={cn(
-          'flex items-center w-full cursor-pointer px-6 py-4 mb-4 text-base font-medium',
-          'bg-card text-card-foreground border border-border',
-          'rounded-2xl shadow-sm hover:shadow-md transition-all duration-200',
-          'hover:bg-accent hover:text-foreground',
-          className
-        )}
-        aria-label="Create new file or folder"
-      >
-        <Plus className="w-6 h-6 mr-3 flex-shrink-0" />
-        <span>New</span>
-      </button>
-
       <CreateMenu
-        isOpen={isMenuOpen}
-        onClose={handleMenuClose}
         onNewFolderClick={handleNewFolderClick}
-        anchorElement={buttonRef.current}
         currentPath={currentPrefix || ''}
+        trigger={
+          <button
+            onClick={handleClick}
+            className={cn(
+              'flex items-center w-full cursor-pointer px-6 py-4 mb-4 text-base font-medium',
+              'bg-card text-card-foreground border border-border',
+              'rounded-2xl shadow-sm hover:shadow-md transition-all duration-200',
+              'hover:bg-accent hover:text-foreground',
+              className
+            )}
+            aria-label="Create new file or folder"
+          >
+            <Plus className="w-6 h-6 mr-3 flex-shrink-0" />
+            <span>New</span>
+          </button>
+        }
       />
 
       {/* Folder creation dialog - managed at this level */}

--- a/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
@@ -8,7 +8,6 @@ import { FileOverflowMenu } from '../menus/file-overflow-menu';
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
-import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { getItemKeyIntent } from './item-keyboard';
 
@@ -29,8 +28,6 @@ export function FileItemGrid({
   additionalActions,
   insertAdditionalActionsAfter,
 }: FileItemGridProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const { openFilePreview } = useFilePreviewActions();
   const { selectItem, isSelected, getSelectionCount } = useMultiSelectStore();
 
@@ -42,14 +39,9 @@ export function FileItemGrid({
   const [isLongPress, setIsLongPress] = useState(false);
 
   const handleMenuClick = (event: React.MouseEvent) => {
+    // The menu opens itself now. This only keeps the row underneath
+    // from reading the same click as opening the item.
     event.stopPropagation();
-    setMenuAnchor(event.currentTarget as HTMLElement);
-    setIsMenuOpen(true);
-  };
-
-  const handleMenuClose = () => {
-    setIsMenuOpen(false);
-    setMenuAnchor(null);
   };
 
   const handleTouchStart = () => {
@@ -197,15 +189,22 @@ export function FileItemGrid({
             <span className="text-sm font-medium text-foreground truncate">{file.name}</span>
           </div>
 
-          <AriaLabel label={`More actions`} position="top">
-            <button
-              className="p-1 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
-              aria-label={`More actions for ${file.name}`}
-              onClick={handleMenuClick}
-            >
-              <HiOutlineDotsVertical size={18} className=" text-muted-foreground" />
-            </button>
-          </AriaLabel>
+          <FileOverflowMenu
+            file={file}
+            allFiles={allFiles}
+            additionalActions={additionalActions}
+            insertAdditionalActionsAfter={insertAdditionalActionsAfter}
+            triggerLabel="More actions"
+            trigger={
+              <button
+                className="p-1 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
+                aria-label={`More actions for ${file.name}`}
+                onClick={handleMenuClick}
+              >
+                <HiOutlineDotsVertical size={18} className=" text-muted-foreground" />
+              </button>
+            }
+          />
         </div>
 
         <div className="space-y-1">
@@ -230,16 +229,6 @@ export function FileItemGrid({
           </div>
         </div>
       </div>
-
-      <FileOverflowMenu
-        file={file}
-        allFiles={allFiles}
-        isOpen={isMenuOpen}
-        onClose={handleMenuClose}
-        anchorElement={menuAnchor}
-        additionalActions={additionalActions}
-        insertAdditionalActionsAfter={insertAdditionalActionsAfter}
-      />
     </div>
   );
 }

--- a/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
@@ -7,7 +7,6 @@ import { FileExtension, FileItem, FileMenuAction } from '@/features/dashboard/ty
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
-import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { getItemKeyIntent } from './item-keyboard';
 
@@ -28,8 +27,6 @@ export function FileItemList({
   additionalActions,
   insertAdditionalActionsAfter,
 }: FileItemListProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const { openFilePreview } = useFilePreviewActions();
   const { selectItem, isSelected, getSelectionCount } = useMultiSelectStore();
 
@@ -41,14 +38,9 @@ export function FileItemList({
   const [isLongPress, setIsLongPress] = useState(false);
 
   const handleMenuClick = (event: React.MouseEvent) => {
+    // The menu opens itself now. This only keeps the row underneath
+    // from reading the same click as opening the item.
     event.stopPropagation();
-    setMenuAnchor(event.currentTarget as HTMLElement);
-    setIsMenuOpen(true);
-  };
-
-  const handleMenuClose = () => {
-    setIsMenuOpen(false);
-    setMenuAnchor(null);
   };
 
   const handleTouchStart = () => {
@@ -218,30 +210,27 @@ export function FileItemList({
 
         {/* Menu button - always visible */}
         <div className="col-span-2 sm:col-span-1 md:col-span-2 lg:col-span-1 xl:col-span-1 flex justify-end">
-          <AriaLabel label={`More actions`} position="top">
-            <button
-              className="p-1.5 sm:p-2 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
-              aria-label={`More actions for ${file.name}`}
-              onClick={handleMenuClick}
-            >
-              <HiOutlineDotsVertical
-                size={16}
-                className="sm:w-[18px] sm:h-[18px] text-muted-foreground"
-              />
-            </button>
-          </AriaLabel>
+          <FileOverflowMenu
+            file={file}
+            allFiles={allFiles}
+            additionalActions={additionalActions}
+            insertAdditionalActionsAfter={insertAdditionalActionsAfter}
+            triggerLabel="More actions"
+            trigger={
+              <button
+                className="p-1.5 sm:p-2 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
+                aria-label={`More actions for ${file.name}`}
+                onClick={handleMenuClick}
+              >
+                <HiOutlineDotsVertical
+                  size={16}
+                  className="sm:w-[18px] sm:h-[18px] text-muted-foreground"
+                />
+              </button>
+            }
+          />
         </div>
       </div>
-
-      <FileOverflowMenu
-        file={file}
-        allFiles={allFiles}
-        isOpen={isMenuOpen}
-        onClose={handleMenuClose}
-        anchorElement={menuAnchor}
-        additionalActions={additionalActions}
-        insertAdditionalActionsAfter={insertAdditionalActionsAfter}
-      />
     </div>
   );
 }

--- a/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
@@ -6,7 +6,6 @@ import { FileOverflowMenu } from '../menus/file-overflow-menu';
 import { FileExtension, FileItem, FileMenuAction } from '@/features/dashboard/types/file';
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { getEffectiveExtension, getFileExtensionWithoutDot } from '@/config/file-extensions';
-import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { useFilePreview } from '@/context/file-preview-context';
 import { getItemKeyIntent } from './item-keyboard';
@@ -30,8 +29,6 @@ export function FileItemMobile({
   additionalActions,
   insertAdditionalActionsAfter,
 }: FileItemMobileProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const { openPreview } = useFilePreview();
   const { selectItem, isSelected, getSelectionCount } = useMultiSelectStore();
 
@@ -44,14 +41,9 @@ export function FileItemMobile({
   const [touchStartPos, setTouchStartPos] = useState<{ x: number; y: number } | null>(null);
 
   const handleMenuClick = (event: React.MouseEvent) => {
+    // The menu opens itself now. This only keeps the row underneath
+    // from reading the same click as opening the item.
     event.stopPropagation();
-    setMenuAnchor(event.currentTarget as HTMLElement);
-    setIsMenuOpen(true);
-  };
-
-  const handleMenuClose = () => {
-    setIsMenuOpen(false);
-    setMenuAnchor(null);
   };
 
   const handleTouchStart = (e: React.TouchEvent) => {
@@ -229,24 +221,21 @@ export function FileItemMobile({
       </div>
 
       {/* Menu Button */}
-      <AriaLabel label={`More actions`} position="top">
-        <button
-          className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
-          aria-label={`More actions for ${file.name}`}
-          onClick={handleMenuClick}
-        >
-          <HiOutlineDotsVertical size={20} className="text-muted-foreground" />
-        </button>
-      </AriaLabel>
-
       <FileOverflowMenu
         file={file}
         allFiles={allFiles}
-        isOpen={isMenuOpen}
-        onClose={handleMenuClose}
-        anchorElement={menuAnchor}
         additionalActions={additionalActions}
         insertAdditionalActionsAfter={insertAdditionalActionsAfter}
+        triggerLabel="More actions"
+        trigger={
+          <button
+            className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
+            aria-label={`More actions for ${file.name}`}
+            onClick={handleMenuClick}
+          >
+            <HiOutlineDotsVertical size={20} className="text-muted-foreground" />
+          </button>
+        }
       />
     </div>
   );

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
@@ -23,8 +23,6 @@ export function FolderItemMobile({
   _onAction,
   index = 0,
 }: FolderItemMobileProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const { selectItem, isSelected, getSelectionCount } = useMultiSelectStore();
 
   const selected = isSelected(folder);
@@ -36,14 +34,9 @@ export function FolderItemMobile({
   const [touchStartPos, setTouchStartPos] = useState<{ x: number; y: number } | null>(null);
 
   const handleMenuClick = (event: React.MouseEvent) => {
+    // The menu opens itself now. This only keeps the row underneath
+    // from reading the same click as opening the item.
     event.stopPropagation();
-    setMenuAnchor(event.currentTarget as HTMLElement);
-    setIsMenuOpen(true);
-  };
-
-  const handleMenuClose = () => {
-    setIsMenuOpen(false);
-    setMenuAnchor(null);
   };
 
   const handleTouchStart = (e: React.TouchEvent) => {
@@ -198,19 +191,17 @@ export function FolderItemMobile({
       </div>
 
       {/* Menu Button */}
-      <button
-        className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
-        onClick={handleMenuClick}
-        aria-label={`More actions for ${folder.name}`}
-      >
-        <HiOutlineDotsVertical size={20} className="text-muted-foreground" />
-      </button>
-
       <FolderOverflowMenu
         folder={folder}
-        isOpen={isMenuOpen}
-        onClose={handleMenuClose}
-        anchorElement={menuAnchor}
+        trigger={
+          <button
+            className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
+            onClick={handleMenuClick}
+            aria-label={`More actions for ${folder.name}`}
+          >
+            <HiOutlineDotsVertical size={20} className="text-muted-foreground" />
+          </button>
+        }
       />
     </div>
   );

--- a/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
@@ -8,7 +8,6 @@ import { FaRegCircle } from 'react-icons/fa';
 import { FolderOverflowMenu } from '../menus/folder-overflow-menu';
 import { Folder, FolderMenuAction } from '@/features/dashboard/types/folder';
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
-import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { getItemKeyIntent } from './item-keyboard';
 
@@ -40,8 +39,6 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   additionalActions,
   insertAdditionalActionsAfter,
 }) => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const { selectItem, isSelected, getSelectionCount } = useMultiSelectStore();
 
   const selected = isSelected(folder);
@@ -146,15 +143,10 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
+    // The menu opens itself now. This only keeps the row underneath from
+    // reading the same click as "open the folder".
     event.stopPropagation();
-    setMenuAnchor(event.currentTarget as HTMLElement);
-    setIsMenuOpen(true);
     onMenuClick?.(folder, event);
-  };
-
-  const handleMenuClose = () => {
-    setIsMenuOpen(false);
-    setMenuAnchor(null);
   };
 
   const timeInfo = formatTimeWithTooltip(folder.lastModified);
@@ -212,29 +204,26 @@ export const FolderItem: React.FC<FolderItemProps> = ({
           )}
         </div>
 
-        <AriaLabel label={`More actions`} position="top">
-          <button
-            className="
-              flex-shrink-0 p-1 rounded-full cursor-pointer
-              hover:bg-accent transition-all duration-200
-              text-muted-foreground hover:text-foreground
-            "
-            aria-label={`More actions for ${folder.name}`}
-            onClick={handleMenuClick}
-          >
-            <MoreVerticalIcon size={16} />
-          </button>
-        </AriaLabel>
+        <FolderOverflowMenu
+          folder={folder}
+          triggerLabel="More actions"
+          additionalActions={additionalActions}
+          insertAdditionalActionsAfter={insertAdditionalActionsAfter}
+          trigger={
+            <button
+              className="
+                flex-shrink-0 p-1 rounded-full cursor-pointer
+                hover:bg-accent transition-all duration-200
+                text-muted-foreground hover:text-foreground
+              "
+              aria-label={`More actions for ${folder.name}`}
+              onClick={handleMenuClick}
+            >
+              <MoreVerticalIcon size={16} />
+            </button>
+          }
+        />
       </div>
-
-      <FolderOverflowMenu
-        folder={folder}
-        isOpen={isMenuOpen}
-        onClose={handleMenuClose}
-        anchorElement={menuAnchor}
-        additionalActions={additionalActions}
-        insertAdditionalActionsAfter={insertAdditionalActionsAfter}
-      />
     </>
   );
 };

--- a/frontend/src/features/dashboard/components/ui/items/item-keyboard.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-keyboard.test.tsx
@@ -26,8 +26,15 @@ import type { FileItem } from '@/features/dashboard/types/file';
 // The overflow menus pull in the rename, drive and router contexts, and the
 // grid thumbnail wants an authenticated S3 client. None of that is what this
 // file is about.
-vi.mock('../menus/folder-overflow-menu', () => ({ FolderOverflowMenu: () => null }));
-vi.mock('../menus/file-overflow-menu', () => ({ FileOverflowMenu: () => null }));
+//
+// The menus own their trigger button now, so these render it rather than
+// nothing - otherwise the button these tests fire keys at would not exist.
+vi.mock('../menus/folder-overflow-menu', () => ({
+  FolderOverflowMenu: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
+vi.mock('../menus/file-overflow-menu', () => ({
+  FileOverflowMenu: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
 vi.mock('./file-thumbnail-with-image', () => ({ FileThumbnailWithImage: () => null }));
 
 const { openFilePreview, openPreview } = vi.hoisted(() => ({

--- a/frontend/src/features/dashboard/components/ui/menus/create-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/create-menu.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useCallback } from 'react';
 import { FolderPlus, Upload, FolderUp } from 'lucide-react';
 import { pickMultipleFiles, pickFolder } from '@/features/upload/utils/file-picker';
 import { ProcessedDragData } from '@/features/upload/types/folder-upload-types';
@@ -10,7 +9,13 @@ import { useDriveStore } from '@/context/data-context';
 import { FolderStructureProcessor } from '@/features/upload/utils/folder-structure-processor';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
-import { PreviewLoading } from '@/components/file-preview/preview-loading';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/components/ui/dropdown-menu';
+import { menuContentClass, menuItemClass } from './menu-styles';
 
 interface CreateMenuAction {
   id: string;
@@ -20,27 +25,26 @@ interface CreateMenuAction {
 }
 
 interface CreateMenuProps {
-  isOpen: boolean;
-  onClose: () => void;
   onNewFolderClick: () => void;
-  anchorElement: HTMLElement | null;
+  /**
+   * The button that opens the menu, rendered as the trigger itself. Replaces
+   * the old isOpen/onClose/anchorElement trio and the hand-rolled positioning
+   * that went with it.
+   */
+  trigger: React.ReactNode;
+  /** Tooltip for the trigger. Omit to render the trigger without one. */
+  triggerLabel?: string;
   className?: string;
   currentPath?: string;
 }
 
 export const CreateMenu: React.FC<CreateMenuProps> = ({
-  isOpen,
-  onClose,
   onNewFolderClick,
-  anchorElement,
+  trigger,
+  triggerLabel,
   className = '',
 }) => {
-  const menuRef = useRef<HTMLDivElement>(null);
   const dispatchDrop = useUploadDispatch();
-  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
-  const [originPosition, setOriginPosition] = useState<
-    'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-  >('top-left');
   const { apiS3, isLoading, isAuthenticated } = useAuthGuard();
 
   // The auth guards used to sit here, above every hook below them, so React
@@ -48,7 +52,6 @@ export const CreateMenu: React.FC<CreateMenuProps> = ({
   // live with the other early return, once all hooks have run.
   const { currentPrefix } = useDriveStore();
 
-  //  file upload handlers using utility functions
   const triggerFileUpload = useCallback(async () => {
     try {
       const result = await pickMultipleFiles();
@@ -58,12 +61,11 @@ export const CreateMenu: React.FC<CreateMenuProps> = ({
           result.files
         );
         void dispatchDrop(processedData, currentPrefix ?? '', apiS3);
-        onClose(); // Close menu after successful file selection
       }
     } catch {
       // Handle error silently or with proper error handling
     }
-  }, [dispatchDrop, onClose, currentPrefix, apiS3]);
+  }, [dispatchDrop, currentPrefix, apiS3]);
 
   const triggerFolderUpload = useCallback(async () => {
     try {
@@ -74,196 +76,72 @@ export const CreateMenu: React.FC<CreateMenuProps> = ({
           result.files
         );
         void dispatchDrop(processedData, currentPrefix ?? '', apiS3);
-        onClose(); // Close menu after successful folder selection
       }
     } catch {
       // Handle error silently or with proper error handling
     }
-  }, [dispatchDrop, onClose, currentPrefix, apiS3]);
+  }, [dispatchDrop, currentPrefix, apiS3]);
 
-  // Handle new folder action - simple approach
-  const handleNewFolderClick = useCallback(() => {
-    onNewFolderClick(); // Call the prop function
-  }, [onNewFolderClick]);
-
-  const getCreateMenuActions = (): CreateMenuAction[] => [
+  const actions: CreateMenuAction[] = [
     {
       id: 'new-folder',
       label: 'New folder',
       icon: <FolderPlus size={16} />,
-      onClick: handleNewFolderClick,
+      onClick: onNewFolderClick,
     },
     {
       id: 'file-upload',
       label: 'File upload',
       icon: <Upload size={16} />,
-      onClick: triggerFileUpload,
+      onClick: () => void triggerFileUpload(),
     },
     {
       id: 'folder-upload',
       label: 'Folder upload',
       icon: <FolderUp size={16} />,
-      onClick: triggerFolderUpload,
+      onClick: () => void triggerFolderUpload(),
     },
   ];
 
-  const actions = getCreateMenuActions();
+  // Rendering nothing at all would take the Create button away with it, so the
+  // trigger stays put and only the menu is withheld until the session is ready.
+  const ready = !isLoading && isAuthenticated;
 
-  // Prevent body scroll when menu is open
-  useEffect(() => {
-    if (isOpen) {
-      const originalOverflow = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
-      return () => {
-        document.body.style.overflow = originalOverflow;
-      };
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (isOpen && anchorElement) {
-      const rect = anchorElement.getBoundingClientRect();
-      const menuWidth = 200;
-      const menuHeight = actions.length * 48 + 16; // Height for padding
-      const padding = 8;
-
-      let left = rect.left;
-      let top = rect.bottom + padding;
-      let origin: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' = 'top-left';
-
-      // Horizontal positioning with boundary check
-      if (left + menuWidth > window.innerWidth - padding) {
-        left = rect.right - menuWidth;
-        origin = 'top-right';
-      }
-
-      // Ensure menu doesn't go off left edge
-      if (left < padding) {
-        left = padding;
-      }
-
-      // Ensure menu doesn't go off right edge
-      if (left + menuWidth > window.innerWidth - padding) {
-        left = window.innerWidth - menuWidth - padding;
-      }
-
-      // Vertical positioning with boundary check
-      if (top + menuHeight > window.innerHeight - padding) {
-        top = rect.top - menuHeight - padding;
-        origin = origin === 'top-right' ? 'bottom-right' : 'bottom-left';
-      }
-
-      // Ensure menu doesn't go off top edge
-      if (top < padding) {
-        top = padding;
-      }
-
-      // Final check: ensure menu fits within viewport height
-      if (top + menuHeight > window.innerHeight - padding) {
-        top = window.innerHeight - menuHeight - padding;
-      }
-
-      // Clamp to ensure menu is always visible
-      top = Math.max(padding, Math.min(top, window.innerHeight - menuHeight - padding));
-      left = Math.max(padding, Math.min(left, window.innerWidth - menuWidth - padding));
-
-      setPosition({ top, left });
-      setOriginPosition(origin);
-    } else {
-      // Reset position when menu closes
-      setPosition(null);
-    }
-  }, [isOpen, anchorElement, actions.length]);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        onClose();
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handleEscape);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [isOpen, onClose]);
-
-  if (isLoading) {
-    return <PreviewLoading message="Authenticating..." />;
-  }
-
-  if (!isAuthenticated || !apiS3) {
-    return null;
-  }
-
-  if (!isOpen || !position) return null;
-
-  // Get transform origin based on position
-  const getTransformOrigin = () => {
-    switch (originPosition) {
-      case 'top-right':
-        return 'top right';
-      case 'bottom-left':
-        return 'bottom left';
-      case 'bottom-right':
-        return 'bottom right';
-      default:
-        return 'top left';
-    }
-  };
-
-  const menuContent = (
-    <AriaLabel label="Create new items" position="top">
-      <div
-        ref={menuRef}
-        className={`
-          fixed z-50 min-w-[200px] max-h-[calc(100vh-16px)] overflow-y-auto p-2
-          bg-secondary border border-border rounded-lg shadow-xl
-          transition-all duration-200 ease-out
-          ${isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}
-          ${className}
-        `}
-        style={{
-          top: position.top,
-          left: position.left,
-          transformOrigin: getTransformOrigin(),
-        }}
-        role="menu"
-      >
-        {actions.map((action, index) => (
-          <React.Fragment key={action.id}>
-            <button
-              className="
-              w-full flex items-center gap-3 px-3 py-3 text-sm rounded-md
-              text-left transition-colors duration-150
-              text-foreground hover:bg-card cursor-pointer
-            "
-              onClick={() => {
-                action.onClick();
-                onClose();
-              }}
-              role="menuitem"
-            >
-              <span className="flex-shrink-0">{action.icon}</span>
-              <span className="flex-1">{action.label}</span>
-            </button>
-            {index === 0 && <div className="my-1 h-px bg-border" />}
-          </React.Fragment>
-        ))}
-      </div>
-    </AriaLabel>
+  const triggerNode = (
+    <DropdownMenuTrigger asChild disabled={!ready}>
+      {trigger}
+    </DropdownMenuTrigger>
   );
 
-  return <>{typeof window !== 'undefined' ? createPortal(menuContent, document.body) : null}</>;
+  return (
+    // modal={false}: a dropdown should not freeze the whole page. This menu used
+    // to set document.body.style.overflow itself, which is half of the scroll
+    // locking mess in #86.
+    <DropdownMenu modal={false}>
+      {triggerLabel ? (
+        <AriaLabel label={triggerLabel} position="top">
+          {triggerNode}
+        </AriaLabel>
+      ) : (
+        triggerNode
+      )}
+
+      <DropdownMenuContent
+        align="start"
+        className={`${menuContentClass} ${className}`}
+        aria-label="Create"
+      >
+        {actions.map((action) => (
+          <DropdownMenuItem
+            key={action.id}
+            className={menuItemClass}
+            onSelect={() => action.onClick()}
+          >
+            <span className="shrink-0">{action.icon}</span>
+            <span className="flex-1">{action.label}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 };

--- a/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * The "Open with" submenu.
+ *
+ * It used to open on hover only, with no key handling anywhere, so Preview and
+ * Open in new tab were unreachable by keyboard entirely - the menu announced
+ * itself as a menu and then hid two of its actions behind a mouse. As a Radix
+ * submenu it opens on Enter or ArrowRight and closes on ArrowLeft.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { FileOverflowMenu } from './file-overflow-menu';
+import type { FileItem } from '@/features/dashboard/types/file';
+
+const { openPreview, openPreviewInNewTab } = vi.hoisted(() => ({
+  openPreview: vi.fn(),
+  openPreviewInNewTab: vi.fn(),
+}));
+
+vi.mock('@/features/dashboard/hooks/use-download', () => ({
+  useDownloadActions: () => ({ downloadFile: vi.fn() }),
+  useIsFileDownloading: () => false,
+}));
+vi.mock('@/features/dashboard/hooks/use-delete-with-progress', () => ({
+  useDeleteWithProgress: () => ({ deleteFile: vi.fn(), isDeleting: () => false }),
+}));
+vi.mock('@/context/rename-context', () => ({
+  useRename: () => ({ isRenaming: () => false, showRenameDialog: vi.fn() }),
+}));
+vi.mock('@/context/details-context', () => ({ useDetails: () => ({ open: vi.fn() }) }));
+vi.mock('@/context/file-preview-context', () => ({
+  useFilePreview: () => ({ openPreview }),
+}));
+vi.mock('@/context/share-context', () => ({ useShare: () => ({ openShareDialog: vi.fn() }) }));
+vi.mock('@/context/data-context', () => ({ useDriveStore: () => ({ currentPrefix: '' }) }));
+vi.mock('@/lib/preview-url', () => ({ openPreviewInNewTab }));
+
+const file = {
+  id: 'q3.pdf',
+  name: 'q3.pdf',
+  Key: 'q3.pdf',
+  ETag: 'etag-1',
+  extension: 'pdf',
+} as FileItem;
+
+function show() {
+  return render(
+    <FileOverflowMenu
+      file={file}
+      trigger={<button aria-label="More actions for q3.pdf">menu</button>}
+    />
+  );
+}
+
+const trigger = () => screen.getByRole('button', { name: 'More actions for q3.pdf' });
+
+/** Opens the menu and moves focus onto the "Open with" row. */
+async function focusOpenWith() {
+  trigger().focus();
+  fireEvent.keyDown(trigger(), { key: 'ArrowDown' });
+  await waitFor(() => expect(screen.queryByRole('menu')).not.toBeNull());
+
+  const openWith = screen.getByText('Open with').closest('[role="menuitem"]') as HTMLElement;
+  await act(async () => {
+    openWith.focus();
+  });
+  return openWith;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('reaching the submenu with a keyboard', () => {
+  it('puts Open with first, so it is one ArrowDown away', async () => {
+    show();
+    trigger().focus();
+    fireEvent.keyDown(trigger(), { key: 'ArrowDown' });
+
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeNull());
+    expect(screen.getAllByRole('menuitem')[0]!.textContent).toContain('Open with');
+  });
+
+  it('opens the submenu on ArrowRight', async () => {
+    show();
+    const openWith = await focusOpenWith();
+
+    fireEvent.keyDown(openWith, { key: 'ArrowRight' });
+
+    await waitFor(() => expect(screen.getByText('Preview')).toBeTruthy());
+    expect(screen.getByText('Open in new tab')).toBeTruthy();
+  });
+
+  it('opens the submenu on Enter', async () => {
+    show();
+    const openWith = await focusOpenWith();
+
+    fireEvent.keyDown(openWith, { key: 'Enter' });
+
+    await waitFor(() => expect(screen.getByText('Preview')).toBeTruthy());
+  });
+
+  it('closes the submenu again on ArrowLeft', async () => {
+    show();
+    const openWith = await focusOpenWith();
+    fireEvent.keyDown(openWith, { key: 'ArrowRight' });
+    await waitFor(() => expect(screen.getByText('Preview')).toBeTruthy());
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowLeft' });
+
+    await waitFor(() => expect(screen.queryByText('Preview')).toBeNull());
+  });
+
+  it('reaches Preview, which had no keyboard path at all before', async () => {
+    show();
+    const openWith = await focusOpenWith();
+    fireEvent.keyDown(openWith, { key: 'ArrowRight' });
+    await waitFor(() => expect(screen.getByText('Preview')).toBeTruthy());
+
+    const preview = screen.getByText('Preview').closest('[role="menuitem"]') as HTMLElement;
+    await act(async () => {
+      preview.focus();
+    });
+    fireEvent.keyDown(preview, { key: 'Enter' });
+
+    await waitFor(() => expect(openPreview).toHaveBeenCalled());
+  });
+
+  it('reaches Open in new tab too', async () => {
+    show();
+    const openWith = await focusOpenWith();
+    fireEvent.keyDown(openWith, { key: 'ArrowRight' });
+    await waitFor(() => expect(screen.getByText('Open in new tab')).toBeTruthy());
+
+    const newTab = screen.getByText('Open in new tab').closest('[role="menuitem"]') as HTMLElement;
+    await act(async () => {
+      newTab.focus();
+    });
+    fireEvent.keyDown(newTab, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(openPreviewInNewTab).toHaveBeenCalledWith({
+        etag: 'etag-1',
+        key: 'q3.pdf',
+      })
+    );
+  });
+});
+
+describe('the page underneath', () => {
+  it('does not freeze page scrolling while open', async () => {
+    show();
+    trigger().focus();
+    fireEvent.keyDown(trigger(), { key: 'ArrowDown' });
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeNull());
+
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.tsx
@@ -1,18 +1,8 @@
 'use client';
 
-import React, { useState, useRef, useEffect } from 'react';
-import { createPortal } from 'react-dom';
+import React from 'react';
 import type { FileItem, FileMenuAction } from '@/features/dashboard/types/file';
-import {
-  Download,
-  Edit3,
-  Info,
-  Trash2,
-  Eye,
-  Share,
-  ChevronRight,
-  ExternalLink,
-} from 'lucide-react';
+import { Download, Edit3, Info, Trash2, Eye, Share, ExternalLink } from 'lucide-react';
 import { useDownloadActions, useIsFileDownloading } from '@/features/dashboard/hooks/use-download';
 import { useDeleteWithProgress } from '@/features/dashboard/hooks/use-delete-with-progress';
 import { useRename } from '@/context/rename-context';
@@ -24,38 +14,45 @@ import { useShare } from '@/context/share-context';
 import { getFileExtensionWithoutDot } from '@/config/file-extensions';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { MdOpenWith } from 'react-icons/md';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/shared/components/ui/dropdown-menu';
+import { menuContentClass, menuItemClass } from './menu-styles';
 
 interface FileOverflowMenuProps {
   file: FileItem;
   allFiles?: FileItem[];
-  isOpen: boolean;
-  onClose: () => void;
-  anchorElement: HTMLElement | null;
+  /**
+   * The button that opens the menu, rendered as the trigger itself. The menu
+   * used to be positioned by hand against an `anchorElement` prop; Radix does
+   * that now, including keeping it on screen near the edges.
+   */
+  trigger: React.ReactNode;
+  /** Tooltip for the trigger. Omit to render the trigger without one. */
+  triggerLabel?: string;
   className?: string;
   additionalActions?: FileMenuAction[];
   insertAdditionalActionsAfter?: string;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
   file,
   allFiles = [],
-  isOpen,
-  onClose,
-  anchorElement,
+  trigger,
+  triggerLabel,
   className = '',
   additionalActions = [],
   insertAdditionalActionsAfter = 'open',
+  onOpenChange,
 }) => {
-  const menuRef = useRef<HTMLDivElement>(null);
-  const submenuRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
-  const [originPosition, setOriginPosition] = useState('top-left');
-  const [isOpenWithSubmenuVisible, setIsOpenWithSubmenuVisible] = useState(false);
-  const [submenuPosition, setSubmenuPosition] = useState<{ top: number; left: number } | null>(
-    null
-  );
-  const [openWithButtonRef, setOpenWithButtonRef] = useState<HTMLButtonElement | null>(null);
-
   const { downloadFile } = useDownloadActions();
   const isDownloading = useIsFileDownloading(file.id);
   const { isRenaming, showRenameDialog: openRenameDialog } = useRename();
@@ -65,34 +62,25 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
   const { openShareDialog } = useShare();
   const { deleteFile, isDeleting } = useDeleteWithProgress();
 
-  // Handle preview action
   const handlePreview = () => {
-    const previewableFile = {
-      id: file.id,
-      name: file.name,
-      key: file.Key,
-      size: typeof file.Size === 'number' ? file.Size : 0,
-      lastModified: file.lastModified,
-      type: file.extension || getFileExtensionWithoutDot(file.name),
-    };
+    const toPreviewable = (item: FileItem) => ({
+      id: item.id,
+      name: item.name,
+      key: item.Key,
+      size: typeof item.Size === 'number' ? item.Size : 0,
+      lastModified: item.lastModified,
+      type: item.extension || getFileExtensionWithoutDot(item.name),
+    });
 
-    const previewableFiles = allFiles.map((f) => ({
-      id: f.id,
-      name: f.name,
-      key: f.Key,
-      size: typeof f.Size === 'number' ? f.Size : 0,
-      lastModified: f.lastModified,
-      type: f.extension || getFileExtensionWithoutDot(f.name),
-    }));
+    const previewableFile = toPreviewable(file);
+    const previewableFiles = allFiles.map(toPreviewable);
 
     openPreview(
       previewableFile,
       previewableFiles.length > 0 ? previewableFiles : [previewableFile]
     );
-    onClose();
   };
 
-  // Handle open in new tab
   const handleOpenInNewTab = () => {
     const etag = file.ETag || '';
     const key = file.Key || '';
@@ -103,10 +91,9 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
     }
 
     openPreviewInNewTab({ etag, key });
-    onClose();
   };
 
-  // Merge additional actions with default actions
+  // Actions other than "Open with", which is a submenu rather than a row.
   const actions = React.useMemo(() => {
     // Built inside the memo so React can see what it actually depends on. As a
     // hoisted helper its live reads - download/rename/delete `disabled` - were
@@ -114,51 +101,32 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
     // unrelated prop happened to change.
     const defaultActions: FileMenuAction[] = [
       {
-        id: 'open',
-        label: 'Open with',
-        icon: MdOpenWith,
-        // This will be handled specially to show submenu
-        onClick: () => {
-          // Submenu handles the actual actions
-        },
-      },
-      {
         id: 'download',
         label: 'Download',
         icon: Download,
         disabled: isDownloading,
-        onClick: (file) => {
-          setTimeout(() => downloadFile(file), 0);
-          onClose();
+        onClick: (item) => {
+          setTimeout(() => downloadFile(item), 0);
         },
       },
       {
         id: 'share',
         label: 'Share',
         icon: Share,
-        onClick: () => {
-          openShareDialog(file);
-          onClose();
-        },
+        onClick: () => openShareDialog(file),
       },
       {
         id: 'rename',
         label: 'Rename',
         icon: Edit3,
         disabled: isRenaming(file.id || file.Key || file.name),
-        onClick: () => {
-          openRenameDialog(file, 'file', currentPrefix || '');
-          onClose();
-        },
+        onClick: () => openRenameDialog(file, 'file', currentPrefix || ''),
       },
       {
         id: 'info',
         label: 'File information',
         icon: Info,
-        onClick: () => {
-          openDetails(file);
-          onClose();
-        },
+        onClick: () => openDetails(file),
       },
       {
         id: 'delete',
@@ -178,7 +146,6 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
               console.error('Delete failed:', error);
             }
           }
-          onClose();
         },
       },
     ];
@@ -187,17 +154,20 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
       return defaultActions;
     }
 
-    // Find insertion point
+    // 'open' is the submenu, which always sits first, so extra actions asking to
+    // follow it belong at the top of this list.
+    if (insertAdditionalActionsAfter === 'open') {
+      return [...additionalActions, ...defaultActions];
+    }
+
     const insertIndex = defaultActions.findIndex(
       (action) => action.id === insertAdditionalActionsAfter
     );
 
     if (insertIndex === -1) {
-      // If insertion point not found, append at the beginning
       return [...additionalActions, ...defaultActions];
     }
 
-    // Insert after the specified action
     return [
       ...defaultActions.slice(0, insertIndex + 1),
       ...additionalActions,
@@ -209,7 +179,6 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
     insertAdditionalActionsAfter,
     isDownloading,
     downloadFile,
-    onClose,
     openShareDialog,
     isRenaming,
     openRenameDialog,
@@ -219,257 +188,60 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
     deleteFile,
   ]);
 
-  // Prevent body scroll when menu is open
-  useEffect(() => {
-    if (isOpen) {
-      const originalOverflow = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
-      return () => {
-        document.body.style.overflow = originalOverflow;
-      };
-    }
-  }, [isOpen]);
+  const triggerNode = <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>;
 
-  useEffect(() => {
-    if (isOpen && anchorElement) {
-      const rect = anchorElement.getBoundingClientRect();
-      const menuWidth = 200;
-      const menuHeight = actions.length * 44 + 16;
-      const padding = 8;
+  return (
+    // modal={false}: a dropdown should not freeze the whole page. This menu used
+    // to set document.body.style.overflow itself, which is half of the scroll
+    // locking mess in #86.
+    <DropdownMenu modal={false} onOpenChange={onOpenChange}>
+      {triggerLabel ? (
+        <AriaLabel label={triggerLabel} position="top">
+          {triggerNode}
+        </AriaLabel>
+      ) : (
+        triggerNode
+      )}
 
-      let left = rect.right + padding;
-      let top = rect.top;
-      let origin = 'top-left';
-
-      // Horizontal positioning with boundary check
-      if (left + menuWidth > window.innerWidth - padding) {
-        left = rect.left - menuWidth - padding;
-        origin = 'top-right';
-      }
-
-      // Ensure menu doesn't go off left edge
-      if (left < padding) {
-        left = padding;
-      }
-
-      // Ensure menu doesn't go off right edge
-      if (left + menuWidth > window.innerWidth - padding) {
-        left = window.innerWidth - menuWidth - padding;
-      }
-
-      // Vertical positioning with boundary check
-      if (top + menuHeight > window.innerHeight - padding) {
-        top = rect.bottom - menuHeight;
-        origin = origin === 'top-right' ? 'bottom-right' : 'bottom-left';
-      }
-
-      // Ensure menu doesn't go off top edge
-      if (top < padding) {
-        top = padding;
-      }
-
-      // Final check: ensure menu fits within viewport height
-      if (top + menuHeight > window.innerHeight - padding) {
-        top = window.innerHeight - menuHeight - padding;
-      }
-
-      // Clamp to ensure menu is always visible
-      top = Math.max(padding, Math.min(top, window.innerHeight - menuHeight - padding));
-      left = Math.max(padding, Math.min(left, window.innerWidth - menuWidth - padding));
-
-      setPosition({ top, left });
-      setOriginPosition(origin);
-    } else {
-      setPosition(null);
-    }
-  }, [isOpen, anchorElement, actions.length]);
-
-  // Position submenu when "Open with" is hovered
-  useEffect(() => {
-    if (isOpenWithSubmenuVisible && openWithButtonRef && menuRef.current) {
-      const buttonRect = openWithButtonRef.getBoundingClientRect();
-      const menuRect = menuRef.current.getBoundingClientRect();
-      const submenuWidth = 180;
-      const padding = 4;
-      const gap = 8; // Gap between main menu and submenu
-
-      // Position submenu to the right of the main menu, not the button
-      let left = menuRect.right + gap;
-      let top = buttonRect.top;
-
-      // Check if submenu goes off right edge
-      if (left + submenuWidth > window.innerWidth - padding) {
-        // Position to the left of the main menu
-        left = menuRect.left - submenuWidth - gap;
-      }
-
-      // Ensure submenu doesn't go off screen
-      if (left < padding) {
-        left = padding;
-      }
-
-      if (top < padding) {
-        top = padding;
-      }
-
-      setSubmenuPosition({ top, left });
-    } else {
-      setSubmenuPosition(null);
-    }
-  }, [isOpenWithSubmenuVisible, openWithButtonRef]);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-      const clickedInMenu = menuRef.current?.contains(target);
-      const clickedInSubmenu = submenuRef.current?.contains(target);
-
-      if (!clickedInMenu && !clickedInSubmenu) {
-        setIsOpenWithSubmenuVisible(false);
-        onClose();
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        if (isOpenWithSubmenuVisible) {
-          setIsOpenWithSubmenuVisible(false);
-        } else {
-          onClose();
-        }
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handleEscape);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [isOpen, isOpenWithSubmenuVisible, onClose]);
-
-  if (!isOpen || !position) return null;
-
-  const getTransformOrigin = () => {
-    switch (originPosition) {
-      case 'top-right':
-        return 'top right';
-      case 'bottom-left':
-        return 'bottom left';
-      case 'bottom-right':
-        return 'bottom right';
-      default:
-        return 'top left';
-    }
-  };
-
-  const submenuContent = isOpenWithSubmenuVisible && submenuPosition && (
-    <div
-      ref={submenuRef}
-      className="fixed z-[60] min-w-[180px] p-2 bg-secondary border border-border rounded-lg shadow-xl"
-      style={{
-        top: submenuPosition.top,
-        left: submenuPosition.left,
-      }}
-      role="menu"
-    >
-      <button
-        className="w-full flex items-center gap-3 px-3 py-2.5 text-sm rounded-md text-left transition-colors duration-150 text-foreground hover:bg-card cursor-pointer"
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          handlePreview();
-        }}
-        role="menuitem"
+      <DropdownMenuContent
+        align="start"
+        className={`${menuContentClass} ${className}`}
+        aria-label={`Actions for ${file.name}`}
       >
-        <Eye className="flex-shrink-0 h-4 w-4" />
-        <span className="flex-1">Preview</span>
-      </button>
-      <button
-        className="w-full flex items-center gap-3 px-3 py-2.5 text-sm rounded-md text-left transition-colors duration-150 text-foreground hover:bg-card cursor-pointer"
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          handleOpenInNewTab();
-        }}
-        role="menuitem"
-      >
-        <ExternalLink className="flex-shrink-0 h-4 w-4" />
-        <span className="flex-1">Open in new tab</span>
-      </button>
-    </div>
-  );
+        {/* Was hover-only, so Preview had no keyboard path at all. As a Radix
+            submenu it opens on Enter or ArrowRight and closes on ArrowLeft. */}
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className={menuItemClass}>
+            <MdOpenWith className="h-4 w-4 shrink-0" />
+            <span className="flex-1">Open with</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className={menuContentClass}>
+            <DropdownMenuItem className={menuItemClass} onSelect={handlePreview}>
+              <Eye className="h-4 w-4 shrink-0" />
+              <span className="flex-1">Preview</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem className={menuItemClass} onSelect={handleOpenInNewTab}>
+              <ExternalLink className="h-4 w-4 shrink-0" />
+              <span className="flex-1">Open in new tab</span>
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
 
-  const menuContent = (
-    <>
-      <AriaLabel label={`Actions for ${file.name}`} position="top">
-        <div
-          ref={menuRef}
-          className={`
-            fixed z-50 min-w-[200px] max-h-[calc(100vh-16px)] overflow-y-auto p-2
-            bg-secondary border border-border rounded-lg shadow-xl
-            transition-all duration-200 ease-out
-            ${isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}
-            ${className}
-          `}
-          style={{
-            top: position.top,
-            left: position.left,
-            transformOrigin: getTransformOrigin(),
-          }}
-          role="menu"
-        >
-          {actions.map((action, index) => (
-            <React.Fragment key={action.id}>
-              {index === actions.length - 1 && <div className="my-1 h-px bg-border" />}
-              <button
-                ref={action.id === 'open' ? setOpenWithButtonRef : undefined}
-                className={`
-                w-full flex items-center gap-3 px-3 cursor-pointer py-2.5 text-sm rounded-md
-                text-left transition-colors duration-150
-                ${
-                  action.variant === 'destructive'
-                    ? 'text-[#d93025] hover:bg-[#fce8e6] dark:text-[#f28b82] dark:hover:bg-[#5f2120]/20'
-                    : 'text-foreground hover:bg-card'
-                }
-                ${action.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
-              `}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  if (!action.disabled) {
-                    if (action.id === 'open') {
-                      // Toggle submenu instead of direct action
-                      setIsOpenWithSubmenuVisible(!isOpenWithSubmenuVisible);
-                    } else {
-                      action.onClick?.(file);
-                    }
-                  }
-                }}
-                onMouseEnter={() => {
-                  if (action.id === 'open') {
-                    setIsOpenWithSubmenuVisible(true);
-                  } else {
-                    setIsOpenWithSubmenuVisible(false);
-                  }
-                }}
-                disabled={action.disabled}
-                role="menuitem"
-              >
-                <action.icon className="flex-shrink-0 h-4 w-4" />
-                <span className="flex-1">{action.label}</span>
-                {action.id === 'open' && <ChevronRight className="flex-shrink-0 h-4 w-4 ml-auto" />}
-              </button>
-            </React.Fragment>
-          ))}
-        </div>
-      </AriaLabel>
-      {submenuContent}
-    </>
+        {actions.map((action, index) => (
+          <React.Fragment key={action.id}>
+            {index === actions.length - 1 && <DropdownMenuSeparator />}
+            <DropdownMenuItem
+              className={menuItemClass}
+              variant={action.variant === 'destructive' ? 'destructive' : 'default'}
+              disabled={action.disabled}
+              onSelect={() => action.onClick?.(file)}
+            >
+              <action.icon className="h-4 w-4 shrink-0" />
+              <span className="flex-1">{action.label}</span>
+            </DropdownMenuItem>
+          </React.Fragment>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
-
-  return <>{typeof window !== 'undefined' ? createPortal(menuContent, document.body) : null}</>;
 };

--- a/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Overflow menu keyboard access.
+ *
+ * The menu advertised `role="menu"` and `role="menuitem"` while implementing no
+ * arrow keys, no Home/End and no focus management, so a screen reader announced
+ * a menu and told the user to press keys that did nothing. It is a Radix
+ * dropdown now, and these tests pin the behaviour that buys, from the outside:
+ * open it with the keyboard, walk it with the keyboard, and get focus back.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { FolderOverflowMenu } from './folder-overflow-menu';
+import type { Folder } from '@/features/dashboard/types/folder';
+
+const { push, openRenameDialog } = vi.hoisted(() => ({
+  push: vi.fn(),
+  openRenameDialog: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }));
+
+vi.mock('@/features/dashboard/hooks/use-delete-with-progress', () => ({
+  useDeleteWithProgress: () => ({ deleteFolder: vi.fn(), isDeleting: () => false }),
+}));
+
+vi.mock('@/context/rename-context', () => ({
+  useRename: () => ({ isRenaming: () => false, showRenameDialog: openRenameDialog }),
+}));
+
+vi.mock('@/context/data-context', () => ({
+  useDriveStore: () => ({ currentPrefix: '' }),
+}));
+
+const folder = { name: 'Reports', Prefix: 'Reports/', id: 'Reports/' } as Folder;
+
+function show() {
+  return render(
+    <FolderOverflowMenu
+      folder={folder}
+      trigger={<button aria-label="More actions for Reports">menu</button>}
+    />
+  );
+}
+
+const trigger = () => screen.getByRole('button', { name: 'More actions for Reports' });
+const items = () => screen.getAllByRole('menuitem');
+
+/** Opens the menu the way a keyboard user does and waits for it to settle. */
+async function openWithKeyboard(key: string) {
+  trigger().focus();
+  fireEvent.keyDown(trigger(), { key });
+  await waitFor(() => expect(screen.queryByRole('menu')).not.toBeNull());
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('opening', () => {
+  it('is closed until asked for', () => {
+    show();
+
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it.each(['Enter', ' ', 'ArrowDown'])('opens on %s', async (key) => {
+    show();
+
+    await openWithKeyboard(key);
+
+    expect(screen.getByRole('menu')).toBeTruthy();
+  });
+
+  it('tells assistive tech the trigger opens a menu', () => {
+    show();
+
+    expect(trigger().getAttribute('aria-haspopup')).toBe('menu');
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('marks the trigger expanded while open', async () => {
+    show();
+
+    await openWithKeyboard('Enter');
+
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+  });
+});
+
+describe('moving through the items', () => {
+  it('focuses the first item when opened downward', async () => {
+    show();
+
+    await openWithKeyboard('ArrowDown');
+
+    // Announcing a menu and leaving focus behind on the trigger is what made
+    // the old roles actively misleading.
+    await waitFor(() => expect(document.activeElement).toBe(items()[0]));
+  });
+
+  it('walks down with ArrowDown', async () => {
+    show();
+    await openWithKeyboard('ArrowDown');
+    await waitFor(() => expect(document.activeElement).toBe(items()[0]));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
+
+    await waitFor(() => expect(document.activeElement).toBe(items()[1]));
+  });
+
+  it('walks back up with ArrowUp', async () => {
+    show();
+    await openWithKeyboard('ArrowDown');
+    await waitFor(() => expect(document.activeElement).toBe(items()[0]));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
+    await waitFor(() => expect(document.activeElement).toBe(items()[1]));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' });
+
+    await waitFor(() => expect(document.activeElement).toBe(items()[0]));
+  });
+
+  it('jumps to the last item with End and back with Home', async () => {
+    show();
+    await openWithKeyboard('ArrowDown');
+    await waitFor(() => expect(document.activeElement).toBe(items()[0]));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'End' });
+    await waitFor(() => expect(document.activeElement).toBe(items()[items().length - 1]));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Home' });
+    await waitFor(() => expect(document.activeElement).toBe(items()[0]));
+  });
+});
+
+describe('choosing and dismissing', () => {
+  it('runs the focused action on Enter', async () => {
+    show();
+    await openWithKeyboard('ArrowDown');
+    await waitFor(() => expect(document.activeElement).toBe(items()[0]));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Enter' });
+
+    // First item is Open, which navigates into the folder.
+    await waitFor(() => expect(push).toHaveBeenCalled());
+  });
+
+  it('closes on Escape and puts focus back on the trigger', async () => {
+    show();
+    await openWithKeyboard('ArrowDown');
+    await waitFor(() => expect(document.activeElement).toBe(items()[0]));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+    // Dropping focus to the body would leave a keyboard user at the top of the
+    // page with no idea where they were.
+    await waitFor(() => expect(document.activeElement).toBe(trigger()));
+  });
+});
+
+describe('the page underneath', () => {
+  it('does not freeze page scrolling while open', async () => {
+    show();
+
+    await openWithKeyboard('ArrowDown');
+
+    // The menu used to set document.body.style.overflow itself just to show a
+    // dropdown, which is half of what made #86 possible.
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import React, { useState, useRef, useEffect, useMemo } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useMemo, useState } from 'react';
 import type { Folder, FolderMenuAction } from '@/features/dashboard/types/folder';
 import { Edit3, Trash2 } from 'lucide-react';
 import { useDeleteWithProgress } from '@/features/dashboard/hooks/use-delete-with-progress';
@@ -15,32 +14,40 @@ import {
 } from '@/shared/components/ui/credit-warning-dialog';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { FaFolderOpen } from 'react-icons/fa';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/shared/components/ui/dropdown-menu';
+import { menuContentClass, menuItemClass } from './menu-styles';
 
 interface OverflowMenuProps {
   folder: Folder;
-  isOpen: boolean;
-  onClose: () => void;
-  anchorElement: HTMLElement | null;
+  /**
+   * The button that opens the menu, rendered as the trigger itself rather than
+   * placed beside it. The menu used to be positioned by hand against an
+   * `anchorElement` prop, which is what Radix does for us now.
+   */
+  trigger: React.ReactNode;
+  /** Tooltip for the trigger. Omit to render the trigger without one. */
+  triggerLabel?: string;
   className?: string;
   additionalActions?: FolderMenuAction[]; // Additional menu actions
   insertAdditionalActionsAfter?: string; // Where to insert additional actions (default: 'open')
+  onOpenChange?: (open: boolean) => void;
 }
 
 export const FolderOverflowMenu: React.FC<OverflowMenuProps> = ({
   folder,
-  isOpen,
-  onClose,
-  anchorElement,
+  trigger,
+  triggerLabel,
   className = '',
   additionalActions = [],
   insertAdditionalActionsAfter = 'open',
+  onOpenChange,
 }) => {
-  const menuRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
-  const [originPosition, setOriginPosition] = useState<
-    'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-  >('top-left');
-  const [showCreditWarning, setShowCreditWarning] = useState(false);
   const [pendingAction, setPendingAction] = useState<'rename' | 'delete' | null>(null);
 
   const { deleteFolder, isDeleting } = useDeleteWithProgress();
@@ -48,53 +55,11 @@ export const FolderOverflowMenu: React.FC<OverflowMenuProps> = ({
   const { currentPrefix } = useDriveStore();
   const router = useRouter();
 
-  // Reset credit warning state when menu closes or component unmounts
-  useEffect(() => {
-    if (!isOpen) {
-      setShowCreditWarning(false);
-      setPendingAction(null);
-    }
-  }, [isOpen]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      setShowCreditWarning(false);
-      setPendingAction(null);
-    };
-  }, []);
-
-  // Handle rename with credit warning
-  const handleRename = () => {
-    if (shouldShowCreditWarning('folder-rename')) {
-      setPendingAction('rename');
-      setShowCreditWarning(true);
-      // Don't close menu yet - let credit warning show first
-    } else {
-      executeRename();
-      handleMenuClose();
-    }
-  };
-
   const executeRename = () => {
     openRenameDialog(folder, 'folder', currentPrefix || '');
-    handleMenuClose(); // Close menu only after opening rename dialog
-  };
-
-  // Handle delete with credit warning
-  const handleDelete = () => {
-    if (shouldShowCreditWarning('folder-delete')) {
-      setPendingAction('delete');
-      setShowCreditWarning(true);
-      // Don't close menu yet - let credit warning show first
-    } else {
-      executeDelete();
-      handleMenuClose();
-    }
   };
 
   const executeDelete = async () => {
-    handleMenuClose(); // Close menu before showing confirmation
     const confirmDelete = window.confirm(
       `Are you sure you want to delete "${folder.name}" forever? This will delete the folder and all its contents. This action cannot be undone.`
     );
@@ -108,68 +73,66 @@ export const FolderOverflowMenu: React.FC<OverflowMenuProps> = ({
     }
   };
 
-  // Handle credit warning confirmation
+  // Selecting an item closes the menu on its own now, so these only decide
+  // whether the credit warning stands between the click and the work.
+  const handleRename = () => {
+    if (shouldShowCreditWarning('folder-rename')) {
+      setPendingAction('rename');
+    } else {
+      executeRename();
+    }
+  };
+
+  const handleDelete = () => {
+    if (shouldShowCreditWarning('folder-delete')) {
+      setPendingAction('delete');
+    } else {
+      void executeDelete();
+    }
+  };
+
   const handleCreditWarningConfirm = () => {
     if (pendingAction === 'rename') {
       executeRename();
     } else if (pendingAction === 'delete') {
-      executeDelete();
+      void executeDelete();
     }
-    setShowCreditWarning(false);
     setPendingAction(null);
   };
 
-  const handleCreditWarningClose = () => {
-    setShowCreditWarning(false);
-    setPendingAction(null);
-    onClose(); // Close menu when credit warning is cancelled
-  };
-
-  // Reset credit warning state and close menu
-  const handleMenuClose = () => {
-    // Reset credit warning state when menu closes
-    setShowCreditWarning(false);
-    setPendingAction(null);
-    onClose();
-  };
-
-  const getDefaultMenuActions = (folder: Folder): FolderMenuAction[] => [
-    {
-      id: 'open',
-      label: 'Open',
-      icon: <FaFolderOpen className="flex-shrink-0 h-4 w-4" />,
-      onClick: (_folder) => {
-        const folderUrl = generateFolderUrl({ prefix: folder.Prefix });
-        router.push(folderUrl);
-        handleMenuClose();
-      },
-    },
-    {
-      id: 'rename',
-      label: 'Rename',
-      icon: <Edit3 className="flex-shrink-0 h-4 w-4" />,
-      disabled: isRenaming(folder.id || folder.Prefix || folder.name),
-      onClick: handleRename,
-    },
-    {
-      id: 'delete',
-      label: isDeleting(folder.id || folder.Prefix || folder.name)
-        ? 'Deleting...'
-        : 'Delete forever',
-      icon: <Trash2 className="flex-shrink-0 h-4 w-4" />,
-      variant: 'destructive' as const,
-      disabled: isDeleting(folder.id || folder.Prefix || folder.name),
-      onClick: handleDelete,
-    },
-  ];
-
-  // Merge additional actions with default actions
   const actions = useMemo(() => {
+    const defaultActions: FolderMenuAction[] = [
+      {
+        id: 'open',
+        label: 'Open',
+        icon: <FaFolderOpen className="h-4 w-4 shrink-0" />,
+        onClick: () => {
+          router.push(generateFolderUrl({ prefix: folder.Prefix }));
+        },
+      },
+      {
+        id: 'rename',
+        label: 'Rename',
+        icon: <Edit3 className="h-4 w-4 shrink-0" />,
+        disabled: isRenaming(folder.id || folder.Prefix || folder.name),
+        onClick: handleRename,
+      },
+      {
+        id: 'delete',
+        label: isDeleting(folder.id || folder.Prefix || folder.name)
+          ? 'Deleting...'
+          : 'Delete forever',
+        icon: <Trash2 className="h-4 w-4 shrink-0" />,
+        variant: 'destructive' as const,
+        disabled: isDeleting(folder.id || folder.Prefix || folder.name),
+        onClick: handleDelete,
+      },
+    ];
+
     if (additionalActions.length === 0) {
-      return getDefaultMenuActions(folder);
+      return defaultActions;
     }
 
-    const defaultActions = getDefaultMenuActions(folder);
     const insertIndex = defaultActions.findIndex(
       (action) => action.id === insertAdditionalActionsAfter
     );
@@ -179,181 +142,59 @@ export const FolderOverflowMenu: React.FC<OverflowMenuProps> = ({
       return [...additionalActions, ...defaultActions];
     }
 
-    // Insert after the specified action
-    const result = [
+    return [
       ...defaultActions.slice(0, insertIndex + 1),
       ...additionalActions,
       ...defaultActions.slice(insertIndex + 1),
     ];
+    // handleRename/handleDelete are redefined every render and only read state
+    // through the hooks above, so listing them would rebuild this every time
+    // without changing what it produces.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folder, additionalActions, insertAdditionalActionsAfter, isRenaming, isDeleting, router]);
 
-    return result;
-  }, [folder, additionalActions, insertAdditionalActionsAfter]);
-
-  // Prevent body scroll when menu is open
-  useEffect(() => {
-    if (isOpen) {
-      const originalOverflow = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
-      return () => {
-        document.body.style.overflow = originalOverflow;
-      };
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (isOpen && anchorElement) {
-      const rect = anchorElement.getBoundingClientRect();
-      const menuWidth = 200;
-      const menuHeight = actions.length * 44 + 16;
-      const padding = 8;
-
-      let left = rect.right + padding;
-      let top = rect.top;
-      let origin: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' = 'top-left';
-
-      // Horizontal positioning with boundary check
-      if (left + menuWidth > window.innerWidth - padding) {
-        left = rect.left - menuWidth - padding;
-        origin = 'top-right';
-      }
-
-      // Ensure menu doesn't go off left edge
-      if (left < padding) {
-        left = padding;
-      }
-
-      // Ensure menu doesn't go off right edge
-      if (left + menuWidth > window.innerWidth - padding) {
-        left = window.innerWidth - menuWidth - padding;
-      }
-
-      // Vertical positioning with boundary check
-      if (top + menuHeight > window.innerHeight - padding) {
-        top = rect.bottom - menuHeight;
-        origin = origin === 'top-right' ? 'bottom-right' : 'bottom-left';
-      }
-
-      // Ensure menu doesn't go off top edge
-      if (top < padding) {
-        top = padding;
-      }
-
-      // Final check: ensure menu fits within viewport height
-      if (top + menuHeight > window.innerHeight - padding) {
-        top = window.innerHeight - menuHeight - padding;
-      }
-
-      // Clamp to ensure menu is always visible
-      top = Math.max(padding, Math.min(top, window.innerHeight - menuHeight - padding));
-      left = Math.max(padding, Math.min(left, window.innerWidth - menuWidth - padding));
-
-      setPosition({ top, left });
-      setOriginPosition(origin);
-    } else {
-      setPosition(null);
-    }
-  }, [isOpen, anchorElement, actions.length]);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        onClose();
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handleEscape);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [isOpen, onClose]);
-
-  if (!isOpen || !position) return null;
-
-  const getTransformOrigin = () => {
-    switch (originPosition) {
-      case 'top-right':
-        return 'top right';
-      case 'bottom-left':
-        return 'bottom left';
-      case 'bottom-right':
-        return 'bottom right';
-      default:
-        return 'top left';
-    }
-  };
-
-  const menuContent = (
-    <AriaLabel label={`Actions for ${folder.name}`} position="top">
-      <div
-        ref={menuRef}
-        className={`
-          fixed z-50 min-w-[200px] max-h-[calc(100vh-16px)] overflow-y-auto p-2
-          bg-secondary border border-border rounded-lg shadow-xl
-          transition-all duration-200 ease-out
-          ${isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}
-          ${className}
-        `}
-        style={{
-          top: position.top,
-          left: position.left,
-          transformOrigin: getTransformOrigin(),
-        }}
-        role="menu"
-      >
-        {actions.map((action, index) => (
-          <React.Fragment key={action.id}>
-            {index === actions.length - 1 && <div className="my-1 h-px bg-border" />}
-            <button
-              className={`
-              w-full flex items-center gap-3 px-3 cursor-pointer py-2.5 text-sm rounded-md
-              text-left transition-colors duration-150
-              ${
-                action.variant === 'destructive'
-                  ? 'text-[#d93025] hover:bg-[#fce8e6] dark:text-[#f28b82] dark:hover:bg-[#5f2120]/20'
-                  : 'text-foreground hover:bg-card'
-              }
-              ${action.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
-            `}
-              onClick={() => {
-                if (!action.disabled) {
-                  action.onClick?.(folder);
-                }
-              }}
-              disabled={action.disabled}
-              role="menuitem"
-            >
-              <span className="flex-shrink-0">{action.icon}</span>
-              <span className="flex-1">{action.label}</span>
-            </button>
-          </React.Fragment>
-        ))}
-      </div>
-    </AriaLabel>
-  );
+  const triggerNode = <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>;
 
   return (
     <>
-      {/* Only render menu if credit warning is not showing */}
-      {!showCreditWarning && typeof window !== 'undefined'
-        ? createPortal(menuContent, document.body)
-        : null}
+      {/* modal={false}: a dropdown should not freeze the whole page. Each menu
+          used to set document.body.style.overflow itself, which is half of the
+          scroll locking mess in #86. */}
+      <DropdownMenu modal={false} onOpenChange={onOpenChange}>
+        {triggerLabel ? (
+          <AriaLabel label={triggerLabel} position="top">
+            {triggerNode}
+          </AriaLabel>
+        ) : (
+          triggerNode
+        )}
 
-      {/* Credit Warning Dialog - rendered outside portal to avoid conflicts */}
-      {showCreditWarning && (
+        <DropdownMenuContent
+          align="start"
+          className={`${menuContentClass} ${className}`}
+          aria-label={`Actions for ${folder.name}`}
+        >
+          {actions.map((action, index) => (
+            <React.Fragment key={action.id}>
+              {index === actions.length - 1 && <DropdownMenuSeparator />}
+              <DropdownMenuItem
+                className={menuItemClass}
+                variant={action.variant === 'destructive' ? 'destructive' : 'default'}
+                disabled={action.disabled}
+                onSelect={() => action.onClick?.(folder)}
+              >
+                <span className="shrink-0">{action.icon}</span>
+                <span className="flex-1">{action.label}</span>
+              </DropdownMenuItem>
+            </React.Fragment>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {pendingAction && (
         <CreditWarningDialog
-          isOpen={showCreditWarning}
-          onClose={handleCreditWarningClose}
+          isOpen
+          onClose={() => setPendingAction(null)}
           onConfirm={handleCreditWarningConfirm}
           operationType={pendingAction === 'rename' ? 'folder-rename' : 'folder-delete'}
         />

--- a/frontend/src/features/dashboard/components/ui/menus/menu-styles.ts
+++ b/frontend/src/features/dashboard/components/ui/menus/menu-styles.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared look for the overflow menus.
+ *
+ * The three menus are now Radix dropdowns, which come with their own popover
+ * styling. These classes put the app's existing appearance back on top, so the
+ * move to Radix changes behaviour without changing how the menus look.
+ */
+
+/** Panel: wider and more padded than the shadcn default, on the secondary surface. */
+export const menuContentClass =
+  'min-w-[200px] max-h-[calc(100vh-16px)] overflow-y-auto p-2 bg-secondary border-border rounded-lg shadow-xl';
+
+/** Row: taller and roomier than the shadcn default, matching the old buttons. */
+export const menuItemClass = 'gap-3 px-3 py-2.5 text-sm rounded-md cursor-pointer';

--- a/frontend/src/hooks/use-scroll-lock.ts
+++ b/frontend/src/hooks/use-scroll-lock.ts
@@ -21,9 +21,10 @@ import { useLayoutEffect } from 'react';
  * overflow for any other reason, so clearing the inline style is the only
  * resting state that can be correct.
  *
- * Not yet used by the three overflow menus, which still lock scroll by hand.
- * Those are being moved to Radix in #88, which removes the manual locking
- * outright, so converting them here would only be undone.
+ * This is now the only thing in the app that writes body overflow. The three
+ * overflow menus used to lock scroll by hand just to show a dropdown; they are
+ * Radix menus now and do not lock at all, which is the behaviour a dropdown
+ * should have had in the first place.
  */
 let holders = 0;
 


### PR DESCRIPTION
Reopens the work from #163, which never reached main.

#163 was stacked on `fix/folder-names-and-scroll-lock` and that branch merged into main at 16:26. #163 then merged into the branch at 16:49, after main had already absorbed it, so the commit landed somewhere main will never pull from. Main today has no `menu-styles.ts` and no Radix imports in the menus.

GitHub still closed #88 and #86 from the old PR body, so both are marked done while the code is not on main. #88 needs reopening; the #86 work from #162 did land, but the menu half did not.

Same change as #163, no edits: the three overflow menus become Radix dropdowns, which gives arrow keys, Home/End, typeahead, Escape, focus restore, and a keyboard path into the `Open with` submenu that did not exist before. Each menu takes its trigger as a prop instead of the old isOpen/onClose/anchorElement trio, which removes the menu state from all six call sites. `modal={false}` means a dropdown no longer freezes the page, so `useScrollLock` becomes the only thing writing body overflow.

Merges cleanly into main. 956 lines removed against 736 added.
