### PR TITLE
fix: dialog focus handling, and stop logout leaving timers running

### DIFF
--- a/frontend/src/components/file-preview/file-preview-modal.test.tsx
+++ b/frontend/src/components/file-preview/file-preview-modal.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Preview modal accessibility.
+ *
+ * This one is not a Radix dialog. It embeds the pdf, monaco and xlsx viewers,
+ * which manage focus themselves, so a focus trap wrapped around them is a good
+ * way to break a viewer quietly. It gets the dialog semantics and the focus
+ * moves by hand instead, which means nothing enforces them but these tests.
+ *
+ * The arrow-key navigation between files predates this and has to keep working,
+ * so it is covered here too.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { FilePreviewModal } from './file-preview-modal';
+
+const preview = vi.hoisted(() => ({
+  value: {
+    isOpen: false,
+    file: null as unknown,
+    currentIndex: 0,
+    files: [] as unknown[],
+    closePreview: vi.fn(),
+    navigateNext: vi.fn(),
+    navigatePrevious: vi.fn(),
+  },
+}));
+
+vi.mock('@/context/file-preview-context', () => ({
+  useFilePreview: () => preview.value,
+}));
+
+// The header and the viewers pull in S3, monaco and pdf. None of that is what
+// this file is about.
+vi.mock('./preview-header', () => ({ PreviewHeader: () => <button>Close preview</button> }));
+vi.mock('./preview-content', () => ({ PreviewContent: () => <div>viewer</div> }));
+
+const file = { id: 'q3.pdf', name: 'q3.pdf', key: 'q3.pdf' };
+const second = { id: 'q4.pdf', name: 'q4.pdf', key: 'q4.pdf' };
+
+function show(overrides: Partial<typeof preview.value> = {}) {
+  preview.value = { ...preview.value, ...overrides };
+  return render(
+    <>
+      <button>the row behind</button>
+      <FilePreviewModal />
+    </>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  preview.value = {
+    ...preview.value,
+    isOpen: false,
+    file: null,
+    currentIndex: 0,
+    files: [],
+  };
+});
+
+describe('dialog semantics', () => {
+  it('renders nothing when closed', () => {
+    show({ isOpen: false, file });
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('announces itself as a modal dialog named for the file', () => {
+    show({ isOpen: true, file, files: [file] });
+
+    const dialog = screen.getByRole('dialog', { name: 'Preview of q3.pdf' });
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('keeps the click-to-close backdrop out of the accessibility tree', () => {
+    const { container } = show({ isOpen: true, file, files: [file] });
+
+    // A bare clickable div with no keyboard path should not be announced; the
+    // close button and Escape are the real ways out.
+    const backdrop = container.querySelector('.absolute.inset-0');
+    expect(backdrop?.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+describe('focus', () => {
+  it('moves focus into the dialog when it opens', async () => {
+    show({ isOpen: true, file, files: [file] });
+
+    // It used to leave focus on the row behind, so a keyboard user carried on
+    // tabbing through a page they could no longer see.
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('dialog')));
+  });
+
+  it('gives focus back to whatever opened it', async () => {
+    const { rerender } = render(
+      <>
+        <button>the row behind</button>
+        <FilePreviewModal />
+      </>
+    );
+
+    const row = screen.getByRole('button', { name: 'the row behind' });
+    row.focus();
+    expect(document.activeElement).toBe(row);
+
+    preview.value = { ...preview.value, isOpen: true, file, files: [file] };
+    await act(async () => {
+      rerender(
+        <>
+          <button>the row behind</button>
+          <FilePreviewModal />
+        </>
+      );
+    });
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('dialog')));
+
+    preview.value = { ...preview.value, isOpen: false };
+    await act(async () => {
+      rerender(
+        <>
+          <button>the row behind</button>
+          <FilePreviewModal />
+        </>
+      );
+    });
+
+    // Landing on the body would drop a keyboard user at the top of the page.
+    await waitFor(() => expect(document.activeElement).toBe(row));
+  });
+});
+
+describe('the keys it already answered still work', () => {
+  it('closes on Escape', () => {
+    show({ isOpen: true, file, files: [file] });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(preview.value.closePreview).toHaveBeenCalled();
+  });
+
+  it('walks to the next file on ArrowRight', () => {
+    show({ isOpen: true, file, files: [file, second], currentIndex: 0 });
+
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+    expect(preview.value.navigateNext).toHaveBeenCalled();
+  });
+
+  it('walks back on ArrowLeft', () => {
+    show({ isOpen: true, file: second, files: [file, second], currentIndex: 1 });
+
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+
+    expect(preview.value.navigatePrevious).toHaveBeenCalled();
+  });
+
+  it('does not walk past the last file', () => {
+    show({ isOpen: true, file: second, files: [file, second], currentIndex: 1 });
+
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+    expect(preview.value.navigateNext).not.toHaveBeenCalled();
+  });
+
+  it('does not walk before the first file', () => {
+    show({ isOpen: true, file, files: [file, second], currentIndex: 0 });
+
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+
+    expect(preview.value.navigatePrevious).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/file-preview/file-preview-modal.tsx
+++ b/frontend/src/components/file-preview/file-preview-modal.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useScrollLock } from '@/hooks/use-scroll-lock';
 
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useRef } from 'react';
 import { useFilePreview } from '@/context/file-preview-context';
 import { PreviewHeader } from './preview-header';
 import { PreviewContent } from './preview-content';
@@ -16,6 +16,9 @@ export function FilePreviewModal() {
     navigateNext,
     navigatePrevious,
   } = useFilePreview();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
 
   // Keyboard event handler
   const handleKeyDown = useCallback(
@@ -57,6 +60,29 @@ export function FilePreviewModal() {
     };
   }, [isOpen, handleKeyDown]);
 
+  /**
+   * Focus went nowhere when this opened, so a keyboard user was left on the row
+   * behind it, tabbing through a page they could no longer see. Moving focus to
+   * the panel puts them inside the dialog, and putting it back on close returns
+   * them to the file they came from rather than the top of the document.
+   *
+   * Deliberately no focus trap. This one embeds the pdf, monaco and xlsx
+   * viewers, which manage focus themselves, and a trap wrapped around them is
+   * the kind of thing that breaks a viewer in a way nobody notices for months.
+   * The panel is full screen, so there is nothing visible behind it to tab to,
+   * and `aria-modal` tells assistive tech the rest of the page is out of play.
+   */
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    containerRef.current?.focus();
+
+    return () => {
+      previouslyFocused.current?.focus?.();
+    };
+  }, [isOpen]);
+
   // Tied to what actually renders, not just `isOpen`: locking while the modal
   // bails out for a missing file would leave the page frozen behind nothing.
   useScrollLock(isOpen && !!currentFile);
@@ -74,16 +100,24 @@ export function FilePreviewModal() {
       className="fixed inset-0 z-50 flex items-center justify-center"
       style={{ backgroundColor: 'rgba(0, 0, 0, 0.8)' }}
     >
-      {/* Backdrop */}
+      {/* Backdrop. Hidden from assistive tech and left out of the tab order on
+          purpose: it is a click shortcut, and Escape and the header's close
+          button are the keyboard paths to the same thing. */}
       <div
         className="absolute inset-0"
         onClick={closePreview}
         style={{ backgroundColor: 'transparent' }}
+        aria-hidden="true"
       />
 
       {/* Modal Content - Full Screen */}
       <div
-        className="relative w-full h-full flex flex-col"
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Preview of ${currentFile.name}`}
+        tabIndex={-1}
+        className="relative w-full h-full flex flex-col outline-none"
         style={{
           backgroundColor: 'var(--background)',
         }}

--- a/frontend/src/components/file-preview/file-preview-modal.tsx
+++ b/frontend/src/components/file-preview/file-preview-modal.tsx
@@ -71,6 +71,11 @@ export function FilePreviewModal() {
    * the kind of thing that breaks a viewer in a way nobody notices for months.
    * The panel is full screen, so there is nothing visible behind it to tab to,
    * and `aria-modal` tells assistive tech the rest of the page is out of play.
+   *
+   * Keyed on `isOpen` alone, which relies on OPEN_PREVIEW setting the file in
+   * the same dispatch. If those ever split, the panel could mount after this
+   * has run and focus would stay outside. Navigating between files must not
+   * re-run it either, or focus would be yanked back off the header controls.
    */
   useEffect(() => {
     if (!isOpen) return;

--- a/frontend/src/context/auth-context.test.tsx
+++ b/frontend/src/context/auth-context.test.tsx
@@ -75,8 +75,11 @@ function SessionControls() {
   );
 }
 
+/** Mirrors the key AuthProvider persists the session under. */
+const STORAGE_KEY = 's3_user_session';
+
 async function renderProvider() {
-  render(
+  const result = render(
     <AuthProvider>
       <SessionControls />
     </AuthProvider>
@@ -84,7 +87,73 @@ async function renderProvider() {
   // AuthProvider swaps children for a placeholder until its restore pass
   // settles, so wait for the controls to actually exist.
   await waitFor(() => expect(screen.getByText('logout')).toBeDefined());
+  return result;
 }
+
+/**
+ * Logout used to defer its work behind two nested timers that nothing
+ * cancelled. They fired into whatever was left of the tree - harmless in a
+ * browser, where this provider only unmounts with the page, but in tests they
+ * landed after the DOM had gone and threw `window is not defined`, which showed
+ * up as an unhandled error attributed to whichever file was unlucky.
+ *
+ * The session is cleared synchronously now, because `setIsLoading(true)` has
+ * already swapped every child for the placeholder in the same update. Only
+ * lifting that gate is still deferred, and that timer is cancelled on unmount.
+ */
+describe('logout leaves no timer running', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    localStorage.clear();
+  });
+
+  it('clears the session without waiting for a timer', async () => {
+    await renderProvider();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ accessKeyId: 'a' }));
+
+    await act(async () => {
+      screen.getByText('logout').click();
+    });
+
+    // Everything except the gate is done by the time the click returns.
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(pushMock).toHaveBeenCalledWith('/');
+    // Children stay behind the placeholder until the route change commits.
+    expect(screen.queryByText('logout')).toBeNull();
+  });
+
+  it('cancels the pending timer if the provider unmounts first', async () => {
+    const { unmount } = await renderProvider();
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        screen.getByText('logout').click();
+      });
+
+      // Exactly one timer: the gate. It used to be two, nested.
+      expect(vi.getTimerCount()).toBe(1);
+
+      unmount();
+
+      // Left pending, this is the one that fires into a torn down environment.
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('lifts the gate once the wait is over', async () => {
+    await renderProvider();
+
+    await act(async () => {
+      screen.getByText('logout').click();
+    });
+    expect(screen.queryByText('logout')).toBeNull();
+
+    await waitFor(() => expect(screen.getByText('logout')).toBeDefined());
+  });
+});
 
 describe('session changes must not leak the search cache', () => {
   beforeEach(() => {

--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type React from 'react';
-import { createContext, useEffect, useState } from 'react';
+import { createContext, useEffect, useRef, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import {
   BYOS3ApiProvider,
@@ -133,6 +133,16 @@ export const AuthContext = createContext<AuthContextType>({
 
 const STORAGE_KEY = 's3_user_session';
 
+/**
+ * How long logout keeps the loading placeholder up before letting children
+ * render again.
+ *
+ * It exists to give `router.push('/')` time to commit, so the dashboard is not
+ * briefly re-rendered without a session behind it. Matches the 100ms + 50ms the
+ * two nested timers used to add up to.
+ */
+const LOGOUT_GATE_MS = 150;
+
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [apiS3, setApiS3] = useState<BYOS3ApiProvider | null>(null);
   const [uploadManager, setUploadManager] = useState<UploadManager | null>(null);
@@ -146,6 +156,39 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   // Get clearAllData at the top level where hooks are allowed
   const clearAllData = useDriveStore((state) => state.clearAllData);
+
+  /**
+   * The one timer logout still needs, held so it can be cancelled.
+   *
+   * Logout used to defer its work behind two nested uncancelled timers. Nothing
+   * stopped them, so they fired into whatever was left of the tree: harmless in
+   * the browser, where this provider only unmounts with the page, but in tests
+   * they land after the DOM has gone and throw `window is not defined`.
+   */
+  const gateTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (gateTimer.current !== null) clearTimeout(gateTimer.current);
+    };
+  }, []);
+
+  const clearSessionState = () => {
+    setUserCreds(null);
+    setApiS3(null);
+    setUploadManager(null);
+    setSignedUrlUploadManager(null);
+  };
+
+  /** Lets children render again once the route change has had time to commit. */
+  const releaseLoadingGate = () => {
+    if (gateTimer.current !== null) clearTimeout(gateTimer.current);
+
+    gateTimer.current = setTimeout(() => {
+      gateTimer.current = null;
+      setIsLoading(false);
+    }, LOGOUT_GATE_MS);
+  };
 
   // Restore session from localStorage on app load
   useEffect(() => {
@@ -254,24 +297,17 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       // Navigate away from authenticated routes first
       router.push('/');
 
-      // Use setTimeout to allow navigation and component unmounting to complete
-      setTimeout(() => {
-        setUserCreds(null);
-        setApiS3(null);
-        setUploadManager(null);
-        setSignedUrlUploadManager(null);
-        setTimeout(() => setIsLoading(false), 50);
-      }, 100);
+      // Cleared straight away rather than behind a timer. `setIsLoading(true)`
+      // above lands in this same update, so the placeholder has already taken
+      // the place of every child and there is nobody left to read a half
+      // cleared session. Only lifting the gate has to wait.
+      clearSessionState();
+      releaseLoadingGate();
     } catch (error) {
       console.error('Error clearing session:', error);
-      setTimeout(() => {
-        setUserCreds(null);
-        setApiS3(null);
-        setUploadManager(null);
-        setSignedUrlUploadManager(null);
-        setIsLoading(false);
-        clearAllData();
-      }, 50);
+      clearSessionState();
+      clearAllData();
+      releaseLoadingGate();
     }
   };
 

--- a/frontend/src/features/dashboard/components/dialogs/multi-share-dialog.tsx
+++ b/frontend/src/features/dashboard/components/dialogs/multi-share-dialog.tsx
@@ -1,11 +1,16 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { X, Share, Clock, Copy, Check, ExternalLink, AlertCircle } from 'lucide-react';
 import type { FileItem } from '../../types/file';
 import { useSettings } from '@/features/settings/hooks/use-settings';
 import { getDurationInSeconds, formatDurationLabel } from '@/features/settings/constants';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
 
 interface MultiShareDialogProps {
   isOpen: boolean;
@@ -40,6 +45,11 @@ export const MultiShareDialog: React.FC<MultiShareDialogProps> = ({
     if (isOpen && files.length > 0) {
       handleGenerateLinks();
     }
+    // handleGenerateLinks is left out on purpose. It is rebuilt every render and
+    // closes over a `generateShareLinks` prop that is not memoised, so listing
+    // it would re-run this on every render - a fresh round of signed URLs each
+    // time. Opening, or a different set of files, is the intended trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, files]);
 
   const handleGenerateLinks = async () => {
@@ -102,29 +112,21 @@ export const MultiShareDialog: React.FC<MultiShareDialogProps> = ({
     onClose();
   };
 
-  if (!isOpen) return null;
-
   const successCount = shareResults.filter((result) => result.url && !result.error).length;
   const errorCount = shareResults.filter((result) => result.error).length;
 
   // Get current duration label using the formatter
   const currentDurationLabel = formatDurationLabel(settings.general.bulkShareDuration);
 
-  const dialogContent = (
-    <div
-      className="fixed inset-0 z-[60] flex items-center justify-center"
-      style={{ isolation: 'isolate' }}
-    >
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 backdrop-blur-sm"
-        style={{ backgroundColor: 'rgba(0, 0, 0, 0.3)' }}
-        onClick={handleClose}
-      />
-
-      {/* Dialog */}
-      <div
-        className="relative rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[85vh] flex flex-col overflow-hidden"
+  return (
+    // Radix brings the focus trap, focus restore, Escape and the dialog role
+    // this had none of. Keeps its own z-index so it still sits above whatever
+    // opened it.
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="z-[60] bg-black/30 backdrop-blur-sm"
+        className="z-[60] max-w-2xl w-full gap-0 max-h-[85vh] flex flex-col overflow-hidden rounded-lg p-0 shadow-xl"
         style={{
           backgroundColor: 'var(--card)',
           border: '1px solid var(--border)',
@@ -138,14 +140,18 @@ export const MultiShareDialog: React.FC<MultiShareDialogProps> = ({
           <div className="flex items-center gap-3">
             <Share className="h-5 w-5" style={{ color: 'var(--primary)' }} />
             <div>
-              <h2 className="text-lg font-semibold" style={{ color: 'var(--foreground)' }}>
+              <DialogTitle className="text-lg font-semibold" style={{ color: 'var(--foreground)' }}>
                 Share {files.length} {files.length === 1 ? 'file' : 'files'}
-              </h2>
-              {shareResults.length > 0 && (
-                <p className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
+              </DialogTitle>
+              {shareResults.length > 0 ? (
+                <DialogDescription className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
                   {successCount} successful
                   {errorCount > 0 && `, ${errorCount} failed`}
-                </p>
+                </DialogDescription>
+              ) : (
+                <DialogDescription className="sr-only">
+                  Create share links for the selected files.
+                </DialogDescription>
               )}
             </div>
           </div>
@@ -315,9 +321,7 @@ export const MultiShareDialog: React.FC<MultiShareDialogProps> = ({
             </div>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
-
-  return typeof window !== 'undefined' ? createPortal(dialogContent, document.body) : null;
 };

--- a/frontend/src/features/dashboard/components/ui/details/mobile-details-dialog.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/details/mobile-details-dialog.test.tsx
@@ -1,15 +1,18 @@
 /**
- * The details sheet locks page scroll only when it is actually on screen.
+ * The details sheet only exists when it has something to show.
  *
- * It renders null unless it has both an open flag and an item, but it used to
- * lock scroll on the flag alone. The details context exposes a `toggle()` that
- * flips the flag without setting an item, so that combination is reachable and
- * leaves the page frozen with nothing rendered to explain it - the same class
- * of failure the shared scroll lock exists to prevent.
+ * It renders nothing without an item, but the details context exposes a
+ * `toggle()` that flips the open flag without setting one, so "open with no
+ * item" is reachable. It used to lock page scroll in that state, freezing the
+ * page with nothing on screen to explain it.
+ *
+ * Scroll locking is Radix's job now rather than the shared hook's, so these
+ * assert on what the user can reach: whether a dialog exists, whether the page
+ * behind it is still reachable, and where focus ends up.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
 import { MobileDetailsDialog } from './mobile-details-dialog';
 import { getScrollLockHolders } from '@/hooks/use-scroll-lock';
 
@@ -29,43 +32,67 @@ const file = { Key: 'reports/q3.pdf', name: 'q3.pdf', id: 'reports/q3.pdf' };
 
 function show(state: { isOpen: boolean; selectedItem: unknown }) {
   details.value = { ...details.value, ...state };
-  return render(<MobileDetailsDialog />);
+  return render(
+    <>
+      <button>behind the dialog</button>
+      <MobileDetailsDialog />
+    </>
+  );
 }
 
 afterEach(() => {
   cleanup();
+  // Nothing here should ever be left holding the shared lock.
   expect(getScrollLockHolders()).toBe(0);
   expect(document.body.style.overflow).toBe('');
 });
 
-describe('scroll locking follows what is rendered', () => {
-  it('locks when open with an item', () => {
+describe('when it should be on screen', () => {
+  it('renders a dialog for the selected item', async () => {
     show({ isOpen: true, selectedItem: file });
 
-    expect(document.body.style.overflow).toBe('hidden');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeNull());
+    expect(screen.getByRole('dialog', { name: 'q3.pdf' })).toBeTruthy();
   });
 
-  it('does not lock when open with no item', () => {
-    const { container } = show({ isOpen: true, selectedItem: null });
+  it('hides the page behind it from assistive tech', async () => {
+    show({ isOpen: true, selectedItem: file });
 
-    // Nothing is rendered, so nothing should be holding the page still.
-    expect(container.innerHTML).toBe('');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeNull());
+    // Tab used to walk straight out into the page behind the backdrop.
+    expect(screen.queryByRole('button', { name: 'behind the dialog' })).toBeNull();
+  });
+
+  it('closes on Escape', async () => {
+    show({ isOpen: true, selectedItem: file });
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeNull());
+
+    await act(async () => {
+      fireEvent.keyDown(document.body, { key: 'Escape' });
+    });
+
+    expect(details.value.close).toHaveBeenCalled();
+  });
+});
+
+describe('when it has nothing to show', () => {
+  it('renders nothing when open with no item', () => {
+    show({ isOpen: true, selectedItem: null });
+
+    // The reachable state behind the old freeze: flag on, nothing selected.
+    expect(screen.queryByRole('dialog')).toBeNull();
     expect(document.body.style.overflow).toBe('');
-    expect(getScrollLockHolders()).toBe(0);
   });
 
-  it('does not lock when closed', () => {
+  it('leaves the page behind reachable when it has no item', () => {
+    show({ isOpen: true, selectedItem: null });
+
+    expect(screen.queryByRole('button', { name: 'behind the dialog' })).not.toBeNull();
+  });
+
+  it('renders nothing when closed', () => {
     show({ isOpen: false, selectedItem: file });
 
-    expect(document.body.style.overflow).toBe('');
-  });
-
-  it('releases the lock when it unmounts', () => {
-    const { unmount } = show({ isOpen: true, selectedItem: file });
-    expect(document.body.style.overflow).toBe('hidden');
-
-    unmount();
-
-    expect(document.body.style.overflow).toBe('');
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/frontend/src/features/dashboard/components/ui/details/mobile-details-dialog.tsx
+++ b/frontend/src/features/dashboard/components/ui/details/mobile-details-dialog.tsx
@@ -1,13 +1,12 @@
 'use client';
-import { useScrollLock } from '@/hooks/use-scroll-lock';
 
 import { X } from 'lucide-react';
 import { useDetails } from '@/context/details-context';
 import { useFileMetadata } from '@/features/dashboard/hooks/use-file-metadata';
 import { FileItem } from '@/features/dashboard/types/file';
 import { FaFolder } from 'react-icons/fa';
-import { createPortal } from 'react-dom';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
+import { Dialog, DialogClose, DialogContent, DialogTitle } from '@/shared/components/ui/dialog';
 
 const isFileItem = (item: FileItem | null): item is FileItem => {
   if (!item) return false;
@@ -18,13 +17,7 @@ export const MobileDetailsDialog = () => {
   const { isOpen, selectedItem, close } = useDetails();
   const { metadata, isLoading } = useFileMetadata(isFileItem(selectedItem) ? selectedItem : null);
 
-  // Matches the render condition below rather than just `isOpen`. The context
-  // exposes a toggle() that flips isOpen without setting an item, so locking on
-  // isOpen alone can stop the page scrolling with no dialog on screen to
-  // explain why.
-  useScrollLock(isOpen && !!selectedItem);
-
-  if (!isOpen || !selectedItem) return null;
+  if (!selectedItem) return null;
 
   const isFile = isFileItem(selectedItem);
   const file = isFile ? (selectedItem as FileItem) : null;
@@ -85,31 +78,24 @@ export const MobileDetailsDialog = () => {
     return 'File';
   };
 
-  const dialogContent = (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="details-title"
-    >
-      <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={close}
-        aria-hidden="true"
-      />
-
-      <div className="relative w-full max-w-md bg-background border border-border rounded-2xl shadow-xl max-h-[90vh] overflow-hidden">
+  return (
+    // Had the dialog role and aria-modal already, but nothing trapped focus or
+    // gave it back on close. Radix supplies both, plus Escape and the scroll
+    // lock, so the hand-rolled backdrop and portal go with it.
+    <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="bg-black/50 backdrop-blur-sm"
+        className="w-full max-w-md gap-0 rounded-2xl border border-border bg-background p-0 shadow-xl max-h-[90vh] overflow-hidden"
+      >
         <div className="flex items-center justify-between p-6 border-b border-border">
-          <h2 id="details-title" className="text-lg font-semibold text-foreground">
+          <DialogTitle className="text-lg font-semibold text-foreground">
             {isFile ? file?.name : 'Unknown'}
-          </h2>
+          </DialogTitle>
           <AriaLabel label="Close details panel" position="top">
-            <button
-              onClick={close}
-              className="p-2 rounded-full cursor-pointer hover:bg-muted transition-colors"
-            >
+            <DialogClose className="p-2 rounded-full cursor-pointer hover:bg-muted transition-colors">
               <X className="h-5 w-5 text-foreground" />
-            </button>
+            </DialogClose>
           </AriaLabel>
         </div>
 
@@ -192,9 +178,7 @@ export const MobileDetailsDialog = () => {
             )}
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
-
-  return typeof window !== 'undefined' ? createPortal(dialogContent, document.body) : null;
 };

--- a/frontend/src/features/dashboard/components/ui/details/mobile-details-dialog.tsx
+++ b/frontend/src/features/dashboard/components/ui/details/mobile-details-dialog.tsx
@@ -6,7 +6,13 @@ import { useFileMetadata } from '@/features/dashboard/hooks/use-file-metadata';
 import { FileItem } from '@/features/dashboard/types/file';
 import { FaFolder } from 'react-icons/fa';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
-import { Dialog, DialogClose, DialogContent, DialogTitle } from '@/shared/components/ui/dialog';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
 
 const isFileItem = (item: FileItem | null): item is FileItem => {
   if (!item) return false;
@@ -98,6 +104,12 @@ export const MobileDetailsDialog = () => {
             </DialogClose>
           </AriaLabel>
         </div>
+
+        {/* Radix warns without one, and a screen reader otherwise gets the
+            file name and then an unannounced wall of properties. */}
+        <DialogDescription className="sr-only">
+          Details for {isFile ? file?.name : 'this item'}.
+        </DialogDescription>
 
         <div className="p-6 overflow-y-auto max-h-[calc(90vh-120px)] custom-scrollbar">
           <div className="space-y-6">

--- a/frontend/src/features/dashboard/components/ui/dialogs/create-folder-dialog.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/dialogs/create-folder-dialog.test.tsx
@@ -152,6 +152,21 @@ describe('dismissing', () => {
   });
 });
 
+describe('panel width', () => {
+  it('is not widened by a leftover responsive default', async () => {
+    await open();
+
+    // Asserting on classes because this failure is invisible any other way in
+    // jsdom, and it is exactly how it got missed: the shared content styling
+    // used to carry `sm:max-w-lg`, which survives a plain `max-w-md` because
+    // tailwind-merge treats another breakpoint as a different property. The
+    // class list looked right while every dialog grew to 32rem above 640px.
+    const panel = screen.getByRole('dialog');
+    expect(panel.className).toContain('max-w-md');
+    expect(panel.className).not.toContain('sm:max-w-lg');
+  });
+});
+
 describe('it still does its job', () => {
   it('creates a folder with the typed name', async () => {
     await open();

--- a/frontend/src/shared/components/ui/dialog.tsx
+++ b/frontend/src/shared/components/ui/dialog.tsx
@@ -101,8 +101,13 @@ function DialogContent({
         // the more reliable of the two techniques, and does not set this. Set
         // it as well so assistive tech that looks for the flag also gets it.
         aria-modal="true"
+        // No responsive width default here on purpose. It used to carry
+        // `sm:max-w-lg`, which survives a caller's plain `max-w-md` because
+        // tailwind-merge treats a different breakpoint as a different property.
+        // Every dialog then quietly widened to 32rem above 640px while looking
+        // correct in the class list. Each dialog sets its own width instead.
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200',
           className
         )}
         {...props}


### PR DESCRIPTION
Part of #96, following #165. Does not close it: `share-dialog.tsx` is left, and the reason is below.

**multi-share-dialog** and **mobile-details-dialog** move onto the Radix primitive, so both get a focus trap, focus restored on close, Escape, and the page behind hidden from assistive tech.

**file-preview-modal** keeps its own markup, as agreed. It embeds the pdf, monaco and xlsx viewers, which manage focus themselves, and a trap wrapped around them is a good way to break a viewer quietly. It now has `role="dialog"`, `aria-modal`, a name from the file, focus moved into the panel on open and returned to the row on close. The backdrop is a bare clickable div with no keyboard path, so it is marked `aria-hidden` rather than announced; Escape and the header's close button are the real ways out. There is deliberately no focus trap here, and the panel is full screen so there is nothing visible behind it to tab to.

**Fixes a width regression that #165 introduced and I missed.** The shared dialog styling carried `sm:max-w-lg`. tailwind-merge treats a different breakpoint as a different property, so a caller's plain `max-w-md` did not override it and every dialog silently grew to 32rem above 640px while the class list looked correct. multi-share went the other way and shrank from 42rem to 32rem. The responsive default is gone; all seven dialogs set their own width, so nothing relied on it. There is a test on the rendered class list, since this failure is invisible any other way in jsdom.

**Fixes the logout timers.** `clearSession` deferred its whole body behind two nested timers that nothing cancelled, plus a third in the catch. They fired into whatever was left of the tree: harmless in a browser, where this provider only unmounts with the page, but in tests they landed after the DOM had gone and threw `window is not defined`, surfacing as an unhandled error attributed to whichever file was unlucky.

The deferral turned out to be guarding against something that cannot happen. `setIsLoading(true)` swaps every child for the placeholder in the same update, so by the time the old timer ran there was nobody left to read a half-cleared session - the render gate predates those timers by several commits. The session is cleared synchronously now. Only lifting the gate is still deferred, so `router.push('/')` has time to commit before children render again, and that single timer is held in a ref and cleared on unmount. Same 150ms as the two nested ones added up to, so nothing changes for a user.

Three tests cover it, including one asserting no timer is left pending after unmount, which fails against the old code. Two full-suite runs are now clean, where before the error appeared intermittently under load.

**share-dialog is not in this PR.** It portals two hand-rolled dropdowns to `document.body`, outside the dialog. A Radix modal makes outside content non-interactive and treats clicks there as an outside dismiss, so porting it as-is would leave both dropdowns dead and clicking one would close the dialog. Doing it properly means converting those dropdowns first, and there is no select wrapper in the repo yet. That is a different piece of work in a 636 line file that mints signed URLs, so it wants its own PR.

Note for #160: that branch adds a `settleLogout` helper to `auth-context.test.tsx` to work around this exact flake. It is unnecessary once this lands and should be dropped on rebase.

One correction to an earlier note: mobile-details-dialog is a centred dialog, not a bottom sheet, so the Radix port keeps its appearance exactly. Its test was also rewritten - it asserted on `document.body.style.overflow`, which was the shared hook's business, and Radix owns scroll locking now.
