### PR TITLE
fix: give the form dialogs a focus trap and real dialog semantics

### DIFF
--- a/frontend/src/features/dashboard/components/ui/dialogs/create-folder-dialog.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/dialogs/create-folder-dialog.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Dialog accessibility.
+ *
+ * The hand-rolled dialogs had no `role="dialog"` and no `aria-modal`, trapped
+ * no focus so Tab walked out behind a backdrop that still blocked the mouse,
+ * never gave focus back to whatever opened them, and put Escape on an inner div
+ * so it only worked while focus happened to be inside it.
+ *
+ * create-folder is the one the issue calls out for the Escape problem, so it
+ * carries the shared assertions for the pattern the other four now follow.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useState } from 'react';
+import { CreateFolderDialog } from './create-folder-dialog';
+
+const onConfirm = vi.fn();
+
+/** Mounts the dialog behind a real trigger, so focus restore has a target. */
+function Harness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>open dialog</button>
+      <button>somewhere else</button>
+      <CreateFolderDialog
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onConfirm={onConfirm}
+        defaultName="Untitled folder"
+      />
+    </>
+  );
+}
+
+const trigger = () => screen.getByRole('button', { name: 'open dialog' });
+
+async function open() {
+  render(<Harness />);
+  await act(async () => {
+    // Focus it first: jsdom does not move focus on click, and focus restore has
+    // nothing to restore to if the trigger never held it.
+    trigger().focus();
+    trigger().click();
+  });
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeNull());
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('it announces itself as a dialog', () => {
+  it('is not rendered until opened', () => {
+    render(<Harness />);
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('exposes the dialog role and modal flag', async () => {
+    await open();
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('gives the dialog an accessible name', async () => {
+    await open();
+
+    // Screen readers announced nothing but loose text before.
+    expect(screen.getByRole('dialog', { name: /new folder/i })).toBeTruthy();
+  });
+});
+
+describe('focus', () => {
+  it('moves focus into the dialog, onto the name', async () => {
+    await open();
+
+    const input = screen.getByPlaceholderText('Folder name');
+    await waitFor(() => expect(document.activeElement).toBe(input));
+  });
+
+  it('selects the default name so it can be typed over', async () => {
+    await open();
+
+    const input = screen.getByPlaceholderText('Folder name') as HTMLInputElement;
+    await waitFor(() => expect(input.selectionStart).toBe(0));
+    expect(input.selectionEnd).toBe('Untitled folder'.length);
+  });
+
+  it('returns focus to whatever opened it', async () => {
+    await open();
+
+    await act(async () => {
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    });
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    // Landing back at the top of the document is what a keyboard user got.
+    await waitFor(() => expect(document.activeElement).toBe(trigger()));
+  });
+
+  it('hides the page behind it from assistive tech', async () => {
+    render(<Harness />);
+    // Reachable before the dialog opens.
+    expect(screen.queryByRole('button', { name: 'somewhere else' })).not.toBeNull();
+
+    await act(async () => {
+      trigger().focus();
+      trigger().click();
+    });
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeNull());
+
+    // The old backdrop blocked the mouse but not Tab or a screen reader, so
+    // everything behind it stayed reachable while the dialog was up.
+    expect(screen.queryByRole('button', { name: 'somewhere else' })).toBeNull();
+  });
+});
+
+describe('dismissing', () => {
+  it('closes on Escape regardless of where focus sits', async () => {
+    await open();
+
+    // Escape used to be bound to an inner div, so it depended on focus being
+    // inside that particular element.
+    await act(async () => {
+      fireEvent.keyDown(document.body, { key: 'Escape' });
+    });
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
+  it('closes from its own close control', async () => {
+    await open();
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Cancel create folder' }).click();
+    });
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
+  it('does not confirm when dismissed', async () => {
+    await open();
+
+    await act(async () => {
+      fireEvent.keyDown(document.body, { key: 'Escape' });
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe('it still does its job', () => {
+  it('creates a folder with the typed name', async () => {
+    await open();
+
+    const input = screen.getByPlaceholderText('Folder name');
+    fireEvent.change(input, { target: { value: 'Café ☕' } });
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Create' }).click();
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith('Café ☕');
+  });
+
+  it('blocks a name that cannot work and says why', async () => {
+    await open();
+
+    const input = screen.getByPlaceholderText('Folder name');
+    fireEvent.change(input, { target: { value: 'a/b' } });
+
+    expect(screen.getByText('Folder name cannot contain a slash.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create' })).toHaveProperty('disabled', true);
+  });
+});

--- a/frontend/src/features/dashboard/components/ui/dialogs/create-folder-dialog.tsx
+++ b/frontend/src/features/dashboard/components/ui/dialogs/create-folder-dialog.tsx
@@ -89,7 +89,9 @@ export const CreateFolderDialog: React.FC<CreateFolderDialogProps> = ({
       <DialogContent
         showCloseButton={false}
         onOpenAutoFocus={focusName}
-        className="w-full max-w-md gap-0 rounded-lg bg-card p-0 shadow-xl"
+        // border-0: the shared content styling carries a border, but this card
+        // never had one and it reads as a hard outline against the backdrop.
+        className="w-full max-w-md gap-0 rounded-lg border-0 bg-card p-0 shadow-xl"
       >
         <div className="flex items-center justify-between p-6 pb-4">
           <div className="flex items-center gap-3">

--- a/frontend/src/features/dashboard/components/ui/dialogs/create-folder-dialog.tsx
+++ b/frontend/src/features/dashboard/components/ui/dialogs/create-folder-dialog.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { createPortal } from 'react-dom';
 import { FolderPlus, X } from 'lucide-react';
 import { describeFolderNameError } from '@/features/upload/utils/folder-name';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
 
 interface CreateFolderDialogProps {
   isOpen: boolean;
@@ -26,19 +32,19 @@ export const CreateFolderDialog: React.FC<CreateFolderDialogProps> = ({
   useEffect(() => {
     if (isOpen) {
       setFolderName(defaultName);
-      setIsCreating(false);
-      setValidationError('');
-      setTimeout(() => {
-        if (inputRef.current) {
-          inputRef.current.focus();
-          inputRef.current.select();
-        }
-      }, 100);
-    } else {
-      setIsCreating(false);
-      setValidationError('');
     }
+    setIsCreating(false);
+    setValidationError('');
   }, [isOpen, defaultName]);
+
+  // Radix focuses the first focusable element on open, which would be the close
+  // button. Take it over so the name lands selected and ready to overtype, the
+  // way the old setTimeout was reaching for.
+  const focusName = (event: Event) => {
+    event.preventDefault();
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  };
 
   const handleFolderNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -74,36 +80,31 @@ export const CreateFolderDialog: React.FC<CreateFolderDialogProps> = ({
     onClose();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      handleCancel();
-    }
-  };
-
-  if (!isOpen) return null;
-
-  const dialogContent = (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
-      onClick={(e) => e.target === e.currentTarget && handleCancel()}
-    >
-      <div
-        className="relative w-full max-w-md mx-4 bg-card rounded-lg shadow-xl"
-        onKeyDown={handleKeyDown}
+  return (
+    // Escape used to be handled by an inner div, so it only worked while focus
+    // happened to be inside it. Radix listens at the document and also traps
+    // focus, restores it to whatever opened the dialog, and supplies the
+    // role/aria-modal wiring this had none of.
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
+      <DialogContent
+        showCloseButton={false}
+        onOpenAutoFocus={focusName}
+        className="w-full max-w-md gap-0 rounded-lg bg-card p-0 shadow-xl"
       >
         <div className="flex items-center justify-between p-6 pb-4">
           <div className="flex items-center gap-3">
             <FolderPlus className="h-5 w-5 text-primary" />
-            <h2 className="text-lg font-medium text-foreground">New folder</h2>
+            <DialogTitle className="text-lg font-medium text-foreground">New folder</DialogTitle>
           </div>
-          <button
-            onClick={handleCancel}
+          <DialogClose
             className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
             aria-label="Cancel create folder"
           >
             <X className="h-4 w-4" />
-          </button>
+          </DialogClose>
         </div>
+
+        <DialogDescription className="sr-only">Enter a name for the new folder.</DialogDescription>
 
         <form onSubmit={handleSubmit} className="px-6 pb-6">
           <div className="space-y-4">
@@ -142,9 +143,7 @@ export const CreateFolderDialog: React.FC<CreateFolderDialogProps> = ({
             </div>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
-
-  return typeof window !== 'undefined' ? createPortal(dialogContent, document.body) : null;
 };

--- a/frontend/src/features/dashboard/components/ui/dialogs/rename-dialog.tsx
+++ b/frontend/src/features/dashboard/components/ui/dialogs/rename-dialog.tsx
@@ -120,7 +120,9 @@ export const RenameDialog: React.FC<RenameDialogProps> = ({
       <DialogContent
         showCloseButton={false}
         onOpenAutoFocus={focusName}
-        className="w-full max-w-md gap-0 rounded-lg bg-card p-0 shadow-xl"
+        // border-0: the shared content styling carries a border, but this card
+        // never had one and it reads as a hard outline against the backdrop.
+        className="w-full max-w-md gap-0 rounded-lg border-0 bg-card p-0 shadow-xl"
       >
         <div className="flex items-center justify-between p-6 pb-4">
           <div className="flex items-center gap-3">

--- a/frontend/src/features/dashboard/components/ui/dialogs/rename-dialog.tsx
+++ b/frontend/src/features/dashboard/components/ui/dialogs/rename-dialog.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { createPortal } from 'react-dom';
 import { Edit3, X } from 'lucide-react';
 import { describeFolderNameError } from '@/features/upload/utils/folder-name';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
 
 interface RenameDialogProps {
   isOpen: boolean;
@@ -30,24 +36,25 @@ export const RenameDialog: React.FC<RenameDialogProps> = ({
     if (isOpen) {
       setNewName(currentName);
       setValidationError('');
-      setTimeout(() => {
-        if (inputRef.current) {
-          inputRef.current.focus();
-
-          if (type === 'file') {
-            const lastDotIndex = currentName.lastIndexOf('.');
-            if (lastDotIndex > 0) {
-              inputRef.current.setSelectionRange(0, lastDotIndex);
-            } else {
-              inputRef.current.select();
-            }
-          } else {
-            inputRef.current.select();
-          }
-        }
-      }, 100);
     }
   }, [isOpen, currentName, type]);
+
+  // Radix would focus the close button first. Take it over so the name is
+  // selected and ready to overtype, with a file's extension left out of the
+  // selection the way the old setTimeout did it.
+  const focusName = (event: Event) => {
+    event.preventDefault();
+    const input = inputRef.current;
+    if (!input) return;
+
+    input.focus();
+    const lastDotIndex = currentName.lastIndexOf('.');
+    if (type === 'file' && lastDotIndex > 0) {
+      input.setSelectionRange(0, lastDotIndex);
+    } else {
+      input.select();
+    }
+  };
 
   const validateName = (name: string): string | null => {
     if (!name.trim()) {
@@ -105,38 +112,30 @@ export const RenameDialog: React.FC<RenameDialogProps> = ({
     onClose();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      handleCancel();
-    }
-  };
-
-  if (!isOpen) {
-    return null;
-  }
-
-  const dialogContent = (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
-      onClick={(e) => e.target === e.currentTarget && handleCancel()}
-    >
-      <div
-        className="relative w-full max-w-md mx-4 bg-card rounded-lg shadow-xl"
-        onKeyDown={handleKeyDown}
+  return (
+    // Escape was handled by an inner div, so it only worked while focus was
+    // inside it. Radix listens at the document, traps focus, restores it on
+    // close, and supplies the dialog role and aria-modal this never had.
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
+      <DialogContent
+        showCloseButton={false}
+        onOpenAutoFocus={focusName}
+        className="w-full max-w-md gap-0 rounded-lg bg-card p-0 shadow-xl"
       >
         <div className="flex items-center justify-between p-6 pb-4">
           <div className="flex items-center gap-3">
             <Edit3 className="h-5 w-5 text-primary" />
-            <h2 className="text-lg font-medium text-foreground">Rename {type}</h2>
+            <DialogTitle className="text-lg font-medium text-foreground">Rename {type}</DialogTitle>
           </div>
-          <button
-            onClick={handleCancel}
+          <DialogClose
             className="rounded-md p-1 text-muted-foreground cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
             aria-label="Cancel rename"
           >
             <X className="h-4 w-4" />
-          </button>
+          </DialogClose>
         </div>
+
+        <DialogDescription className="sr-only">Enter a new name for this {type}.</DialogDescription>
 
         <form onSubmit={handleSubmit} className="px-6 pb-6">
           <div className="space-y-4">
@@ -177,9 +176,7 @@ export const RenameDialog: React.FC<RenameDialogProps> = ({
             </div>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
-
-  return typeof window !== 'undefined' ? createPortal(dialogContent, document.body) : null;
 };

--- a/frontend/src/features/dashboard/components/ui/dialogs/rename-duplicate-dialog.tsx
+++ b/frontend/src/features/dashboard/components/ui/dialogs/rename-duplicate-dialog.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import React, { useState } from 'react';
-import { createPortal } from 'react-dom';
 import { File, Folder, AlertTriangle } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
 
 interface RenameDuplicateDialogProps {
   isOpen: boolean;
@@ -24,8 +29,6 @@ export const RenameDuplicateDialog: React.FC<RenameDuplicateDialogProps> = ({
 }) => {
   const [selectedAction, setSelectedAction] = useState<'replace' | 'keep-both'>('keep-both');
 
-  if (!isOpen) return null;
-
   const handleContinue = () => {
     if (selectedAction === 'keep-both') {
       onKeepBoth();
@@ -39,16 +42,15 @@ export const RenameDuplicateDialog: React.FC<RenameDuplicateDialogProps> = ({
     onClose();
   };
 
-  const dialogContent = (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center">
-      <div
-        className="absolute inset-0 backdrop-blur-sm"
-        style={{ backgroundColor: 'rgba(0, 0, 0, 0.3)' }}
-        onClick={handleCancel}
-      />
-
-      <div
-        className="relative rounded-lg shadow-xl max-w-md w-full mx-4 overflow-hidden"
+  return (
+    // Stacks on top of the rename dialog, so it keeps the higher layer the
+    // hand-rolled version had. Radix moves the focus trap to whichever dialog
+    // opened last, so the one on top owns the keyboard.
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="z-[60] bg-black/30 backdrop-blur-sm"
+        className="z-[60] max-w-md w-full gap-0 overflow-hidden rounded-lg p-0 shadow-xl"
         style={{
           backgroundColor: 'var(--card)',
           border: '1px solid var(--border)',
@@ -57,13 +59,13 @@ export const RenameDuplicateDialog: React.FC<RenameDuplicateDialogProps> = ({
         <div className="px-6 py-4">
           <div className="flex items-center gap-3 mb-3">
             <AlertTriangle className="h-5 w-5 text-amber-500" />
-            <h2 className="text-lg font-medium" style={{ color: 'var(--foreground)' }}>
+            <DialogTitle className="text-lg font-medium" style={{ color: 'var(--foreground)' }}>
               {type === 'file' ? 'File' : 'Folder'} already exists
-            </h2>
+            </DialogTitle>
           </div>
-          <p className="text-sm" style={{ color: 'var(--muted-foreground)' }}>
+          <DialogDescription className="text-sm" style={{ color: 'var(--muted-foreground)' }}>
             A {type} named "{newName}" already exists in this location. What would you like to do?
-          </p>
+          </DialogDescription>
         </div>
 
         <div className="px-6 pb-4">
@@ -197,9 +199,7 @@ export const RenameDuplicateDialog: React.FC<RenameDuplicateDialogProps> = ({
             Continue
           </button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
-
-  return typeof window !== 'undefined' ? createPortal(dialogContent, document.body) : null;
 };

--- a/frontend/src/features/upload/components/duplicate-dialog.tsx
+++ b/frontend/src/features/upload/components/duplicate-dialog.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import React, { useState } from 'react';
-import { createPortal } from 'react-dom';
 import { File, Folder, AlertTriangle } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
 
 export interface DuplicateItem {
   name: string;
@@ -28,8 +33,6 @@ export function DuplicateDialog({
 }: DuplicateDialogProps) {
   const [selectedAction, setSelectedAction] = useState<'replace' | 'keep-both'>('keep-both');
 
-  if (!isOpen || !duplicateItem) return null;
-
   const handleUpload = () => {
     if (selectedAction === 'keep-both') {
       onKeepBoth();
@@ -43,183 +46,171 @@ export function DuplicateDialog({
     onClose();
   };
 
-  return typeof window !== 'undefined'
-    ? createPortal(
-        <div className="fixed inset-0 z-[60] flex items-center justify-center">
-          <div
-            className="absolute inset-0 backdrop-blur-sm"
-            style={{ backgroundColor: 'rgba(0, 0, 0, 0.3)' }}
-            onClick={handleCancel}
-          />
+  if (!duplicateItem) return null;
 
+  return (
+    // Stacks on top of the create-folder dialog, so it keeps the higher layer
+    // the hand-rolled version had. Radix takes the focus trap with it, so the
+    // newest dialog owns focus while it is open.
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="z-[60] bg-black/30 backdrop-blur-sm"
+        className="z-[60] max-w-md w-full gap-0 overflow-hidden rounded-lg p-0 shadow-xl"
+        style={{
+          backgroundColor: 'var(--card)',
+          border: '1px solid var(--border)',
+        }}
+      >
+        <div className="px-6 py-4">
+          <div className="flex items-center gap-3 mb-3">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            <DialogTitle className="text-lg font-medium" style={{ color: 'var(--foreground)' }}>
+              {duplicateItem.type === 'file' ? 'File already exists' : 'Folder already exists'}
+            </DialogTitle>
+          </div>
+          <DialogDescription className="text-sm" style={{ color: 'var(--muted-foreground)' }}>
+            A {duplicateItem.type} named "{duplicateItem.name}" already exists in this location.
+            What would you like to do?
+          </DialogDescription>
+        </div>
+
+        <div className="px-6 pb-4">
           <div
-            className="relative rounded-lg shadow-xl max-w-md w-full mx-4 overflow-hidden"
-            style={{
-              backgroundColor: 'var(--card)',
-              border: '1px solid var(--border)',
-            }}
+            className="flex items-center  gap-3 p-3 rounded-lg"
+            style={{ backgroundColor: 'var(--muted)' }}
           >
-            <div className="px-6 py-4">
-              <div className="flex items-center gap-3 mb-3">
-                <AlertTriangle className="h-5 w-5 text-amber-500" />
-                <h2 className="text-lg font-medium" style={{ color: 'var(--foreground)' }}>
-                  {duplicateItem.type === 'file' ? 'File already exists' : 'Folder already exists'}
-                </h2>
-              </div>
-              <p className="text-sm" style={{ color: 'var(--muted-foreground)' }}>
-                A {duplicateItem.type} named "{duplicateItem.name}" already exists in this location.
-                What would you like to do?
+            {duplicateItem.type === 'file' ? (
+              <File className="h-5 w-5 flex-shrink-0" style={{ color: 'var(--primary)' }} />
+            ) : (
+              <Folder className="h-5 w-5 flex-shrink-0" style={{ color: 'var(--primary)' }} />
+            )}
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-sm truncate" style={{ color: 'var(--foreground)' }}>
+                {duplicateItem.name}
+              </p>
+              <p className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
+                Existing {duplicateItem.type} in this location
               </p>
             </div>
-
-            <div className="px-6 pb-4">
-              <div
-                className="flex items-center  gap-3 p-3 rounded-lg"
-                style={{ backgroundColor: 'var(--muted)' }}
-              >
-                {duplicateItem.type === 'file' ? (
-                  <File className="h-5 w-5 flex-shrink-0" style={{ color: 'var(--primary)' }} />
-                ) : (
-                  <Folder className="h-5 w-5 flex-shrink-0" style={{ color: 'var(--primary)' }} />
-                )}
-                <div className="flex-1 min-w-0">
-                  <p
-                    className="font-medium text-sm truncate"
-                    style={{ color: 'var(--foreground)' }}
-                  >
-                    {duplicateItem.name}
-                  </p>
-                  <p className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
-                    Existing {duplicateItem.type} in this location
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="px-6 pb-6">
-              <div className="space-y-3">
-                <label
-                  className="flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-colors"
-                  style={{
-                    backgroundColor: selectedAction === 'replace' ? 'var(--accent)' : 'transparent',
-                    border:
-                      selectedAction === 'replace'
-                        ? '1px solid var(--primary)'
-                        : '1px solid var(--border)',
-                  }}
-                  onClick={() => setSelectedAction('replace')}
-                >
-                  <div className="relative mt-0.5">
-                    <input
-                      type="radio"
-                      name="duplicate-action"
-                      value="replace"
-                      checked={selectedAction === 'replace'}
-                      onChange={() => setSelectedAction('replace')}
-                      className="w-4 h-4"
-                      style={{ accentColor: 'var(--primary)' }}
-                    />
-                  </div>
-                  <div className="flex-1">
-                    <span
-                      className="text-sm font-medium block"
-                      style={{ color: 'var(--foreground)' }}
-                    >
-                      {duplicateItem.type === 'file'
-                        ? 'Replace existing file'
-                        : 'Merge with existing folder'}
-                    </span>
-                    <span className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
-                      {duplicateItem.type === 'file'
-                        ? 'The existing file will be replaced with the new one'
-                        : 'Contents will be merged with the existing folder'}
-                    </span>
-                  </div>
-                </label>
-
-                <label
-                  className="flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-colors"
-                  style={{
-                    backgroundColor:
-                      selectedAction === 'keep-both' ? 'var(--accent)' : 'transparent',
-                    border:
-                      selectedAction === 'keep-both'
-                        ? '1px solid var(--primary)'
-                        : '1px solid var(--border)',
-                  }}
-                  onClick={() => setSelectedAction('keep-both')}
-                >
-                  <div className="relative mt-0.5">
-                    <input
-                      type="radio"
-                      name="duplicate-action"
-                      value="keep-both"
-                      checked={selectedAction === 'keep-both'}
-                      onChange={() => setSelectedAction('keep-both')}
-                      className="w-4 h-4"
-                      style={{ accentColor: 'var(--primary)' }}
-                    />
-                  </div>
-                  <div className="flex-1">
-                    <span
-                      className="text-sm font-medium block"
-                      style={{ color: 'var(--foreground)' }}
-                    >
-                      {duplicateItem.type === 'file' ? 'Keep both files' : 'Keep both folders'}
-                    </span>
-                    <span className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
-                      {duplicateItem.type === 'file'
-                        ? 'The new file will be saved with a unique name'
-                        : 'The renamed folder will be saved with a unique name'}
-                    </span>
-                  </div>
-                </label>
-              </div>
-            </div>
-
-            <div
-              className="px-6 py-4 flex justify-end gap-3"
-              style={{
-                backgroundColor: 'var(--muted)',
-                borderTop: '1px solid var(--border)',
-              }}
-            >
-              <button
-                onClick={handleCancel}
-                className="px-4 py-2 cursor-pointer text-sm font-medium transition-colors rounded-md"
-                style={{
-                  color: 'var(--muted-foreground)',
-                  backgroundColor: 'transparent',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--accent)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'transparent';
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleUpload}
-                className="px-6 py-2 text-sm cursor-pointer font-medium rounded-md transition-colors"
-                style={{
-                  backgroundColor: 'var(--primary)',
-                  color: 'var(--primary-foreground)',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.opacity = '0.9';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.opacity = '1';
-                }}
-              >
-                Continue
-              </button>
-            </div>
           </div>
-        </div>,
-        document.body
-      )
-    : null;
+        </div>
+
+        <div className="px-6 pb-6">
+          <div className="space-y-3">
+            <label
+              className="flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-colors"
+              style={{
+                backgroundColor: selectedAction === 'replace' ? 'var(--accent)' : 'transparent',
+                border:
+                  selectedAction === 'replace'
+                    ? '1px solid var(--primary)'
+                    : '1px solid var(--border)',
+              }}
+              onClick={() => setSelectedAction('replace')}
+            >
+              <div className="relative mt-0.5">
+                <input
+                  type="radio"
+                  name="duplicate-action"
+                  value="replace"
+                  checked={selectedAction === 'replace'}
+                  onChange={() => setSelectedAction('replace')}
+                  className="w-4 h-4"
+                  style={{ accentColor: 'var(--primary)' }}
+                />
+              </div>
+              <div className="flex-1">
+                <span className="text-sm font-medium block" style={{ color: 'var(--foreground)' }}>
+                  {duplicateItem.type === 'file'
+                    ? 'Replace existing file'
+                    : 'Merge with existing folder'}
+                </span>
+                <span className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
+                  {duplicateItem.type === 'file'
+                    ? 'The existing file will be replaced with the new one'
+                    : 'Contents will be merged with the existing folder'}
+                </span>
+              </div>
+            </label>
+
+            <label
+              className="flex items-start gap-3 p-3 rounded-lg cursor-pointer transition-colors"
+              style={{
+                backgroundColor: selectedAction === 'keep-both' ? 'var(--accent)' : 'transparent',
+                border:
+                  selectedAction === 'keep-both'
+                    ? '1px solid var(--primary)'
+                    : '1px solid var(--border)',
+              }}
+              onClick={() => setSelectedAction('keep-both')}
+            >
+              <div className="relative mt-0.5">
+                <input
+                  type="radio"
+                  name="duplicate-action"
+                  value="keep-both"
+                  checked={selectedAction === 'keep-both'}
+                  onChange={() => setSelectedAction('keep-both')}
+                  className="w-4 h-4"
+                  style={{ accentColor: 'var(--primary)' }}
+                />
+              </div>
+              <div className="flex-1">
+                <span className="text-sm font-medium block" style={{ color: 'var(--foreground)' }}>
+                  {duplicateItem.type === 'file' ? 'Keep both files' : 'Keep both folders'}
+                </span>
+                <span className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
+                  {duplicateItem.type === 'file'
+                    ? 'The new file will be saved with a unique name'
+                    : 'The renamed folder will be saved with a unique name'}
+                </span>
+              </div>
+            </label>
+          </div>
+        </div>
+
+        <div
+          className="px-6 py-4 flex justify-end gap-3"
+          style={{
+            backgroundColor: 'var(--muted)',
+            borderTop: '1px solid var(--border)',
+          }}
+        >
+          <button
+            onClick={handleCancel}
+            className="px-4 py-2 cursor-pointer text-sm font-medium transition-colors rounded-md"
+            style={{
+              color: 'var(--muted-foreground)',
+              backgroundColor: 'transparent',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = 'var(--accent)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'transparent';
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleUpload}
+            className="px-6 py-2 text-sm cursor-pointer font-medium rounded-md transition-colors"
+            style={{
+              backgroundColor: 'var(--primary)',
+              color: 'var(--primary-foreground)',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.opacity = '0.9';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.opacity = '1';
+            }}
+          >
+            Continue
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/frontend/src/shared/components/ui/credit-warning-dialog.tsx
+++ b/frontend/src/shared/components/ui/credit-warning-dialog.tsx
@@ -1,10 +1,15 @@
 'use client';
-import { useScrollLock } from '@/hooks/use-scroll-lock';
 
 import React, { useState, useEffect } from 'react';
-import { createPortal } from 'react-dom';
 import { AlertTriangle, X } from 'lucide-react';
 import { Button } from '@/shared/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
 
 type OperationType = 'folder-rename' | 'folder-delete' | 'search-operation';
 
@@ -56,8 +61,6 @@ export function CreditWarningDialog({
     }
   }, [isOpen]);
 
-  useScrollLock(isOpen);
-
   const handleConfirm = () => {
     if (dontShowAgain) {
       localStorage.setItem(config.storageKey, 'true');
@@ -71,156 +74,121 @@ export function CreditWarningDialog({
     onClose();
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      handleClose();
-    }
-  };
-
-  // Don't render anything if not open
-  if (!isOpen) return null;
-
-  const dialogContent = (
-    <div
-      className="fixed inset-0 z-[9999] overflow-y-auto"
-      aria-labelledby="modal-title"
-      role="dialog"
-      aria-modal="true"
-    >
-      {/* Backdrop */}
-      <div
-        className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
-        onClick={(e) => {
-          // Only close if clicking the backdrop itself (not the dialog)
-          if (e.target === e.currentTarget) {
-            handleClose();
-          }
+  return (
+    // Was the only dialog with role and aria-modal already, but Escape sat on
+    // an inner div and focus was never trapped or restored. Radix supplies all
+    // of that, and locks scroll itself, so the shared scroll lock goes.
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="z-[9998] bg-black/50"
+        className="z-[9999] sm:max-w-md w-full gap-0 overflow-hidden rounded-xl p-0 text-left shadow-xl"
+        style={{
+          backgroundColor: 'var(--background)',
+          borderColor: 'var(--border)',
         }}
       >
+        {/* Header */}
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 transition-opacity pointer-events-none"
-          aria-hidden="true"
-        />
-
-        {/* This element is to trick the browser into centering the modal contents. */}
-        <span
-          className="hidden sm:inline-block sm:align-middle sm:h-screen pointer-events-none"
-          aria-hidden="true"
+          className="flex items-center justify-between p-6 border-b"
+          style={{ borderColor: 'var(--border)' }}
         >
-          &#8203;
-        </span>
-
-        {/* Dialog panel */}
-        <div
-          className="relative inline-block align-bottom rounded-xl text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-md sm:w-full border pointer-events-auto"
-          style={{
-            backgroundColor: 'var(--background)',
-            borderColor: 'var(--border)',
-          }}
-          onKeyDown={handleKeyDown}
-        >
-          {/* Header */}
-          <div
-            className="flex items-center justify-between p-6 border-b"
-            style={{ borderColor: 'var(--border)' }}
-          >
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg" style={{ backgroundColor: 'var(--accent)' }}>
-                <AlertTriangle className="h-5 w-5" style={{ color: 'var(--primary)' }} />
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold" style={{ color: 'var(--foreground)' }}>
-                  {config.title}
-                </h2>
-                <p className="text-sm font-medium" style={{ color: 'var(--primary)' }}>
-                  {config.warning}
-                </p>
-              </div>
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg" style={{ backgroundColor: 'var(--accent)' }}>
+              <AlertTriangle className="h-5 w-5" style={{ color: 'var(--primary)' }} />
             </div>
-            <button
-              onClick={handleClose}
-              className="p-1 rounded-lg transition-colors cursor-pointer hover:opacity-80"
-              style={{ backgroundColor: 'var(--secondary)' }}
-              aria-label="Close warning"
-            >
-              <X className="h-5 w-5" style={{ color: 'var(--muted-foreground)' }} />
-            </button>
+            <div>
+              <DialogTitle className="text-lg font-semibold" style={{ color: 'var(--foreground)' }}>
+                {config.title}
+              </DialogTitle>
+              <DialogDescription
+                className="text-sm font-medium"
+                style={{ color: 'var(--primary)' }}
+              >
+                {config.warning}
+              </DialogDescription>
+            </div>
+          </div>
+          <DialogClose
+            className="p-1 rounded-lg transition-colors cursor-pointer hover:opacity-80"
+            style={{ backgroundColor: 'var(--secondary)' }}
+            aria-label="Close warning"
+          >
+            <X className="h-5 w-5" style={{ color: 'var(--muted-foreground)' }} />
+          </DialogClose>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-4">
+          <div className="text-sm leading-relaxed" style={{ color: 'var(--muted-foreground)' }}>
+            {config.description}
           </div>
 
-          {/* Content */}
-          <div className="p-6 space-y-4">
-            <div className="text-sm leading-relaxed" style={{ color: 'var(--muted-foreground)' }}>
-              {config.description}
+          <div
+            className="p-4 rounded-lg border"
+            style={{
+              backgroundColor: 'var(--accent)',
+              borderColor: 'var(--border)',
+            }}
+          >
+            <div className="flex items-start gap-2">
+              <AlertTriangle
+                className="h-4 w-4 mt-0.5 flex-shrink-0"
+                style={{ color: 'var(--primary)' }}
+              />
+              <div className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
+                <strong>Credit Usage Notice:</strong> This operation involves multiple S3 API calls.
+                Each file operation (copy, delete, list) consumes credits based on AWS pricing. Your
+                current credit balance will be updated accordingly.
+              </div>
             </div>
+          </div>
 
-            <div
-              className="p-4 rounded-lg border"
+          {/* Don't show again checkbox */}
+          <div className="flex items-center gap-3 pt-2">
+            <input
+              id="dont-show-again"
+              type="checkbox"
+              checked={dontShowAgain}
+              onChange={(e) => setDontShowAgain(e.target.checked)}
+              className="h-4 w-4 cursor-pointer rounded"
               style={{
-                backgroundColor: 'var(--accent)',
+                accentColor: 'var(--primary)',
                 borderColor: 'var(--border)',
               }}
+            />
+            <label
+              htmlFor="dont-show-again"
+              className="text-sm cursor-pointer"
+              style={{ color: 'var(--muted-foreground)' }}
             >
-              <div className="flex items-start gap-2">
-                <AlertTriangle
-                  className="h-4 w-4 mt-0.5 flex-shrink-0"
-                  style={{ color: 'var(--primary)' }}
-                />
-                <div className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
-                  <strong>Credit Usage Notice:</strong> This operation involves multiple S3 API
-                  calls. Each file operation (copy, delete, list) consumes credits based on AWS
-                  pricing. Your current credit balance will be updated accordingly.
-                </div>
-              </div>
-            </div>
-
-            {/* Don't show again checkbox */}
-            <div className="flex items-center gap-3 pt-2">
-              <input
-                id="dont-show-again"
-                type="checkbox"
-                checked={dontShowAgain}
-                onChange={(e) => setDontShowAgain(e.target.checked)}
-                className="h-4 w-4 cursor-pointer rounded"
-                style={{
-                  accentColor: 'var(--primary)',
-                  borderColor: 'var(--border)',
-                }}
-              />
-              <label
-                htmlFor="dont-show-again"
-                className="text-sm cursor-pointer"
-                style={{ color: 'var(--muted-foreground)' }}
-              >
-                I understand and don't show this warning again
-              </label>
-            </div>
-          </div>
-
-          {/* Footer */}
-          <div
-            className="flex items-center justify-end gap-3 p-6 border-t"
-            style={{ borderColor: 'var(--border)' }}
-          >
-            <Button variant="outline" onClick={handleClose} className="min-w-[80px]">
-              Cancel
-            </Button>
-            <Button
-              onClick={handleConfirm}
-              className="min-w-[100px] text-white"
-              style={{
-                backgroundColor: 'var(--primary)',
-                borderColor: 'var(--primary)',
-              }}
-            >
-              I Understand
-            </Button>
+              I understand and don't show this warning again
+            </label>
           </div>
         </div>
-      </div>
-    </div>
-  );
 
-  return typeof window !== 'undefined' ? createPortal(dialogContent, document.body) : null;
+        {/* Footer */}
+        <div
+          className="flex items-center justify-end gap-3 p-6 border-t"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          <Button variant="outline" onClick={handleClose} className="min-w-[80px]">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            className="min-w-[100px] text-white"
+            style={{
+              backgroundColor: 'var(--primary)',
+              borderColor: 'var(--primary)',
+            }}
+          >
+            I Understand
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 // Utility function to check if warning should be shown

--- a/frontend/src/shared/components/ui/dialog.tsx
+++ b/frontend/src/shared/components/ui/dialog.tsx
@@ -38,16 +38,69 @@ function DialogOverlay({
   );
 }
 
+/**
+ * Restores focus to whatever was focused before the dialog opened.
+ *
+ * Radix's modal content already prevents the focus scope's own restore and
+ * focuses `DialogTrigger` instead. Every dialog in this app is opened
+ * programmatically and has no trigger, so that ref is null and focus was landing
+ * on the body - the exact thing a keyboard user notices, since they end up back
+ * at the top of the page.
+ */
+function useFocusRestore() {
+  const previouslyFocused = React.useRef<HTMLElement | null>(null);
+
+  const rememberFocus = (event: Event) => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    void event;
+  };
+
+  const restoreFocus = (event: Event) => {
+    // Taking the default cancels Radix's own handler, which would otherwise
+    // focus a trigger that does not exist.
+    event.preventDefault();
+    previouslyFocused.current?.focus?.();
+  };
+
+  return { rememberFocus, restoreFocus };
+}
+
 function DialogContent({
   className,
   children,
+  overlayClassName,
+  showCloseButton = true,
+  onOpenAutoFocus,
+  onCloseAutoFocus,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  /**
+   * Set false when the dialog draws its own close control, so it does not end
+   * up with two. Wrap that control in `DialogClose` to keep it working.
+   */
+  showCloseButton?: boolean;
+  /** For dialogs that stack and need their backdrop above another one. */
+  overlayClassName?: string;
+}) {
+  const { rememberFocus, restoreFocus } = useFocusRestore();
+
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        onOpenAutoFocus={(event) => {
+          rememberFocus(event);
+          onOpenAutoFocus?.(event);
+        }}
+        onCloseAutoFocus={(event) => {
+          onCloseAutoFocus?.(event);
+          restoreFocus(event);
+        }}
+        // Radix conveys modality by aria-hiding the rest of the page, which is
+        // the more reliable of the two techniques, and does not set this. Set
+        // it as well so assistive tech that looks for the flag also gets it.
+        aria-modal="true"
         className={cn(
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           className
@@ -55,10 +108,12 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {showCloseButton && (
+          <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   );


### PR DESCRIPTION
Part of #96. Covers the five form dialogs; the rest follow in a second PR.

create-folder, rename, rename-duplicate, duplicate and credit-warning now use the Radix dialog primitive that was already in the repo but unused. That gives `role="dialog"`, a focus trap, Escape handled at the document instead of on an inner div, and focus returned to whatever opened the dialog. The page behind is hidden from assistive tech, so it is no longer reachable by Tab while a dialog is up.

**Two things worth a look in review.**

Radix's modal content prevents the focus scope's own restore and focuses `DialogTrigger` instead. Every dialog here is opened programmatically and has no trigger, so that ref is null and focus was landing on the body. `DialogContent` now remembers what was focused before opening and restores it. Without that, focus restore silently would not have worked in any of the five.

Radix conveys modality by aria-hiding the rest of the page rather than setting `aria-modal`. That is the more reliable technique, but since the issue asks for the attribute, `DialogContent` sets it too.

Also added a `showCloseButton` prop, matching upstream shadcn, so dialogs that draw their own close control do not end up with two. The stacked dialogs keep their explicit z-index rather than relying on portal mount order.

Not in this PR, per the scoping decision: share-dialog, multi-share, mobile-details and the file preview modal. The advanced search sheet is deliberately left for #80, which rewrites that file anyway. The preview modal is agreed to get hand-rolled ARIA rather than Radix, since a focus trap around the pdf and monaco viewers risks fighting their own focus handling.
