### PR TITLE
fix: overflow menu placement, and select the row when its menu opens

### DIFF
--- a/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
@@ -39,9 +39,22 @@ export function FileItemGrid({
   const [isLongPress, setIsLongPress] = useState(false);
 
   const handleMenuClick = (event: React.MouseEvent) => {
-    // The menu opens itself now. This only keeps the row underneath
-    // from reading the same click as opening the item.
+    // The menu opens itself. This only keeps the row underneath from
+    // reading the same click as opening the item.
     event.stopPropagation();
+
+    // Opening the menu selects the item, the same way a plain click on the
+    // row does: no ctrl or shift, so it replaces whatever was selected
+    // before. Multi-select stays a keyboard gesture.
+    //
+    // Not on touch. There a tap opens an item and selection sits behind a
+    // long press, and once anything is selected a tap selects instead of
+    // opening - so selecting here would quietly change what every later
+    // tap does.
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    if (!isTouchDevice) {
+      selectItem(file, 'file', index, false, false, allFiles);
+    }
   };
 
   const handleTouchStart = () => {

--- a/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
@@ -38,9 +38,22 @@ export function FileItemList({
   const [isLongPress, setIsLongPress] = useState(false);
 
   const handleMenuClick = (event: React.MouseEvent) => {
-    // The menu opens itself now. This only keeps the row underneath
-    // from reading the same click as opening the item.
+    // The menu opens itself. This only keeps the row underneath from
+    // reading the same click as opening the item.
     event.stopPropagation();
+
+    // Opening the menu selects the item, the same way a plain click on the
+    // row does: no ctrl or shift, so it replaces whatever was selected
+    // before. Multi-select stays a keyboard gesture.
+    //
+    // Not on touch. There a tap opens an item and selection sits behind a
+    // long press, and once anything is selected a tap selects instead of
+    // opening - so selecting here would quietly change what every later
+    // tap does.
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    if (!isTouchDevice) {
+      selectItem(file, 'file', index, false, false, allFiles);
+    }
   };
 
   const handleTouchStart = () => {

--- a/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
@@ -41,9 +41,22 @@ export function FileItemMobile({
   const [touchStartPos, setTouchStartPos] = useState<{ x: number; y: number } | null>(null);
 
   const handleMenuClick = (event: React.MouseEvent) => {
-    // The menu opens itself now. This only keeps the row underneath
-    // from reading the same click as opening the item.
+    // The menu opens itself. This only keeps the row underneath from
+    // reading the same click as opening the item.
     event.stopPropagation();
+
+    // Opening the menu selects the item, the same way a plain click on the
+    // row does: no ctrl or shift, so it replaces whatever was selected
+    // before. Multi-select stays a keyboard gesture.
+    //
+    // Not on touch. There a tap opens an item and selection sits behind a
+    // long press, and once anything is selected a tap selects instead of
+    // opening - so selecting here would quietly change what every later
+    // tap does.
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    if (!isTouchDevice) {
+      selectItem(file, 'file', index, false, false, allFiles);
+    }
   };
 
   const handleTouchStart = (e: React.TouchEvent) => {

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
@@ -34,9 +34,22 @@ export function FolderItemMobile({
   const [touchStartPos, setTouchStartPos] = useState<{ x: number; y: number } | null>(null);
 
   const handleMenuClick = (event: React.MouseEvent) => {
-    // The menu opens itself now. This only keeps the row underneath
-    // from reading the same click as opening the item.
+    // The menu opens itself. This only keeps the row underneath from
+    // reading the same click as opening the item.
     event.stopPropagation();
+
+    // Opening the menu selects the item, the same way a plain click on the
+    // row does: no ctrl or shift, so it replaces whatever was selected
+    // before. Multi-select stays a keyboard gesture.
+    //
+    // Not on touch. There a tap opens an item and selection sits behind a
+    // long press, and once anything is selected a tap selects instead of
+    // opening - so selecting here would quietly change what every later
+    // tap does.
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    if (!isTouchDevice) {
+      selectItem(folder, 'folder', index, false, false, allFolders);
+    }
   };
 
   const handleTouchStart = (e: React.TouchEvent) => {

--- a/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
@@ -143,9 +143,23 @@ export const FolderItem: React.FC<FolderItemProps> = ({
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
-    // The menu opens itself now. This only keeps the row underneath from
-    // reading the same click as "open the folder".
+    // The menu opens itself. This only keeps the row underneath from
+    // reading the same click as opening the item.
     event.stopPropagation();
+
+    // Opening the menu selects the item, the same way a plain click on the
+    // row does: no ctrl or shift, so it replaces whatever was selected
+    // before. Multi-select stays a keyboard gesture.
+    //
+    // Not on touch. There a tap opens an item and selection sits behind a
+    // long press, and once anything is selected a tap selects instead of
+    // opening - so selecting here would quietly change what every later
+    // tap does.
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    if (!isTouchDevice) {
+      selectItem(folder, 'folder', index, false, false, allFolders);
+    }
+
     onMenuClick?.(folder, event);
   };
 

--- a/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Opening a row's overflow menu selects that row.
+ *
+ * It behaves like a plain click on the row: no ctrl or shift, so it replaces
+ * whatever was selected before rather than adding to it. Multi-select stays a
+ * keyboard gesture, so clicking the menu on a third folder while two are
+ * selected leaves just the third one selected.
+ *
+ * Deliberately not on touch. There a tap opens an item and selection sits
+ * behind a long press, and once anything is selected a tap selects instead of
+ * opening - so selecting from the menu button would quietly change what every
+ * later tap does.
+ *
+ * All five row components carry their own copy of the handler, so all five are
+ * covered. They started as copies of each other and drift is how this regresses.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FolderItem } from './folder-item';
+import { FolderItemMobile } from './folder-item-mobile';
+import { FileItemList } from './file-item-list';
+import { FileItemGrid } from './file-item-grid';
+import { FileItemMobile } from './file-item-mobile';
+import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
+import type { Folder } from '@/features/dashboard/types/folder';
+import type { FileItem } from '@/features/dashboard/types/file';
+
+// The menus own their trigger button, so these render it rather than nothing.
+vi.mock('../menus/folder-overflow-menu', () => ({
+  FolderOverflowMenu: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
+vi.mock('../menus/file-overflow-menu', () => ({
+  FileOverflowMenu: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
+vi.mock('./file-thumbnail-with-image', () => ({ FileThumbnailWithImage: () => null }));
+vi.mock('@/hooks/use-file-preview-actions', () => ({
+  useFilePreviewActions: () => ({ openFilePreview: vi.fn() }),
+}));
+vi.mock('@/context/file-preview-context', () => ({
+  useFilePreview: () => ({ openPreview: vi.fn() }),
+}));
+
+function folder(overrides: Partial<Folder> = {}): Folder {
+  return {
+    id: 'reports',
+    name: 'Reports',
+    Prefix: 'reports/',
+    location: { type: 'my-drive', label: 'My Drive' },
+    ...overrides,
+  };
+}
+
+function file(overrides: Partial<FileItem> = {}): FileItem {
+  return {
+    id: 'budget',
+    name: 'budget.xlsx',
+    Key: 'reports/budget.xlsx',
+    extension: 'xlsx',
+    size: { value: 12, unit: 'KB' },
+    ...overrides,
+  };
+}
+
+const selection = () => useMultiSelectStore.getState().selectedItems;
+const menuButton = (name: string) =>
+  screen.getByRole('button', { name: `More actions for ${name}` });
+
+/** Makes the environment look like a mouse-driven one, or a touchscreen. */
+function setPointer({ touch }: { touch: boolean }) {
+  Object.defineProperty(navigator, 'maxTouchPoints', { value: touch ? 5 : 0, configurable: true });
+  if (touch) {
+    (window as unknown as Record<string, unknown>).ontouchstart = null;
+  } else {
+    delete (window as unknown as Record<string, unknown>).ontouchstart;
+  }
+}
+
+beforeEach(() => {
+  useMultiSelectStore.getState().clearSelection();
+  setPointer({ touch: false });
+});
+
+afterEach(() => {
+  setPointer({ touch: false });
+});
+
+describe('a mouse click on the menu button selects the row', () => {
+  it('selects a folder row', () => {
+    render(<FolderItem folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.click(menuButton('Reports'));
+
+    expect(selection()).toHaveLength(1);
+    expect(useMultiSelectStore.getState().selectedType).toBe('folder');
+  });
+
+  it('selects a folder row on mobile layout', () => {
+    render(<FolderItemMobile folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.click(menuButton('Reports'));
+
+    expect(selection()).toHaveLength(1);
+  });
+
+  it.each([
+    ['list', FileItemList],
+    ['grid', FileItemGrid],
+    ['mobile', FileItemMobile],
+  ])('selects a file row in the %s layout', (_label, Component) => {
+    render(<Component file={file()} allFiles={[file()]} />);
+
+    fireEvent.click(menuButton('budget.xlsx'));
+
+    expect(selection()).toHaveLength(1);
+    expect(useMultiSelectStore.getState().selectedType).toBe('file');
+  });
+
+  it('does not open the item as well', () => {
+    const onClick = vi.fn();
+    render(<FolderItem folder={folder()} onClick={onClick} allFolders={[folder()]} />);
+
+    fireEvent.click(menuButton('Reports'));
+
+    // The click must not reach the row underneath, or opening a menu would
+    // navigate into the folder behind it.
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+describe('it replaces the selection rather than extending it', () => {
+  it('drops an existing selection when a different row is used', () => {
+    const folders = [
+      folder(),
+      folder({ id: 'taxes', name: 'Taxes', Prefix: 'taxes/' }),
+      folder({ id: 'photos', name: 'Photos', Prefix: 'photos/' }),
+    ];
+    render(
+      <>
+        <FolderItem folder={folders[0]} index={0} allFolders={folders} />
+        <FolderItem folder={folders[1]} index={1} allFolders={folders} />
+        <FolderItem folder={folders[2]} index={2} allFolders={folders} />
+      </>
+    );
+
+    // Two selected by keyboard, the way multi-select is meant to be built.
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Reports, folder' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Taxes, folder' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+    expect(selection()).toHaveLength(2);
+
+    fireEvent.click(menuButton('Photos'));
+
+    // Plain click semantics: the third replaces the other two.
+    expect(selection()).toHaveLength(1);
+    expect(selection()[0]).toMatchObject({ name: 'Photos' });
+  });
+});
+
+describe('touch is left alone', () => {
+  it('does not select on a touchscreen', () => {
+    setPointer({ touch: true });
+    render(<FolderItem folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.click(menuButton('Reports'));
+
+    // Selecting here would put the list into selection mode, where the next
+    // tap on any row selects instead of opening it.
+    expect(selection()).toHaveLength(0);
+  });
+
+  it('does not select on a touchscreen for files either', () => {
+    setPointer({ touch: true });
+    render(<FileItemMobile file={file()} allFiles={[file()]} />);
+
+    fireEvent.click(menuButton('budget.xlsx'));
+
+    expect(selection()).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.test.tsx
@@ -147,6 +147,19 @@ describe('reaching the submenu with a keyboard', () => {
   });
 });
 
+describe('where it opens', () => {
+  it('opens beside the button rather than over the rows below', async () => {
+    show();
+    trigger().focus();
+    fireEvent.keyDown(trigger(), { key: 'ArrowDown' });
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeNull());
+
+    const menu = screen.getByRole('menu');
+    expect(menu.getAttribute('data-side')).toBe('left');
+    expect(menu.getAttribute('data-align')).toBe('start');
+  });
+});
+
 describe('the page underneath', () => {
   it('does not freeze page scrolling while open', async () => {
     show();

--- a/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.test.tsx
@@ -155,8 +155,19 @@ describe('where it opens', () => {
     await waitFor(() => expect(screen.queryByRole('menu')).not.toBeNull());
 
     const menu = screen.getByRole('menu');
-    expect(menu.getAttribute('data-side')).toBe('left');
+    // The side follows the space available; what must not happen is above or
+    // below, which covers the rows underneath and their own menu buttons.
+    expect(['left', 'right']).toContain(menu.getAttribute('data-side'));
     expect(menu.getAttribute('data-align')).toBe('start');
+  });
+
+  it('prefers the right and lets Radix flip it when there is no room', async () => {
+    show();
+    trigger().focus();
+    fireEvent.keyDown(trigger(), { key: 'ArrowDown' });
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeNull());
+
+    expect(screen.getByRole('menu').getAttribute('data-side')).toBe('right');
   });
 });
 

--- a/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.tsx
@@ -203,8 +203,17 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
         triggerNode
       )}
 
+      {/* Beside the button, not under it. Dropping below covers the rows
+          underneath, including their own menu buttons. The hand-rolled version
+          placed this alongside the trigger and only ever fell back to the other
+          side when it ran out of room, which is the behaviour restored here:
+          `align="start"` lines the top up with the button, and Radix shifts it
+          up or down to stay on screen. */}
       <DropdownMenuContent
+        side="left"
         align="start"
+        sideOffset={8}
+        collisionPadding={8}
         className={`${menuContentClass} ${className}`}
         aria-label={`Actions for ${file.name}`}
       >

--- a/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/file-overflow-menu.tsx
@@ -203,14 +203,17 @@ export const FileOverflowMenu: React.FC<FileOverflowMenuProps> = ({
         triggerNode
       )}
 
-      {/* Beside the button, not under it. Dropping below covers the rows
-          underneath, including their own menu buttons. The hand-rolled version
-          placed this alongside the trigger and only ever fell back to the other
-          side when it ran out of room, which is the behaviour restored here:
-          `align="start"` lines the top up with the button, and Radix shifts it
-          up or down to stay on screen. */}
+      {/* Beside the button rather than under it, since dropping below covers
+          the rows underneath along with their own menu buttons.
+
+          Asks for the right and lets Radix flip it to the left when there is no
+          room, which is what the hand-rolled version worked out by hand: it
+          tried `rect.right + padding` first and only used
+          `rect.left - menuWidth - padding` when that ran off screen.
+          `align="start"` lines the top up with the button, and Radix nudges it
+          up or down to keep it in view. */}
       <DropdownMenuContent
-        side="left"
+        side="right"
         align="start"
         sideOffset={8}
         collisionPadding={8}

--- a/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.test.tsx
@@ -161,6 +161,28 @@ describe('choosing and dismissing', () => {
   });
 });
 
+describe('where it opens', () => {
+  it('opens beside the button, not under it', async () => {
+    show();
+
+    await openWithKeyboard('ArrowDown');
+
+    // Dropping below covers the rows underneath, including their own menu
+    // buttons, which is what the move to Radix accidentally changed. The
+    // hand-rolled version always placed this alongside the trigger.
+    const menu = screen.getByRole('menu');
+    expect(menu.getAttribute('data-side')).toBe('left');
+  });
+
+  it('lines its top up with the button', async () => {
+    show();
+
+    await openWithKeyboard('ArrowDown');
+
+    expect(screen.getByRole('menu').getAttribute('data-align')).toBe('start');
+  });
+});
+
 describe('the page underneath', () => {
   it('does not freeze page scrolling while open', async () => {
     show();

--- a/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.test.tsx
@@ -162,16 +162,26 @@ describe('choosing and dismissing', () => {
 });
 
 describe('where it opens', () => {
-  it('opens beside the button, not under it', async () => {
+  it('opens beside the button, never above or below it', async () => {
     show();
 
     await openWithKeyboard('ArrowDown');
 
-    // Dropping below covers the rows underneath, including their own menu
-    // buttons, which is what the move to Radix accidentally changed. The
-    // hand-rolled version always placed this alongside the trigger.
-    const menu = screen.getByRole('menu');
-    expect(menu.getAttribute('data-side')).toBe('left');
+    // Which side it lands on is up to the space available, so this pins the
+    // part that matters: not above or below, because that covers the rows
+    // underneath along with their own menu buttons.
+    const side = screen.getByRole('menu').getAttribute('data-side');
+    expect(['left', 'right']).toContain(side);
+  });
+
+  it('prefers the right, so a menu with room does not jump left', async () => {
+    show();
+
+    await openWithKeyboard('ArrowDown');
+
+    // Radix flips this to the left on its own when the right will not fit.
+    // Asking for the left outright meant it opened there even with space.
+    expect(screen.getByRole('menu').getAttribute('data-side')).toBe('right');
   });
 
   it('lines its top up with the button', async () => {

--- a/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.tsx
@@ -169,14 +169,17 @@ export const FolderOverflowMenu: React.FC<OverflowMenuProps> = ({
           triggerNode
         )}
 
-        {/* Beside the button, not under it. Dropping below covers the rows
-            underneath, including their own menu buttons. The hand-rolled
-            version placed this alongside the trigger and only fell back to the
-            other side when it ran out of room, which is what is restored here:
-            `align="start"` lines the top up with the button, and Radix shifts
-            it up or down to stay on screen. */}
+        {/* Beside the button rather than under it, since dropping below covers
+            the rows underneath along with their own menu buttons.
+
+            Asks for the right and lets Radix flip it to the left when there is
+            no room, which is what the hand-rolled version worked out by hand:
+            it tried `rect.right + padding` first and only used
+            `rect.left - menuWidth - padding` when that ran off screen.
+            `align="start"` lines the top up with the button, and Radix nudges
+            it up or down to keep it in view. */}
         <DropdownMenuContent
-          side="left"
+          side="right"
           align="start"
           sideOffset={8}
           collisionPadding={8}

--- a/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.tsx
+++ b/frontend/src/features/dashboard/components/ui/menus/folder-overflow-menu.tsx
@@ -169,8 +169,17 @@ export const FolderOverflowMenu: React.FC<OverflowMenuProps> = ({
           triggerNode
         )}
 
+        {/* Beside the button, not under it. Dropping below covers the rows
+            underneath, including their own menu buttons. The hand-rolled
+            version placed this alongside the trigger and only fell back to the
+            other side when it ran out of room, which is what is restored here:
+            `align="start"` lines the top up with the button, and Radix shifts
+            it up or down to stay on screen. */}
         <DropdownMenuContent
+          side="left"
           align="start"
+          sideOffset={8}
+          collisionPadding={8}
           className={`${menuContentClass} ${className}`}
           aria-label={`Actions for ${folder.name}`}
         >


### PR DESCRIPTION
Two things, both on the row overflow menus.

**Placement, fixing a regression I introduced in #164.** The menus dropped below the three dot button, covering the rows underneath along with their own menu buttons. Moving them to Radix took the default placement, which is below the trigger.

The hand-rolled version placed them alongside: it tried `rect.right + padding` first and only fell back to `rect.left - menuWidth - padding` when that ran off screen. Both menus now pass `side="right" align="start"`, the same rule expressed as a preference. Radix flips to the left on its own when the right will not fit, so a menu with room beside it no longer jumps to the far side, and the top still lines up with the button.

The create menu in the sidebar is untouched, since that one really was below its button before. The `Open with` submenu is untouched too: Radix opens a submenu to the right and flips when it does not fit, which matches what the old code did.

**Opening a menu now selects its row.** It behaves like a plain click on the row: no ctrl or shift, so it replaces whatever was selected rather than adding to it. Open the menu on a third folder while two are selected and you are left with just the third, with the multi-select toolbar showing as usual. Ctrl and shift remain the way to build a multi-selection.

Not applied on touch. There a tap opens an item and selection sits behind a long press, and once anything is selected a tap selects instead of opening - so selecting from the menu button would quietly change what every later tap does. The check uses the same `ontouchstart`/`maxTouchPoints` test the row click handlers already use, since the mobile and desktop row variants are both in the DOM and only swapped by CSS.

All five row components carry their own copy of the handler, so all five are covered, with tests for each.

The placement tests assert the menu opens to a horizontal side rather than above or below, since that is the part that broke, and that it asks for the right. The flip itself is Radix's collision handling and needs a real viewport, so it is worth a quick look by hand at a row near the right edge of a narrow window.
