### PR TITLE
feat: one drive table, sortable by name

### DIFF
--- a/.changeset/sort-by-name.md
+++ b/.changeset/sort-by-name.md
@@ -7,3 +7,7 @@ both sort case-insensitively with natural number ordering, since S3's own
 listing order puts every capital before every lowercase. Descending is disabled
 while a folder still has pages to load, because a partial listing cannot know
 what belongs at the top. The choice is remembered between visits.
+
+Also stops My Drive borrowing Home's language: the browse tree called its own
+contents "Suggested files" and labelled the modified date "Last Opened", which
+S3 does not record. Sections are named by the page showing them now.

--- a/.changeset/sort-by-name.md
+++ b/.changeset/sort-by-name.md
@@ -1,0 +1,9 @@
+---
+'frontend': patch
+---
+
+Sort the file list by name from the list-view header. Ascending and descending
+both sort case-insensitively with natural number ordering, since S3's own
+listing order puts every capital before every lowercase. Descending is disabled
+while a folder still has pages to load, because a partial listing cannot know
+what belongs at the top. The choice is remembered between visits.

--- a/frontend/src/app/dashboard/browse/page.tsx
+++ b/frontend/src/app/dashboard/browse/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useScroll } from '@/context/scroll-context';
-import { SuggestedFolders } from '@/features/dashboard/components/views/home/suggested-folders';
-import { SuggestedFiles } from '@/features/dashboard/components/views/home/suggested-files';
+import { DriveList } from '@/features/dashboard/components/views/drive/drive-list';
 import { DashboardLoading } from '@/features/dashboard/components/ui/skeletons/dashboard-skeleton';
 import { Folder } from '@/features/dashboard/types/folder';
 import { FileItem } from '@/features/dashboard/types/file';
@@ -411,23 +410,15 @@ function BrowsePageContent() {
             {() => (
               <>
                 {/* Folders */}
-                <SuggestedFolders
+                <DriveList
                   folders={displayedFolders}
+                  files={displayedFiles}
                   onFolderClick={handleFolderClick}
                   onFolderMenuClick={handleFolderMenuClick}
-                  onFilesDroppedToFolder={handleFilesDroppedToFolderWrapper}
-                  className="mt-8"
-                  title="Folders"
-                />
-
-                {/* Files */}
-                <SuggestedFiles
-                  files={displayedFiles}
                   onFileClick={handleFileClick}
                   onFileAction={handleFileAction}
                   onFilesDropped={handleFilesDroppedToDirectoryWrapper}
-                  className="mt-8"
-                  title="Files"
+                  onFilesDroppedToFolder={handleFilesDroppedToFolderWrapper}
                   sortDirection={sortDirection}
                   onToggleSort={toggleSort}
                   canSortDescending={sortableBothWays}

--- a/frontend/src/app/dashboard/browse/page.tsx
+++ b/frontend/src/app/dashboard/browse/page.tsx
@@ -103,7 +103,6 @@ function BrowsePageContent() {
   const params = parseFolderParams(searchParams);
   const {
     prefix: prefixParam = '',
-    key: keyParam = '',
     maxKeys: _maxKeys,
     continuationToken: _continuationToken,
   } = params;
@@ -169,7 +168,7 @@ function BrowsePageContent() {
       const folderName = folder.name;
       if (folderName) {
         // Use utility function to build URL
-        const url = buildFolderClickUrl(prefixParam, folderName, keyParam);
+        const url = buildFolderClickUrl(prefixParam, folderName);
         router.push(url);
       }
     }
@@ -339,17 +338,13 @@ function BrowsePageContent() {
       {pathSegments.length > 0 && (
         <EnhancedFolderBreadcrumb
           pathSegments={pathSegments}
-          currentKey={keyParam}
-          onNavigate={(prefix: string, key?: string) => {
+          onNavigate={(prefix: string) => {
             const params = new URLSearchParams();
             if (prefix) {
               params.set('prefix', prefix);
             }
-            if (key) {
-              params.set('key', key);
-            }
 
-            const url = prefix || key ? `/dashboard/browse?${params.toString()}` : '/dashboard';
+            const url = prefix ? `/dashboard/browse?${params.toString()}` : '/dashboard';
             router.push(url);
           }}
         />

--- a/frontend/src/app/dashboard/browse/page.tsx
+++ b/frontend/src/app/dashboard/browse/page.tsx
@@ -417,7 +417,7 @@ function BrowsePageContent() {
                   onFolderMenuClick={handleFolderMenuClick}
                   onFilesDroppedToFolder={handleFilesDroppedToFolderWrapper}
                   className="mt-8"
-                  hideTitle={pathSegments.length > 0}
+                  title="Folders"
                 />
 
                 {/* Files */}
@@ -427,7 +427,7 @@ function BrowsePageContent() {
                   onFileAction={handleFileAction}
                   onFilesDropped={handleFilesDroppedToDirectoryWrapper}
                   className="mt-8"
-                  hideTitle={pathSegments.length > 0}
+                  title="Files"
                   sortDirection={sortDirection}
                   onToggleSort={toggleSort}
                   canSortDescending={sortableBothWays}

--- a/frontend/src/app/dashboard/browse/page.tsx
+++ b/frontend/src/app/dashboard/browse/page.tsx
@@ -9,7 +9,9 @@ import { FileItem } from '@/features/dashboard/types/file';
 import { useDriveStore, useDirectoryState } from '@/context/data-context';
 import { AsyncBoundary } from '@/shared/components/ui/async-boundary';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
-import { useEffect, Suspense, useState, useCallback, useRef } from 'react';
+import { useEffect, Suspense, useState, useCallback, useRef, useMemo } from 'react';
+import { useSortPreference } from '@/hooks/use-sort-preference';
+import { sortByName, canSortDescending } from '@/features/dashboard/utils/sort-items';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { EnhancedFolderBreadcrumb } from '@/features/dashboard/components/layout/breadcrumb/enhanced-folder-breadcrumb';
 import {
@@ -53,6 +55,12 @@ function BrowsePageContent() {
   } = useDriveStore();
 
   const { apiS3, isLoading, isAuthenticated } = useAuthGuard();
+
+  const { direction: sortDirection, setDirection: setSortDirection } = useSortPreference();
+
+  const toggleSort = useCallback(() => {
+    setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+  }, [sortDirection, setSortDirection]);
 
   const dispatchDrop = useUploadDispatch();
 
@@ -211,9 +219,23 @@ function BrowsePageContent() {
   const isLoadingMore = currentPrefix ? loadMoreStatus[currentPrefix] === 'loading' : false;
   const currentData = currentPrefix ? cache[currentPrefix] : null;
 
+  // Only meaningful once the folder is whole, so it is read off the same cache
+  // entry the rows come from rather than tracked separately.
+  const sortableBothWays = canSortDescending(currentData?.isTruncated);
+
   // Calculate item counts and chunked data
-  const allFolders = currentData?.folders || [];
-  const allFiles = currentData?.files || [];
+  // Sorted before the chunking below, not after. Slicing first would order
+  // only the rows already on screen, so "sort A to Z" would mean "sort the
+  // first hundred", and pressing Show More would append a second, separately
+  // ordered run underneath the first.
+  const allFolders = useMemo(
+    () => sortByName(currentData?.folders ?? [], sortDirection),
+    [currentData?.folders, sortDirection]
+  );
+  const allFiles = useMemo(
+    () => sortByName(currentData?.files ?? [], sortDirection),
+    [currentData?.files, sortDirection]
+  );
 
   // Calculate how many items to show based on chunks
   const maxVisibleFiles = visibleFileChunks * CHUNK_SIZE;
@@ -406,6 +428,9 @@ function BrowsePageContent() {
                   onFilesDropped={handleFilesDroppedToDirectoryWrapper}
                   className="mt-8"
                   hideTitle={pathSegments.length > 0}
+                  sortDirection={sortDirection}
+                  onToggleSort={toggleSort}
+                  canSortDescending={sortableBothWays}
                 />
 
                 {/* Invisible sentinel element for Intersection Observer - only render when chunks available */}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -137,10 +137,7 @@ export default function HomePage() {
   const handleFolderClick = (folder: Folder) => {
     if (folder.Prefix && folder.name) {
       // Navigate to the folder using the enhanced browse route
-      const url = generateFolderUrl({
-        prefix: `${folder.name}/`,
-        key: folder.name,
-      });
+      const url = generateFolderUrl({ prefix: `${folder.name}/` });
       router.push(url);
     }
   };

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -70,11 +70,6 @@
   --success-foreground: #ffffff;
   --success-surface: #e6f4ea;
 
-  /* Error state for form validation and failed connections */
-  --danger: #d93025;
-  --danger-surface: #fce8e6;
-  --danger-border: #f6aea9;
-
   /* Informational banner, softer than a warning and calmer than primary */
   --info-surface: #e8f0fe;
   --info-border: #d2e3fc;
@@ -114,6 +109,12 @@
      white-on-white. */
   --destructive: #d93025;
   --destructive-foreground: #ffffff;
+  /* Tints of the same red, for the surface and border of an error panel.
+     These were a second scale called `danger` holding byte-identical values,
+     which is one retune away from the app having two different reds and no
+     rule for which belongs where. */
+  --destructive-surface: #fce8e6;
+  --destructive-border: #f6aea9;
 }
 
 @theme inline {
@@ -142,9 +143,6 @@
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
   --color-success-surface: var(--success-surface);
-  --color-danger: var(--danger);
-  --color-danger-surface: var(--danger-surface);
-  --color-danger-border: var(--danger-border);
   --color-info-surface: var(--info-surface);
   --color-info-border: var(--info-border);
   --color-info-foreground: var(--info-foreground);
@@ -165,6 +163,8 @@
   --color-provider-custom-soft: var(--provider-custom-soft);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-destructive-surface: var(--destructive-surface);
+  --color-destructive-border: var(--destructive-border);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -225,10 +225,6 @@
   --success-foreground: #202124;
   --success-surface: rgba(129, 201, 149, 0.16);
 
-  --danger: #f28b82;
-  --danger-surface: rgba(242, 139, 130, 0.14);
-  --danger-border: rgba(242, 139, 130, 0.32);
-
   --info-surface: rgba(138, 180, 248, 0.12);
   --info-border: rgba(138, 180, 248, 0.28);
   --info-foreground: #aecbfa;
@@ -241,6 +237,8 @@
      dark here the way --primary-foreground does. */
   --destructive: #f28b82;
   --destructive-foreground: #202124;
+  --destructive-surface: rgba(242, 139, 130, 0.14);
+  --destructive-border: rgba(242, 139, 130, 0.32);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -300,10 +298,6 @@
     --success-foreground: #202124;
     --success-surface: rgba(129, 201, 149, 0.16);
 
-    --danger: #f28b82;
-    --danger-surface: rgba(242, 139, 130, 0.14);
-    --danger-border: rgba(242, 139, 130, 0.32);
-
     --info-surface: rgba(138, 180, 248, 0.12);
     --info-border: rgba(138, 180, 248, 0.28);
     --info-foreground: #aecbfa;
@@ -313,6 +307,8 @@
     --step-pending-border: #5f6368;
     --destructive: #f28b82;
     --destructive-foreground: #202124;
+    --destructive-surface: rgba(242, 139, 130, 0.14);
+    --destructive-border: rgba(242, 139, 130, 0.32);
   }
 }
 

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -6,22 +6,12 @@ export default function robots(): MetadataRoute.Robots {
 
   return {
     rules: [
+      // One rule, not three. Googlebot and Bingbot each had a byte-identical
+      // copy of this block, including the comment, and `*` already covers them
+      // both - so the only thing the duplicates added was three places to keep
+      // in step.
       {
         userAgent: '*',
-        allow: '/',
-        // /connect and its provider pages are public landing pages and need to
-        // be crawlable. /dashboard is private and useless to a crawler.
-        disallow: ['/api/', '/dashboard/'],
-      },
-      {
-        userAgent: 'Googlebot',
-        allow: '/',
-        // /connect and its provider pages are public landing pages and need to
-        // be crawlable. /dashboard is private and useless to a crawler.
-        disallow: ['/api/', '/dashboard/'],
-      },
-      {
-        userAgent: 'Bingbot',
         allow: '/',
         // /connect and its provider pages are public landing pages and need to
         // be crawlable. /dashboard is private and useless to a crawler.

--- a/frontend/src/config/providers.ts
+++ b/frontend/src/config/providers.ts
@@ -39,6 +39,14 @@ export interface S3Provider {
   regions: RegionOption[];
   /** True when the endpoint cannot be derived and the user must supply it. */
   requiresCustomEndpoint: boolean;
+  /**
+   * What to show in an empty endpoint field.
+   *
+   * The template was being used for this, so R2 offered the user a literal
+   * `{{accountId}}` - our own templating syntax, leaking onto a page we are
+   * trying to rank. This is written the way the provider's own docs write it.
+   */
+  endpointPlaceholder?: string;
   seo: {
     title: string;
     description: string;
@@ -114,6 +122,7 @@ export const S3_PROVIDERS: readonly S3Provider[] = [
     name: 'Cloudflare R2',
     tagline: 'S3 API with no egress fees',
     endpoint: 'https://{{accountId}}.r2.cloudflarestorage.com',
+    endpointPlaceholder: 'https://<account-id>.r2.cloudflarestorage.com',
     defaultRegion: 'auto',
     regions: [
       { value: 'auto', label: 'Automatic - auto' },

--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -256,10 +256,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
             // Only redirect to dashboard if user is on home page/connect page
             // Otherwise, stay on current route (preserve the URL after refresh)
-            // Provider pages count as /connect here. Landing on
-            // /connect/cloudflare-r2 with a live session should behave the same
-            // as landing on /connect with one.
-            if (pathname === '/' || pathname === '/connect' || pathname.startsWith('/connect/')) {
+            // The provider pages are deliberately NOT in here. They exist to
+            // be found in search, and bouncing a visitor who happens to have a
+            // session means the page Google indexed is the one page they never
+            // see. It also left someone with a bucket already connected unable
+            // to reach the form for a second one.
+            //
+            // `/` and a bare `/connect` still redirect: those are entry points
+            // with nothing to read, so sending a signed-in user onward is the
+            // helpful thing rather than the disruptive one.
+            if (pathname === '/' || pathname === '/connect') {
               router.push('/dashboard');
             }
           } else {

--- a/frontend/src/context/data-context-deleted-folder.test.ts
+++ b/frontend/src/context/data-context-deleted-folder.test.ts
@@ -61,7 +61,11 @@ describe('forgetting the folder itself', () => {
         'docs/': listing(['docs/2024/'], ['docs/a.txt']),
         'docs/2024/': listing([], ['docs/2024/b.txt']),
       },
-      status: { '/': 'ready', 'docs/': 'ready', 'docs/2024/': 'ready' },
+      directory: {
+        '/': { status: 'ready' },
+        'docs/': { status: 'ready' },
+        'docs/2024/': { status: 'ready' },
+      },
       loadMoreStatus: { 'docs/': 'ready' },
     });
   });
@@ -75,7 +79,7 @@ describe('forgetting the folder itself', () => {
   it('drops the statuses too, so nothing is served as ready', () => {
     store().removeDeletedFolder('docs/');
 
-    expect(store().status).toEqual({ '/': 'ready' });
+    expect(store().directory).toEqual({ '/': { status: 'ready' } });
     expect(store().loadMoreStatus).toEqual({});
   });
 
@@ -107,14 +111,14 @@ describe('the parent listing', () => {
   it('loses the folder but stays cached, so it still renders', () => {
     useDriveStore.setState({
       cache: { '/': listing(['docs/', 'photos/'], ['readme.md']) },
-      status: { '/': 'ready' },
+      directory: { '/': { status: 'ready' } },
     });
 
     store().removeDeletedFolder('docs/');
 
     expect(store().cache['/'].folders.map((f) => f.Prefix)).toEqual(['photos/']);
     expect(store().cache['/'].files.map((f) => f.Key)).toEqual(['readme.md']);
-    expect(store().status['/']).toBe('ready');
+    expect(store().directory['/']?.status).toBe('ready');
   });
 
   it('is found through the bucket prefix the session is pinned to', () => {
@@ -162,7 +166,7 @@ describe('the recents on the home page', () => {
           folderOffset: 10,
         },
       },
-      recentStatus: { '/': 'ready', 'docs/': 'ready' },
+      recent: { '/': { status: 'ready' }, 'docs/': { status: 'ready' } },
     });
   });
 
@@ -186,7 +190,7 @@ describe('the recents on the home page', () => {
     store().removeDeletedFolder('docs/');
 
     expect(store().recentCache['docs/']).toBeUndefined();
-    expect(store().recentStatus).toEqual({ '/': 'ready' });
+    expect(store().recent).toEqual({ '/': { status: 'ready' } });
   });
 });
 
@@ -241,7 +245,7 @@ describe('a read still in the air', () => {
       rootPrefix: '/',
       currentPrefix: '/',
       cache: { '/': { ...listing(['docs/']), isTruncated: true, nextToken: 'page-2' } },
-      status: { '/': 'ready' },
+      directory: { '/': { status: 'ready' } },
     });
 
     // "Show more" is already running when the delete lands
@@ -267,18 +271,18 @@ describe('a read still in the air', () => {
       rootPrefix: '/',
       currentPrefix: '/',
       cache: { '/': listing(['docs/', 'photos/']) },
-      status: { '/': 'ready' },
+      directory: { '/': { status: 'ready' } },
     });
 
     const reading = store().fetchData({ sync: true });
-    expect(store().status['/']).toBe('loading');
+    expect(store().directory['/']?.status).toBe('loading');
 
     store().removeDeletedFolder('docs/');
 
     page.resolve({ files: [], folders: [{ Prefix: 'docs/' }] });
     await reading;
 
-    expect(store().status['/']).toBe('ready');
+    expect(store().directory['/']?.status).toBe('ready');
     expect(store().cache['/'].folders.map((f) => f.Prefix)).toEqual(['photos/']);
   });
 
@@ -301,7 +305,7 @@ describe('a read still in the air', () => {
 
     // A resurrected entry reads as ready and gets served to whoever walks back in
     expect(store().cache['docs/2024/']).toBeUndefined();
-    expect(store().status['docs/2024/']).toBeUndefined();
+    expect(store().directory['docs/2024/']?.status).toBeUndefined();
   });
 });
 

--- a/frontend/src/context/data-context.test.ts
+++ b/frontend/src/context/data-context.test.ts
@@ -96,7 +96,7 @@ describe('returning to a folder whose request is still open', () => {
 
     expect(fetchDirectoryStructure).toHaveBeenCalledTimes(1);
     expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
-    expect(store().status['/']).toBe('ready');
+    expect(store().directory['/']?.status).toBe('ready');
   });
 
   it('gives the second caller the first caller result', async () => {
@@ -186,7 +186,7 @@ describe('returning to a folder whose request is still open', () => {
 
     // A folder that loaded fine must not render as failed because an older
     // request for it happened to give up afterwards.
-    expect(store().status['/']).toBe('ready');
+    expect(store().directory['/']?.status).toBe('ready');
     expect(cachedKeys()).toEqual(['fresh.txt']);
   });
 });
@@ -439,8 +439,8 @@ describe('a listing that fails', () => {
 
     await store().fetchData({ sync: false });
 
-    expect(useDriveStore.getState().status['/']).toBe('error');
-    expect(useDriveStore.getState().failures['/']?.kind).toBe('permissions');
+    expect(useDriveStore.getState().directory['/']?.status).toBe('error');
+    expect(useDriveStore.getState().directory['/']?.failure?.kind).toBe('permissions');
   });
 
   it('keeps the reason specific enough to act on', async () => {
@@ -450,21 +450,21 @@ describe('a listing that fails', () => {
 
     // A blocked CORS preflight and a wrong secret key are different problems
     // fixed in different places, so they must not arrive as the same message.
-    expect(useDriveStore.getState().failures['/']?.kind).toBe('network');
+    expect(useDriveStore.getState().directory['/']?.failure?.kind).toBe('network');
   });
 
   it('forgets the reason once the folder loads', async () => {
     fetchDirectoryStructure.mockRejectedValueOnce(sdkError('AccessDenied', 403));
     await store().fetchData({ sync: false });
-    expect(useDriveStore.getState().failures['/']).toBeDefined();
+    expect(useDriveStore.getState().directory['/']?.failure).toBeDefined();
 
     // What Retry does. A stale reason left behind would render over a folder
     // that had just come back fine.
     fetchDirectoryStructure.mockResolvedValueOnce(page(['a.txt']));
     await store().fetchData({ sync: true });
 
-    expect(useDriveStore.getState().status['/']).toBe('ready');
-    expect(useDriveStore.getState().failures['/']).toBeUndefined();
+    expect(useDriveStore.getState().directory['/']?.status).toBe('ready');
+    expect(useDriveStore.getState().directory['/']?.failure).toBeUndefined();
   });
 
   it('does not carry a failure into the next session', async () => {
@@ -473,7 +473,7 @@ describe('a listing that fails', () => {
 
     store().clearAllData();
 
-    expect(useDriveStore.getState().failures).toEqual({});
+    expect(useDriveStore.getState().directory).toEqual({});
   });
 
   // The superseding rule already covered the status; the reason has to follow
@@ -489,8 +489,8 @@ describe('a listing that fails', () => {
     slowFailure.reject(sdkError('AccessDenied', 403));
     await first;
 
-    expect(useDriveStore.getState().status['/']).toBe('ready');
-    expect(useDriveStore.getState().failures['/']).toBeUndefined();
+    expect(useDriveStore.getState().directory['/']?.status).toBe('ready');
+    expect(useDriveStore.getState().directory['/']?.failure).toBeUndefined();
   });
 });
 
@@ -522,9 +522,9 @@ describe('two requests for one prefix', () => {
 
     const state = useDriveStore.getState();
 
-    expect(state.recentStatus['/']).toBe('error');
+    expect(state.recent['/']?.status).toBe('error');
     // Not 'unknown': the recent list still has to be able to say it was denied.
-    expect(state.recentFailures['/']?.kind).toBe('permissions');
+    expect(state.recent['/']?.failure?.kind).toBe('permissions');
   });
 
   it('keeps the directory failure when the recent listing succeeds', async () => {
@@ -539,7 +539,7 @@ describe('two requests for one prefix', () => {
 
     const state = useDriveStore.getState();
 
-    expect(state.status['/']).toBe('error');
-    expect(state.failures['/']?.kind).toBe('bucket');
+    expect(state.directory['/']?.status).toBe('error');
+    expect(state.directory['/']?.failure?.kind).toBe('bucket');
   });
 });

--- a/frontend/src/context/data-context.tsx
+++ b/frontend/src/context/data-context.tsx
@@ -31,42 +31,44 @@ type RecentDataWithCache = RecentData & {
 
 type Status = 'idle' | 'loading' | 'ready' | 'error';
 
+/**
+ * One request's outcome, held as a single value.
+ *
+ * Status and reason used to live in separate maps keyed by the same prefix, and
+ * nothing forced them to agree. That is not theoretical: with one shared
+ * failures map, the directory listing finishing erased why the recent list had
+ * failed, and the recent list fell back to a generic "something went wrong".
+ * Splitting the map per request kind fixed that instance without fixing the
+ * shape - four maps that must stay in step are still four maps that can fall
+ * out of step.
+ *
+ * Together they cannot drift: a reason is only ever written with the status it
+ * explains, and replacing the status replaces the reason with it.
+ */
+type RequestState = {
+  status: Status;
+  /** Only meaningful with status 'error'. Cleared by any other status. */
+  failure?: ConnectionFailure;
+};
+
 type Store = {
   apiS3: BYOS3ApiProvider | null;
   setApiS3: (api: BYOS3ApiProvider) => void;
   cache: Record<string, PrefixData>;
   recentCache: Record<string, RecentDataWithCache>;
-  status: Record<string, Status>;
-  recentStatus: Record<string, Status>;
+  directory: Record<string, RequestState>;
+  recent: Record<string, RequestState>;
   loadMoreStatus: Record<string, Status>;
-  /**
-   * Why the last request for a key failed, one map per request kind.
-   *
-   * The catch blocks below used to be bare `catch {}`, so the reason was gone
-   * before anyone could render it - which is half of why a failed listing was
-   * indistinguishable from one still loading.
-   *
-   * Split the same way `status` and `recentStatus` are, and for a sharper
-   * reason: `refreshCurrentData` runs both requests against the same prefix at
-   * once. Sharing one map by prefix meant the directory listing succeeding
-   * erased why the recent list had just failed, and the recent list then fell
-   * back to a generic "something went wrong" - the exact vagueness this change
-   * exists to remove. Each status setter owns its own map, so a status and its
-   * reason cannot drift apart.
-   */
-  failures: Record<string, ConnectionFailure>;
-  recentFailures: Record<string, ConnectionFailure>;
   currentPrefix: string | null;
   rootPrefix: string | null;
 
   setPrefixData: (prefix: string, data: PrefixData) => void;
   setRecentData: (prefix: string, data: RecentDataWithCache) => void;
   setCurrentPrefix: (prefix: string) => void;
-  setStatus: (prefix: string, s: Status) => void;
-  setRecentStatus: (prefix: string, s: Status) => void;
+  /** Writes a status and its reason as one value. */
+  setDirectoryState: (prefix: string, status: Status, failure?: ConnectionFailure) => void;
+  setRecentState: (prefix: string, status: Status, failure?: ConnectionFailure) => void;
   setLoadMoreStatus: (prefix: string, s: Status) => void;
-  setFailure: (prefix: string, failure: ConnectionFailure) => void;
-  setRecentFailure: (prefix: string, failure: ConnectionFailure) => void;
   setRootPrefix: (prefix: string) => void;
   clearAllData: () => void;
   removeDeletedFolder: (prefix: string) => void;
@@ -294,11 +296,9 @@ export const useDriveStore = create<Store>((set, get) => ({
   apiS3: null,
   cache: {},
   recentCache: {},
-  status: {},
-  recentStatus: {},
+  directory: {},
+  recent: {},
   loadMoreStatus: {},
-  failures: {},
-  recentFailures: {},
   rootPrefix: null,
   currentPrefix: null,
 
@@ -314,29 +314,17 @@ export const useDriveStore = create<Store>((set, get) => ({
       recentCache: { ...state.recentCache, [prefix]: data },
     })),
 
-  setStatus: (prefix, s) =>
-    set((state) => {
-      // A key that is loading or ready has no current failure. Leaving the old
-      // one behind would let a retry that succeeded still render its reason.
-      const failures = { ...state.failures };
-      if (s !== 'error') delete failures[prefix];
+  setDirectoryState: (prefix, status, failure) =>
+    set((state) => ({
+      // The reason travels with the status, so a stale one cannot outlive the
+      // failure it describes - a retry that succeeded used to keep rendering it.
+      directory: { ...state.directory, [prefix]: { status, failure } },
+    })),
 
-      return { status: { ...state.status, [prefix]: s }, failures };
-    }),
-
-  setFailure: (prefix, failure) =>
-    set((state) => ({ failures: { ...state.failures, [prefix]: failure } })),
-
-  setRecentFailure: (prefix, failure) =>
-    set((state) => ({ recentFailures: { ...state.recentFailures, [prefix]: failure } })),
-
-  setRecentStatus: (prefix, s) =>
-    set((state) => {
-      const recentFailures = { ...state.recentFailures };
-      if (s !== 'error') delete recentFailures[prefix];
-
-      return { recentStatus: { ...state.recentStatus, [prefix]: s }, recentFailures };
-    }),
+  setRecentState: (prefix, status, failure) =>
+    set((state) => ({
+      recent: { ...state.recent, [prefix]: { status, failure } },
+    })),
 
   setLoadMoreStatus: (prefix, s) =>
     set((state) => ({ loadMoreStatus: { ...state.loadMoreStatus, [prefix]: s } })),
@@ -360,11 +348,9 @@ export const useDriveStore = create<Store>((set, get) => ({
       apiS3: null,
       cache: {},
       recentCache: {},
-      status: {},
-      recentStatus: {},
+      directory: {},
+      recent: {},
       loadMoreStatus: {},
-      failures: {},
-      recentFailures: {},
       currentPrefix: null,
       rootPrefix: null,
     });
@@ -394,8 +380,8 @@ export const useDriveStore = create<Store>((set, get) => ({
     for (const map of [
       current.cache,
       current.recentCache,
-      current.status,
-      current.recentStatus,
+      current.directory,
+      current.recent,
       current.loadMoreStatus,
     ]) {
       for (const key of Object.keys(map)) {
@@ -413,15 +399,15 @@ export const useDriveStore = create<Store>((set, get) => ({
     set((state) => {
       const cache = { ...state.cache };
       const recentCache = { ...state.recentCache };
-      const status = { ...state.status };
-      const recentStatus = { ...state.recentStatus };
+      const directory = { ...state.directory };
+      const recent = { ...state.recent };
       const loadMoreStatus = { ...state.loadMoreStatus };
 
       for (const key of gone) {
         delete cache[key];
         delete recentCache[key];
-        delete status[key];
-        delete recentStatus[key];
+        delete directory[key];
+        delete recent[key];
         delete loadMoreStatus[key];
       }
 
@@ -439,17 +425,17 @@ export const useDriveStore = create<Store>((set, get) => ({
       // 'loading' for good: a listing stuck behind its skeleton, and a "Show
       // more" that refuses to run again because it thinks one is still going.
       // What is already cached is what there is to show, so say so.
-      if (status[parentKey] === 'loading') {
-        if (cache[parentKey]) status[parentKey] = 'ready';
-        else delete status[parentKey];
+      if (directory[parentKey]?.status === 'loading') {
+        if (cache[parentKey]) directory[parentKey] = { status: 'ready' };
+        else delete directory[parentKey];
       }
-      if (recentStatus[parentKey] === 'loading') {
-        if (recentCache[parentKey]) recentStatus[parentKey] = 'ready';
-        else delete recentStatus[parentKey];
+      if (recent[parentKey]?.status === 'loading') {
+        if (recentCache[parentKey]) recent[parentKey] = { status: 'ready' };
+        else delete recent[parentKey];
       }
       if (loadMoreStatus[parentKey] === 'loading') delete loadMoreStatus[parentKey];
 
-      return { cache, recentCache, status, recentStatus, loadMoreStatus };
+      return { cache, recentCache, directory, recent, loadMoreStatus };
     });
 
     // The search cache is deliberately left alone. clearCache also drops the
@@ -460,16 +446,8 @@ export const useDriveStore = create<Store>((set, get) => ({
   },
 
   fetchData: async (opts = { sync: false }) => {
-    const {
-      apiS3,
-      currentPrefix,
-      rootPrefix,
-      status,
-      cache,
-      setPrefixData,
-      setStatus,
-      setFailure,
-    } = get();
+    const { apiS3, currentPrefix, rootPrefix, directory, cache, setPrefixData, setDirectoryState } =
+      get();
 
     if (!apiS3) return;
 
@@ -482,7 +460,7 @@ export const useDriveStore = create<Store>((set, get) => ({
     const keyPrefix = formattedPrefix === '' ? '/' : formattedPrefix;
 
     // Avoid duplicate concurrent fetches unless forced by sync
-    const currStatus = status[keyPrefix];
+    const currStatus = directory[keyPrefix]?.status;
 
     if (currStatus === 'ready' && !opts.sync) return;
 
@@ -492,7 +470,7 @@ export const useDriveStore = create<Store>((set, get) => ({
     // Don't auto-refetch just because isTruncated is true - let the user decide
     // with the "Show More" button.
     if (currentData && !opts.sync) {
-      if (currStatus !== 'ready') setStatus(keyPrefix, 'ready');
+      if (currStatus !== 'ready') setDirectoryState(keyPrefix, 'ready');
       return;
     }
 
@@ -504,7 +482,7 @@ export const useDriveStore = create<Store>((set, get) => ({
       const requestId = claimRequestId(latestRequestId, keyPrefix);
 
       try {
-        setStatus(keyPrefix, 'loading');
+        setDirectoryState(keyPrefix, 'loading');
 
         // Always read from the top. This branch only runs when there is no data
         // yet or a sync was forced, and either way the result replaces the cache
@@ -523,17 +501,15 @@ export const useDriveStore = create<Store>((set, get) => ({
           nextToken: data.nextToken,
           isTruncated: data.isTruncated,
         });
-        setStatus(keyPrefix, 'ready');
+        setDirectoryState(keyPrefix, 'ready');
       } catch (error) {
         // A superseded request must not report an error over a newer request's
         // result, or a folder that loaded fine renders as failed.
         if (isSuperseded(latestRequestId, keyPrefix, requestId)) return;
 
-        // Recorded before the status, because setStatus('error') is what a
-        // subscriber wakes on - setting it first would render one frame with
-        // no reason to show.
-        setFailure(keyPrefix, classifyConnectionFailure(error));
-        setStatus(keyPrefix, 'error');
+        // One write, so there is no frame in which the row knows it failed
+        // but not why.
+        setDirectoryState(keyPrefix, 'error', classifyConnectionFailure(error));
       }
     });
   },
@@ -571,16 +547,8 @@ export const useDriveStore = create<Store>((set, get) => ({
   },
 
   fetchRecentItems: async (opts = { sync: false, itemsPerType: 10 }) => {
-    const {
-      apiS3,
-      currentPrefix,
-      rootPrefix,
-      recentStatus,
-      recentCache,
-      setRecentData,
-      setRecentStatus,
-      setRecentFailure,
-    } = get();
+    const { apiS3, currentPrefix, rootPrefix, recent, recentCache, setRecentData, setRecentState } =
+      get();
 
     if (!apiS3) return;
 
@@ -589,7 +557,7 @@ export const useDriveStore = create<Store>((set, get) => ({
     const formattedPrefix = rootPrefix === '/' && currentPrefix === '/' ? '' : currentPrefix;
     const keyPrefix = formattedPrefix === '' ? '/' : formattedPrefix;
 
-    const currStatus = recentStatus[keyPrefix];
+    const currStatus = recent[keyPrefix]?.status;
     if (currStatus === 'ready' && !opts.sync) return;
 
     // Ensure itemsPerType has a default value
@@ -602,7 +570,7 @@ export const useDriveStore = create<Store>((set, get) => ({
       const requestId = claimRequestId(latestRecentRequestId, keyPrefix);
 
       try {
-        setRecentStatus(keyPrefix, 'loading');
+        setRecentState(keyPrefix, 'loading');
 
         // Fetch up to 1000 items from current directory
         const data = await apiS3.fetchDirectoryStructure(formattedPrefix, 1000);
@@ -648,12 +616,11 @@ export const useDriveStore = create<Store>((set, get) => ({
         }
 
         setRecentData(keyPrefix, recentData);
-        setRecentStatus(keyPrefix, 'ready');
+        setRecentState(keyPrefix, 'ready');
       } catch (error) {
         if (isSuperseded(latestRecentRequestId, keyPrefix, requestId)) return;
 
-        setRecentFailure(keyPrefix, classifyConnectionFailure(error));
-        setRecentStatus(keyPrefix, 'error');
+        setRecentState(keyPrefix, 'error', classifyConnectionFailure(error));
       }
     });
   },
@@ -795,45 +762,40 @@ export const useDriveStore = create<Store>((set, get) => ({
  */
 export function useDirectoryState(): AsyncState<PrefixData> {
   const currentPrefix = useDriveStore((state) => state.currentPrefix);
-  const status = useDriveStore((state) =>
-    currentPrefix ? state.status[currentPrefix] : undefined
+  const entry = useDriveStore((state) =>
+    currentPrefix ? state.directory[currentPrefix] : undefined
   );
   const data = useDriveStore((state) => (currentPrefix ? state.cache[currentPrefix] : undefined));
-  const failure = useDriveStore((state) =>
-    currentPrefix ? state.failures[currentPrefix] : undefined
-  );
   const fetchData = useDriveStore((state) => state.fetchData);
 
-  return toAsyncState(status, data, failure, () => void fetchData({ sync: true }));
+  return toAsyncState(entry, data, () => void fetchData({ sync: true }));
 }
 
 /** The same, for the recent-items list on the dashboard home. */
 export function useRecentState(): AsyncState<RecentDataWithCache> {
   const currentPrefix = useDriveStore((state) => state.currentPrefix);
-  const status = useDriveStore((state) =>
-    currentPrefix ? state.recentStatus[currentPrefix] : undefined
-  );
+  const entry = useDriveStore((state) => (currentPrefix ? state.recent[currentPrefix] : undefined));
   const data = useDriveStore((state) =>
     currentPrefix ? state.recentCache[currentPrefix] : undefined
   );
-  const failure = useDriveStore((state) =>
-    currentPrefix ? state.recentFailures[currentPrefix] : undefined
-  );
   const fetchRecentItems = useDriveStore((state) => state.fetchRecentItems);
 
-  return toAsyncState(status, data, failure, () => void fetchRecentItems({ sync: true }));
+  return toAsyncState(entry, data, () => void fetchRecentItems({ sync: true }));
 }
 
 function toAsyncState<T>(
-  status: Status | undefined,
+  entry: RequestState | undefined,
   data: T | undefined,
-  failure: ConnectionFailure | undefined,
   retry: () => void
 ): AsyncState<T> {
-  if (status === 'error') {
-    // A key can be marked failed a frame before its reason is recorded, and an
-    // 'unknown' failure still tells the user more than a skeleton would.
-    return { state: 'error', failure: failure ?? classifyConnectionFailure(undefined), retry };
+  if (entry?.status === 'error') {
+    // The reason arrives with the status now, so the fallback is only for a
+    // failure recorded before this rule existed.
+    return {
+      state: 'error',
+      failure: entry.failure ?? classifyConnectionFailure(undefined),
+      retry,
+    };
   }
 
   // Data without a ready status is a folder being re-synced: it has rows on
@@ -841,5 +803,5 @@ function toAsyncState<T>(
   // a worse answer than showing what is there.
   if (data !== undefined) return { state: 'ready', data };
 
-  return status === 'loading' ? { state: 'loading' } : { state: 'idle' };
+  return entry?.status === 'loading' ? { state: 'loading' } : { state: 'idle' };
 }

--- a/frontend/src/features/connect/components/connect-wizard.tsx
+++ b/frontend/src/features/connect/components/connect-wizard.tsx
@@ -198,7 +198,9 @@ export function ConnectWizard({ provider }: ConnectWizardProps) {
             required={provider.requiresCustomEndpoint}
             spellCheck={false}
             className={FIELD}
-            placeholder={provider.endpoint || 'https://storage.example.com'}
+            placeholder={
+              provider.endpointPlaceholder ?? provider.endpoint ?? 'https://storage.example.com'
+            }
             value={form.endpoint}
             onChange={(event) => update({ endpoint: event.target.value })}
           />
@@ -232,9 +234,9 @@ export function ConnectWizard({ provider }: ConnectWizardProps) {
         {failure && (
           <div
             role="alert"
-            className="rounded-lg border border-danger-border bg-danger-surface px-3 py-2.5"
+            className="rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2.5"
           >
-            <p className="text-sm font-medium text-danger">{failure.title}</p>
+            <p className="text-sm font-medium text-destructive">{failure.title}</p>
             <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{failure.detail}</p>
           </div>
         )}

--- a/frontend/src/features/dashboard/components/layout/breadcrumb/enhanced-folder-breadcrumb.tsx
+++ b/frontend/src/features/dashboard/components/layout/breadcrumb/enhanced-folder-breadcrumb.tsx
@@ -5,37 +5,27 @@ import { Breadcrumb, type BreadcrumbItem } from '@/shared/components/ui/breadcru
 
 interface EnhancedFolderBreadcrumbProps {
   pathSegments: string[];
-  currentKey?: string;
-  onNavigate?: (prefix: string, key?: string) => void;
+  onNavigate?: (prefix: string) => void;
 }
 
 export function EnhancedFolderBreadcrumb({
   pathSegments,
-  currentKey,
   onNavigate,
 }: EnhancedFolderBreadcrumbProps) {
   const router = useRouter();
 
   const handleNavigation = (segments: string[]) => {
     const newPrefix = segments.length > 0 ? segments.join('/') + '/' : '';
-    const newKey = segments.length > 0 ? segments[segments.length - 1] : undefined;
 
     if (onNavigate) {
-      onNavigate(newPrefix, newKey);
+      onNavigate(newPrefix);
     } else {
       // Default navigation behavior
       const params = new URLSearchParams();
       if (newPrefix) {
         params.set('prefix', newPrefix);
       }
-      if (newKey && currentKey) {
-        params.set('key', newKey);
-      }
-
-      const url =
-        newPrefix || (newKey && currentKey)
-          ? `/dashboard/browse?${params.toString()}`
-          : '/dashboard';
+      const url = newPrefix ? `/dashboard/browse?${params.toString()}` : '/dashboard';
       router.push(url);
     }
   };

--- a/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
@@ -60,6 +60,21 @@ export function FileItemGrid({
     }
   };
 
+  /**
+   * The keyboard's way in.
+   *
+   * Radix opens the menu from onKeyDown and calls preventDefault, which stops
+   * the browser synthesising the click the mouse path selects on - so tabbing
+   * to the button and pressing Enter opened a menu over an unselected row, and
+   * the toolbar never appeared to say what it would act on. Same keys Radix
+   * itself opens on.
+   */
+  const handleMenuKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'ArrowDown') return;
+
+    selectItem(file, 'file', index, false, false, allFiles);
+  };
+
   const handleMenuClick = (event: React.MouseEvent) => {
     // Still load-bearing after the selection moved off it: the row opens the
     // item on click, so the click that opened the menu must not reach it.
@@ -222,6 +237,7 @@ export function FileItemGrid({
                 className="p-1 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
                 aria-label={`More actions for ${file.name}`}
                 onPointerDown={handleMenuPointerDown}
+                onKeyDown={handleMenuKeyDown}
                 onClick={handleMenuClick}
               >
                 <HiOutlineDotsVertical size={18} className=" text-muted-foreground" />

--- a/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
@@ -4,6 +4,7 @@ import { HiOutlineDotsVertical, HiOutlineCheck } from 'react-icons/hi';
 import { FaUserAlt, FaRegCircle } from 'react-icons/fa';
 import { FileOverflowMenu } from '../menus/file-overflow-menu';
 import { FileExtension, FileItem, FileMenuAction } from '@/features/dashboard/types/file';
+import type { Folder } from '@/features/dashboard/types/folder';
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
@@ -12,7 +13,12 @@ import { getItemKeyIntent } from './item-keyboard';
 
 interface FileItemListProps {
   file: FileItem;
-  allFiles?: FileItem[]; // For navigation between files
+  /**
+   * The rows a shift-select range can span. Widened to include folders: in list
+   * view they share one table with the files, so a range from a folder into the
+   * files below has to be sliceable out of a single array.
+   */
+  allFiles?: (FileItem | Folder)[];
   _onAction?: (action: string, file: FileItem) => void;
   index?: number; // For shift-select range
   additionalActions?: FileMenuAction[]; // Additional menu actions
@@ -29,6 +35,17 @@ export function FileItemList({
 }: FileItemListProps) {
   const { openFilePreview } = useFilePreviewActions();
   const { selectItem, isSelected, getSelectionCount } = useMultiSelectStore();
+
+  /**
+   * The neighbours the preview can arrow through.
+   *
+   * `allFiles` carries the folders too now, because shift-select ranges span
+   * the whole table - but a folder has nothing to preview, so it is dropped
+   * here rather than handed to a viewer that would not know what to do with it.
+   */
+  const previewableFiles = allFiles.filter(
+    (item): item is FileItem => !('Prefix' in item && Boolean(item.Prefix))
+  );
 
   const selected = isSelected(file);
   const hasSelection = getSelectionCount() > 0;
@@ -115,7 +132,7 @@ export function FileItemList({
 
       // No selection and not a long press - open file
       if (!file.Key?.endsWith('/')) {
-        openFilePreview(file, allFiles);
+        openFilePreview(file, previewableFiles);
       }
       setIsLongPress(false);
     } else {
@@ -128,7 +145,7 @@ export function FileItemList({
     // Only open preview for non-folder items on double click (desktop only)
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     if (!isTouchDevice && !file.Key?.endsWith('/')) {
-      openFilePreview(file, allFiles);
+      openFilePreview(file, previewableFiles);
     }
   };
 
@@ -145,7 +162,7 @@ export function FileItemList({
     }
 
     if (!file.Key?.endsWith('/')) {
-      openFilePreview(file, allFiles);
+      openFilePreview(file, previewableFiles);
     }
   };
 
@@ -234,7 +251,7 @@ export function FileItemList({
         <div className="col-span-2 sm:col-span-1 md:col-span-2 lg:col-span-1 xl:col-span-1 flex justify-end">
           <FileOverflowMenu
             file={file}
-            allFiles={allFiles}
+            allFiles={previewableFiles}
             additionalActions={additionalActions}
             insertAdditionalActionsAfter={insertAdditionalActionsAfter}
             triggerLabel="More actions"

--- a/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
@@ -76,6 +76,21 @@ export function FileItemList({
     }
   };
 
+  /**
+   * The keyboard's way in.
+   *
+   * Radix opens the menu from onKeyDown and calls preventDefault, which stops
+   * the browser synthesising the click the mouse path selects on - so tabbing
+   * to the button and pressing Enter opened a menu over an unselected row, and
+   * the toolbar never appeared to say what it would act on. Same keys Radix
+   * itself opens on.
+   */
+  const handleMenuKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'ArrowDown') return;
+
+    selectItem(file, 'file', index, false, false, allFiles);
+  };
+
   const handleMenuClick = (event: React.MouseEvent) => {
     // Still load-bearing after the selection moved off it: the row opens the
     // item on click, so the click that opened the menu must not reach it.
@@ -260,6 +275,7 @@ export function FileItemList({
                 className="p-1.5 sm:p-2 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
                 aria-label={`More actions for ${file.name}`}
                 onPointerDown={handleMenuPointerDown}
+                onKeyDown={handleMenuKeyDown}
                 onClick={handleMenuClick}
               >
                 <HiOutlineDotsVertical

--- a/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
@@ -5,7 +5,7 @@ import { FaUserAlt, FaRegCircle } from 'react-icons/fa';
 import { FileOverflowMenu } from '../menus/file-overflow-menu';
 import { FileExtension, FileItem, FileMenuAction } from '@/features/dashboard/types/file';
 import type { Folder } from '@/features/dashboard/types/folder';
-import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
+import { formatTimeWithTooltip, NO_DATE } from '@/shared/utils/time-utils';
 import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
@@ -228,7 +228,7 @@ export function FileItemList({
         {/* Last modified - visible from sm up */}
         <div className="hidden sm:block sm:col-span-2 md:col-span-2 lg:col-span-3 xl:col-span-3">
           <span className="text-xs sm:text-sm text-muted-foreground" title={timeInfo.tooltip}>
-            {timeInfo.display}
+            {timeInfo.display || NO_DATE}
           </span>
         </div>
 

--- a/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
@@ -62,6 +62,21 @@ export function FileItemMobile({
     }
   };
 
+  /**
+   * The keyboard's way in.
+   *
+   * Radix opens the menu from onKeyDown and calls preventDefault, which stops
+   * the browser synthesising the click the mouse path selects on - so tabbing
+   * to the button and pressing Enter opened a menu over an unselected row, and
+   * the toolbar never appeared to say what it would act on. Same keys Radix
+   * itself opens on.
+   */
+  const handleMenuKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'ArrowDown') return;
+
+    selectItem(file, 'file', index, false, false, allFiles);
+  };
+
   const handleMenuClick = (event: React.MouseEvent) => {
     // Still load-bearing after the selection moved off it: the row opens the
     // item on click, so the click that opened the menu must not reach it.
@@ -254,6 +269,7 @@ export function FileItemMobile({
             className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
             aria-label={`More actions for ${file.name}`}
             onPointerDown={handleMenuPointerDown}
+            onKeyDown={handleMenuKeyDown}
             onClick={handleMenuClick}
           >
             <HiOutlineDotsVertical size={20} className="text-muted-foreground" />

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-list.tsx
@@ -8,7 +8,7 @@ import { FaRegCircle, FaUserAlt } from 'react-icons/fa';
 import { FolderOverflowMenu } from '../menus/folder-overflow-menu';
 import { Folder, FolderMenuAction } from '@/features/dashboard/types/folder';
 import type { FileItem } from '@/features/dashboard/types/file';
-import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
+import { formatTimeWithTooltip, NO_DATE } from '@/shared/utils/time-utils';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { getItemKeyIntent } from './item-keyboard';
 
@@ -189,7 +189,7 @@ export const FolderItemList: React.FC<FolderItemListProps> = ({
 
         <div className="hidden sm:block sm:col-span-2 md:col-span-2 lg:col-span-3 xl:col-span-3">
           <span className="text-xs sm:text-sm text-muted-foreground" title={timeInfo.tooltip}>
-            {timeInfo.display}
+            {timeInfo.display || NO_DATE}
           </span>
         </div>
 

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-list.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import type React from 'react';
+import { useState } from 'react';
+import { FolderIcon, MoreVerticalIcon } from '@/shared/components/icons/folder-icons';
+import { HiOutlineCheck } from 'react-icons/hi';
+import { FaRegCircle, FaUserAlt } from 'react-icons/fa';
+import { FolderOverflowMenu } from '../menus/folder-overflow-menu';
+import { Folder, FolderMenuAction } from '@/features/dashboard/types/folder';
+import type { FileItem } from '@/features/dashboard/types/file';
+import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
+import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
+import { getItemKeyIntent } from './item-keyboard';
+
+/**
+ * A folder as a row in the drive table.
+ *
+ * Folders only ever existed as cards, which is why the list view had to show
+ * them in a separate block above the file table - two lists, two headers, one
+ * folder. This renders a folder into the same column grid a file row uses, so
+ * the two can share one table and one sort.
+ *
+ * Deliberately its own component rather than a mode on `FolderItem`: the
+ * codebase already splits rows per layout, and a card and a table row share
+ * almost no markup. What they do share is the handler set, which is copied the
+ * way the other four row components copy it - `item-menu-selection.test.tsx`
+ * covers all of them precisely because drift is how that regresses.
+ */
+
+interface FolderItemListProps {
+  folder: Folder;
+  onClick?: (folder: Folder) => void;
+  onMenuClick?: (folder: Folder, event: React.MouseEvent) => void;
+  className?: string;
+  /** Position in the combined folders-then-files list, for shift-select. */
+  index?: number;
+  /** The combined list, so a range can run from a folder into the files. */
+  allItems?: (Folder | FileItem)[];
+  additionalActions?: FolderMenuAction[];
+  insertAdditionalActionsAfter?: string;
+}
+
+export const FolderItemList: React.FC<FolderItemListProps> = ({
+  folder,
+  onClick,
+  onMenuClick,
+  className = '',
+  index = 0,
+  allItems = [],
+  additionalActions,
+  insertAdditionalActionsAfter,
+}) => {
+  const { selectItem, isSelected, getSelectionCount } = useMultiSelectStore();
+
+  const selected = isSelected(folder);
+  const hasSelection = getSelectionCount() > 0;
+  const timeInfo = formatTimeWithTooltip(folder.lastModified);
+
+  const [pressTimer, setPressTimer] = useState<NodeJS.Timeout | null>(null);
+  const [isLongPress, setIsLongPress] = useState(false);
+
+  const handleTouchStart = () => {
+    setIsLongPress(false);
+    const timer = setTimeout(() => {
+      setIsLongPress(true);
+      selectItem(folder, 'folder', index, true, false, allItems);
+      try {
+        if (navigator.vibrate) {
+          navigator.vibrate(50);
+        }
+      } catch (e) {
+        console.error('Vibration error:', e);
+      }
+    }, 500);
+    setPressTimer(timer);
+  };
+
+  const handleTouchEnd = () => {
+    if (pressTimer) {
+      clearTimeout(pressTimer);
+      setPressTimer(null);
+    }
+  };
+
+  const handleClick = (event: React.MouseEvent) => {
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+
+    if (isTouchDevice) {
+      if (hasSelection) {
+        event.preventDefault();
+        event.stopPropagation();
+        selectItem(folder, 'folder', index, true, false, allItems);
+        setIsLongPress(false);
+        return;
+      }
+
+      if (isLongPress) {
+        event.preventDefault();
+        event.stopPropagation();
+        setIsLongPress(false);
+        return;
+      }
+
+      onClick?.(folder);
+      setIsLongPress(false);
+    } else {
+      selectItem(folder, 'folder', index, event.ctrlKey || event.metaKey, event.shiftKey, allItems);
+    }
+  };
+
+  const handleDoubleClick = () => {
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    if (!isTouchDevice) {
+      onClick?.(folder);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const intent = getItemKeyIntent(event);
+    if (!intent) return;
+
+    event.preventDefault();
+
+    if (intent === 'select') {
+      selectItem(folder, 'folder', index, event.ctrlKey || event.metaKey, event.shiftKey, allItems);
+      return;
+    }
+
+    onClick?.(folder);
+  };
+
+  /**
+   * Selecting runs on pointer down rather than click, because that is when the
+   * menu itself opens: Radix's trigger calls onOpenToggle from onPointerDown.
+   */
+  const handleMenuPointerDown = (event: React.PointerEvent) => {
+    // The same guard Radix puts on its own trigger.
+    if (event.button !== 0 || event.ctrlKey) return;
+
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    if (!isTouchDevice) {
+      selectItem(folder, 'folder', index, false, false, allItems);
+    }
+  };
+
+  const handleMenuClick = (event: React.MouseEvent) => {
+    // The row opens the folder on click, so the click that opened the menu must
+    // not reach it.
+    event.stopPropagation();
+    onMenuClick?.(folder, event);
+  };
+
+  return (
+    <div className={`group relative select-none ${className}`}>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={`${folder.name}, folder${selected ? ', selected' : ''}`}
+        className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2 sm:gap-3 lg:gap-4 px-3 sm:px-4 py-3 hover:bg-secondary/50 transition-all cursor-pointer items-center min-h-[56px] sm:min-h-[64px] focus-visible:ring-2 focus-visible:ring-primary"
+        style={{
+          borderLeft: selected ? '3px solid var(--primary)' : '3px solid transparent',
+          background: selected ? 'var(--accent)' : undefined,
+        }}
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+        onKeyDown={handleKeyDown}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
+      >
+        <div className="col-span-2 sm:col-span-3 md:col-span-4 lg:col-span-4 xl:col-span-4 flex items-center gap-2 sm:gap-3 min-w-0">
+          {hasSelection &&
+            (selected ? (
+              <div
+                className="w-5 h-5 rounded-sm flex items-center justify-center flex-shrink-0"
+                style={{ background: 'var(--primary)', color: 'var(--primary-foreground)' }}
+              >
+                <HiOutlineCheck size={14} />
+              </div>
+            ) : (
+              <FaRegCircle className="w-5 h-5 text-muted-foreground flex-shrink-0" />
+            ))}
+
+          <FolderIcon className="text-blue-400 flex-shrink-0" size={20} />
+          <span className="text-xs sm:text-sm lg:text-base font-medium text-foreground truncate">
+            {folder.name}
+          </span>
+        </div>
+
+        <div className="hidden sm:block sm:col-span-2 md:col-span-2 lg:col-span-3 xl:col-span-3">
+          <span className="text-xs sm:text-sm text-muted-foreground" title={timeInfo.tooltip}>
+            {timeInfo.display}
+          </span>
+        </div>
+
+        <div className="hidden lg:flex items-center gap-2 lg:col-span-2 xl:col-span-2">
+          <div className="h-4 w-4 lg:h-5 lg:w-5 rounded-full bg-card-foreground/70 flex items-center justify-center">
+            <FaUserAlt size={10} className="lg:text-[12px] text-background" />
+          </div>
+          <span className="text-xs lg:text-sm text-muted-foreground truncate">me</span>
+        </div>
+
+        {/* A folder has no size of its own. S3 reports none, and totalling the
+            objects beneath it would cost a LIST per row, so an em dash says
+            "not applicable" where a 0 B would be a lie. */}
+        <div className="hidden xl:flex items-center xl:col-span-2">
+          <span className="text-sm text-muted-foreground">&mdash;</span>
+        </div>
+
+        <div className="col-span-2 sm:col-span-1 md:col-span-2 lg:col-span-1 xl:col-span-1 flex justify-end">
+          <FolderOverflowMenu
+            folder={folder}
+            additionalActions={additionalActions}
+            insertAdditionalActionsAfter={insertAdditionalActionsAfter}
+            triggerLabel="More actions"
+            trigger={
+              <button
+                className="p-1.5 sm:p-2 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
+                aria-label={`More actions for ${folder.name}`}
+                onPointerDown={handleMenuPointerDown}
+                onClick={handleMenuClick}
+              >
+                <MoreVerticalIcon size={16} className="text-muted-foreground" />
+              </button>
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-list.tsx
@@ -143,6 +143,21 @@ export const FolderItemList: React.FC<FolderItemListProps> = ({
     }
   };
 
+  /**
+   * The keyboard's way in.
+   *
+   * Radix opens the menu from onKeyDown and calls preventDefault, which stops
+   * the browser synthesising the click the mouse path selects on - so tabbing
+   * to the button and pressing Enter opened a menu over an unselected row, and
+   * the toolbar never appeared to say what it would act on. Same keys Radix
+   * itself opens on.
+   */
+  const handleMenuKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'ArrowDown') return;
+
+    selectItem(folder, 'folder', index, false, false, allItems);
+  };
+
   const handleMenuClick = (event: React.MouseEvent) => {
     // The row opens the folder on click, so the click that opened the menu must
     // not reach it.
@@ -218,6 +233,7 @@ export const FolderItemList: React.FC<FolderItemListProps> = ({
                 className="p-1.5 sm:p-2 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
                 aria-label={`More actions for ${folder.name}`}
                 onPointerDown={handleMenuPointerDown}
+                onKeyDown={handleMenuKeyDown}
                 onClick={handleMenuClick}
               >
                 <MoreVerticalIcon size={16} className="text-muted-foreground" />

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
@@ -55,6 +55,21 @@ export function FolderItemMobile({
     }
   };
 
+  /**
+   * The keyboard's way in.
+   *
+   * Radix opens the menu from onKeyDown and calls preventDefault, which stops
+   * the browser synthesising the click the mouse path selects on - so tabbing
+   * to the button and pressing Enter opened a menu over an unselected row, and
+   * the toolbar never appeared to say what it would act on. Same keys Radix
+   * itself opens on.
+   */
+  const handleMenuKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'ArrowDown') return;
+
+    selectItem(folder, 'folder', index, false, false, allFolders);
+  };
+
   const handleMenuClick = (event: React.MouseEvent) => {
     // Still load-bearing after the selection moved off it: the row opens the
     // item on click, so the click that opened the menu must not reach it.
@@ -219,6 +234,7 @@ export function FolderItemMobile({
           <button
             className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
             onPointerDown={handleMenuPointerDown}
+            onKeyDown={handleMenuKeyDown}
             onClick={handleMenuClick}
             aria-label={`More actions for ${folder.name}`}
           >

--- a/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
@@ -164,6 +164,21 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     }
   };
 
+  /**
+   * The keyboard's way in.
+   *
+   * Radix opens the menu from onKeyDown and calls preventDefault, which stops
+   * the browser synthesising the click the mouse path selects on - so tabbing
+   * to the button and pressing Enter opened a menu over an unselected row, and
+   * the toolbar never appeared to say what it would act on. Same keys Radix
+   * itself opens on.
+   */
+  const handleMenuKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'ArrowDown') return;
+
+    selectItem(folder, 'folder', index, false, false, allFolders);
+  };
+
   const handleMenuClick = (event: React.MouseEvent) => {
     // Still load-bearing after the selection moved off it: the row opens the
     // item on click, so the click that opened the menu must not reach it.
@@ -240,6 +255,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
               "
               aria-label={`More actions for ${folder.name}`}
               onPointerDown={handleMenuPointerDown}
+              onKeyDown={handleMenuKeyDown}
               onClick={handleMenuClick}
             >
               <MoreVerticalIcon size={16} />

--- a/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
@@ -245,3 +245,36 @@ describe('presses that do not open the menu do not select', () => {
     expect(selection()).toHaveLength(1);
   });
 });
+
+/**
+ * Opening the same menu from the keyboard has to select the same row.
+ *
+ * Radix opens on keydown and preventDefaults, so no click is synthesised and
+ * the mouse path never ran - a keyboard user got a menu over an unselected row
+ * with no toolbar to say what it would act on.
+ */
+describe('the keyboard opens the menu and selects too', () => {
+  it.each(['Enter', ' ', 'ArrowDown'])('selects on %s', (key) => {
+    render(<FolderItem folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.keyDown(menuButton('Reports'), { key });
+
+    expect(selection()).toHaveLength(1);
+  });
+
+  it('ignores keys that do not open the menu', () => {
+    render(<FolderItem folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.keyDown(menuButton('Reports'), { key: 'a' });
+
+    expect(selection()).toHaveLength(0);
+  });
+
+  it('selects a file row from the keyboard as well', () => {
+    render(<FileItemList file={file()} allFiles={[file()]} />);
+
+    fireEvent.keyDown(menuButton('budget.xlsx'), { key: 'Enter' });
+
+    expect(selection()).toHaveLength(1);
+  });
+});

--- a/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
@@ -15,7 +15,7 @@
  * Radix opens the menu. On click the multi-select bar trailed the menu by the
  * whole length of the press.
  *
- * All five row components carry their own copy of the handler, so all five are
+ * All six row components carry their own copy of the handler, so all six are
  * covered. They started as copies of each other and drift is how this regresses.
  */
 
@@ -23,6 +23,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { FolderItem } from './folder-item';
 import { FolderItemMobile } from './folder-item-mobile';
+import { FolderItemList } from './folder-item-list';
 import { FileItemList } from './file-item-list';
 import { FileItemGrid } from './file-item-grid';
 import { FileItemMobile } from './file-item-mobile';
@@ -105,6 +106,17 @@ afterEach(() => {
 describe('a mouse click on the menu button selects the row', () => {
   it('selects a folder row', () => {
     render(<FolderItem folder={folder()} allFolders={[folder()]} />);
+
+    pressMenu(menuButton('Reports'));
+
+    expect(selection()).toHaveLength(1);
+    expect(useMultiSelectStore.getState().selectedType).toBe('folder');
+  });
+
+  // The row form folders take in the unified list view. It carries its own copy
+  // of the handler like the others, which is exactly why it is covered here.
+  it('selects a folder row in the list layout', () => {
+    render(<FolderItemList folder={folder()} allItems={[folder()]} />);
 
     pressMenu(menuButton('Reports'));
 

--- a/frontend/src/features/dashboard/components/views/drive/drive-list.tsx
+++ b/frontend/src/features/dashboard/components/views/drive/drive-list.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCurrentLayout } from '@/hooks/use-current-layout';
+import type { FileItem } from '@/features/dashboard/types/file';
+import type { Folder } from '@/features/dashboard/types/folder';
+import type { ProcessedDragData } from '@/features/upload/types/folder-upload-types';
+import type { DragDropTarget } from '@/features/upload/types/drag-drop-types';
+import type { SortDirection } from '@/features/dashboard/utils/sort-items';
+import { SuggestedFiles } from '../home/suggested-files';
+import { SuggestedFolders } from '../home/suggested-folders';
+import { FolderItemList } from '../../ui/items/folder-item-list';
+
+/**
+ * The drive's contents, in whichever shape the current layout calls for.
+ *
+ * List and grid want genuinely different groupings, and pretending otherwise is
+ * what produced the old arrangement: a block of folder cards with its own
+ * heading sitting above a file table with its own heading and its own sort, for
+ * what is really one directory.
+ *
+ * - **List** is one table. Folders and files share a header, a sort and an
+ *   index space, so a range can run from a folder into the files below it.
+ *   Folders lead, as they do everywhere that lists a directory.
+ * - **Grid** keeps the two sections. Folder cards and file cards are different
+ *   shapes, and interleaving them leaves a ragged grid for no gain.
+ *
+ * Home does not use this. It lists recent activity rather than a directory, so
+ * it keeps the sectioned components directly.
+ */
+
+interface DriveListProps {
+  folders: Folder[];
+  files: FileItem[];
+  onFolderClick?: (folder: Folder) => void;
+  onFolderMenuClick?: (folder: Folder, event: React.MouseEvent) => void;
+  onFileClick?: (file: FileItem) => void;
+  onFileAction?: (action: string, file: FileItem) => void;
+  onFilesDropped?: (processedData: ProcessedDragData) => void;
+  onFilesDroppedToFolder?: (processedData: ProcessedDragData, targetFolder: DragDropTarget) => void;
+  sortDirection: SortDirection;
+  onToggleSort: () => void;
+  canSortDescending: boolean;
+}
+
+export function DriveList({
+  folders,
+  files,
+  onFolderClick,
+  onFolderMenuClick,
+  onFileClick,
+  onFileAction,
+  onFilesDropped,
+  onFilesDroppedToFolder,
+  sortDirection,
+  onToggleSort,
+  canSortDescending,
+}: DriveListProps) {
+  const { layout } = useCurrentLayout();
+
+  if (layout !== 'list') {
+    return (
+      <>
+        <SuggestedFolders
+          folders={folders}
+          onFolderClick={onFolderClick}
+          onFolderMenuClick={onFolderMenuClick}
+          onFilesDroppedToFolder={onFilesDroppedToFolder}
+          className="mt-8"
+          title="Folders"
+        />
+        <SuggestedFiles
+          files={files}
+          onFileClick={onFileClick}
+          onFileAction={onFileAction}
+          onFilesDropped={onFilesDropped}
+          className="mt-8"
+          title="Files"
+        />
+      </>
+    );
+  }
+
+  /**
+   * One index space across both kinds, folders first.
+   *
+   * Shift-select ranges are computed by slicing this array between two indices,
+   * so the numbers a row reports have to describe its position in the table the
+   * user can actually see. Indexing each kind from zero would make a range from
+   * folder 1 to file 3 select the wrong four things.
+   */
+  const allItems = [...folders, ...files];
+
+  return (
+    <SuggestedFiles
+      files={files}
+      onFileClick={onFileClick}
+      onFileAction={onFileAction}
+      onFilesDropped={onFilesDropped}
+      className="mt-8"
+      // No section heading in the unified table: the page is already titled,
+      // and "Files" above a list that opens with folders would be a lie.
+      hideTitle
+      sortDirection={sortDirection}
+      onToggleSort={onToggleSort}
+      canSortDescending={canSortDescending}
+      allItems={allItems}
+      fileIndexOffset={folders.length}
+      leadingRows={folders.map((folder, index) => (
+        <FolderItemList
+          key={folder.Prefix ?? folder.name}
+          folder={folder}
+          index={index}
+          allItems={allItems}
+          onClick={onFolderClick}
+          onMenuClick={onFolderMenuClick}
+        />
+      ))}
+    />
+  );
+}

--- a/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
+++ b/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
@@ -385,7 +385,10 @@ function SortByNameButton({
         // w-full, not a negative-margin bleed: the hover surface should stop at
         // the column boundary, or it reaches under "Last modified" and the two
         // headings look like one control.
-        'group flex w-full items-center gap-1.5 rounded-t-lg px-2 py-1 -ml-2 -my-1 text-left text-sm font-medium transition-colors',
+        // -ml matches px so "Name" still lines up with the rows beneath it; the
+        // hover surface just starts further left. No negative -my here: it used to
+        // cancel the vertical padding outright, which is why the cell felt cramped.
+        'group flex w-full items-center gap-1.5 rounded-t-lg px-4 py-2 -ml-4 text-left text-sm font-medium transition-colors',
         blocked
           ? 'cursor-not-allowed opacity-60'
           : 'cursor-pointer hover:bg-secondary/70 hover:text-foreground'

--- a/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
+++ b/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
@@ -264,7 +264,7 @@ export function SuggestedFiles({
           ) : (
             <div>
               <div className="hidden sm:block space-y-1">
-                <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2 sm:gap-3 lg:gap-4 px-3 sm:px-4 py-3.5 text-sm font-medium text-muted-foreground border-b border-border/50">
+                <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2 sm:gap-3 lg:gap-4 px-3 sm:px-4 py-3.5 items-center text-sm font-medium text-muted-foreground border-b border-border/50">
                   <div className="col-span-2 sm:col-span-3 md:col-span-4 lg:col-span-4 xl:col-span-4">
                     {onToggleSort && sortDirection ? (
                       <SortByNameButton

--- a/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
+++ b/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
@@ -31,6 +31,15 @@ interface SuggestedFilesProps {
    * the one thing that page is for. Absent these props the heading is plain
    * text, exactly as it was.
    */
+  /**
+   * What this section is called.
+   *
+   * These components were written for Home and then reused wholesale by My
+   * Drive, heading and all - so the browse tree announced the literal contents
+   * of a bucket as "Suggested files". Nothing about a folder listing is a
+   * suggestion. Home keeps the suggesting; browse passes its own plain label.
+   */
+  title?: string;
   sortDirection?: SortDirection;
   onToggleSort?: () => void;
   /** False while the folder still has pages the listing has not fetched. */
@@ -47,6 +56,7 @@ export function SuggestedFiles({
   className = '',
   hideTitle = false,
   onFilesDropped,
+  title = 'Suggested files',
   sortDirection,
   onToggleSort,
   canSortDescending = true,
@@ -180,7 +190,7 @@ export function SuggestedFiles({
       )}
       {!hideTitle ? (
         <div className="flex items-center justify-between mb-3">
-          <AriaLabel label="Suggested files - Click to expand/collapse" position="top">
+          <AriaLabel label={`${title} - Click to expand/collapse`} position="top">
             <button
               className="
                 flex items-center cursor-pointer gap-2 p-2
@@ -205,7 +215,7 @@ export function SuggestedFiles({
                   d="M9 5l7 7-7 7"
                 />
               </svg>
-              Suggested files
+              {title}
             </button>
           </AriaLabel>
 
@@ -247,7 +257,7 @@ export function SuggestedFiles({
                     )}
                   </div>
                   <div className="hidden sm:block sm:col-span-2 md:col-span-2 lg:col-span-3 xl:col-span-3">
-                    Last Opened
+                    Last modified
                   </div>
                   <div className="hidden lg:block lg:col-span-2 xl:col-span-2">Owner</div>
                   <div className="hidden xl:block xl:col-span-2">Size</div>
@@ -347,12 +357,32 @@ function SortByNameButton({
         blocked ? 'This folder has more to load, so it cannot be sorted Z to A yet.' : undefined
       }
       className={cn(
-        'group -ml-1 inline-flex items-center gap-1 rounded px-1 py-0.5 font-medium transition-colors',
-        blocked ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:text-foreground'
+        // Fills the column rather than wrapping the word. A target the size of
+        // the label is a target you have to aim at; the whole cell lighting up
+        // is what tells you the heading is pressable at all.
+        // w-full, not a negative-margin bleed: the hover surface should stop at
+        // the column boundary, or it reaches under "Last modified" and the two
+        // headings look like one control.
+        'group flex w-full items-center gap-1.5 rounded-t-lg px-2 py-1.5 -ml-2 text-left font-medium transition-colors',
+        blocked
+          ? 'cursor-not-allowed opacity-60'
+          : 'cursor-pointer hover:bg-secondary/70 hover:text-foreground'
       )}
     >
       Name
-      <Arrow className="h-3.5 w-3.5" aria-hidden="true" />
+      {/* A filled disc, not a bare glyph. At this size a 1px stroke on a muted
+          foreground is nearly invisible against the header, which is how the
+          sort state ends up unreadable at a glance. */}
+      <span
+        className={cn(
+          'flex h-4 w-4 shrink-0 items-center justify-center rounded-full transition-colors',
+          blocked
+            ? 'bg-muted-foreground/30 text-background'
+            : 'bg-muted-foreground/70 text-background group-hover:bg-primary group-hover:text-primary-foreground'
+        )}
+      >
+        <Arrow className="h-3 w-3" strokeWidth={3} aria-hidden="true" />
+      </span>
     </button>
   );
 }

--- a/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
+++ b/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
@@ -10,6 +10,8 @@ import { FolderStructureProcessor } from '@/features/upload/utils/folder-structu
 import { ProcessedDragData } from '@/features/upload/types/folder-upload-types';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
+import { ArrowDown, ArrowUp } from 'lucide-react';
+import type { SortDirection } from '@/features/dashboard/utils/sort-items';
 
 interface SuggestedFilesProps {
   files: FileItem[];
@@ -21,6 +23,18 @@ interface SuggestedFilesProps {
   className?: string;
   hideTitle?: boolean;
   onFilesDropped?: (processedData: ProcessedDragData) => void;
+  /**
+   * Sorting, supplied only by the browse view.
+   *
+   * Home lists recent activity and is already ordered by when things were
+   * touched; offering to re-order it by name would be offering to throw away
+   * the one thing that page is for. Absent these props the heading is plain
+   * text, exactly as it was.
+   */
+  sortDirection?: SortDirection;
+  onToggleSort?: () => void;
+  /** False while the folder still has pages the listing has not fetched. */
+  canSortDescending?: boolean;
 }
 
 export function SuggestedFiles({
@@ -33,6 +47,9 @@ export function SuggestedFiles({
   className = '',
   hideTitle = false,
   onFilesDropped,
+  sortDirection,
+  onToggleSort,
+  canSortDescending = true,
 }: SuggestedFilesProps) {
   const { layout } = useCurrentLayout();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -219,7 +236,15 @@ export function SuggestedFiles({
               <div className="hidden sm:block space-y-1">
                 <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2 sm:gap-3 lg:gap-4 px-3 sm:px-4 py-2 text-xs font-medium text-muted-foreground border-b border-border/50">
                   <div className="col-span-2 sm:col-span-3 md:col-span-4 lg:col-span-4 xl:col-span-4">
-                    Name
+                    {onToggleSort && sortDirection ? (
+                      <SortByNameButton
+                        direction={sortDirection}
+                        canSortDescending={canSortDescending}
+                        onToggle={onToggleSort}
+                      />
+                    ) : (
+                      'Name'
+                    )}
                   </div>
                   <div className="hidden sm:block sm:col-span-2 md:col-span-2 lg:col-span-3 xl:col-span-3">
                     Last Opened
@@ -280,5 +305,54 @@ export function SuggestedFiles({
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * The Name heading, when the view offers sorting.
+ *
+ * Descending is refused while the folder is still truncated. S3 pages in key
+ * order, so a partial listing is a truthful beginning of the ascending answer
+ * but says nothing about the end - the last object in the bucket could belong
+ * at the top, and no amount of reordering what has arrived would reveal it.
+ * Disabled and explained rather than hidden, so the control does not appear to
+ * come and go as folders load.
+ */
+function SortByNameButton({
+  direction,
+  canSortDescending,
+  onToggle,
+}: {
+  direction: SortDirection;
+  canSortDescending: boolean;
+  onToggle: () => void;
+}) {
+  const ascending = direction === 'asc';
+  // Only descending needs the whole folder, so the control locks solely when
+  // the next press would ask for it.
+  const blocked = ascending && !canSortDescending;
+  const Arrow = ascending ? ArrowUp : ArrowDown;
+
+  return (
+    <button
+      type="button"
+      onClick={blocked ? undefined : onToggle}
+      disabled={blocked}
+      aria-label={
+        blocked
+          ? 'Sorted A to Z. Z to A needs the whole folder loaded.'
+          : `Sorted ${ascending ? 'A to Z' : 'Z to A'}. Sort ${ascending ? 'Z to A' : 'A to Z'}.`
+      }
+      title={
+        blocked ? 'This folder has more to load, so it cannot be sorted Z to A yet.' : undefined
+      }
+      className={cn(
+        'group -ml-1 inline-flex items-center gap-1 rounded px-1 py-0.5 font-medium transition-colors',
+        blocked ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:text-foreground'
+      )}
+    >
+      Name
+      <Arrow className="h-3.5 w-3.5" aria-hidden="true" />
+    </button>
   );
 }

--- a/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
+++ b/frontend/src/features/dashboard/components/views/home/suggested-files.tsx
@@ -4,6 +4,7 @@ import { useState, Fragment, useRef, useEffect } from 'react';
 import { LayoutToggle } from '@/features/dashboard/components/ui/layout-toggle';
 import { useCurrentLayout } from '@/hooks/use-current-layout';
 import type { FileItem } from '@/features/dashboard/types/file';
+import type { Folder } from '@/features/dashboard/types/folder';
 import { FileItemGrid, FileItemList, FileItemMobile } from '../../ui';
 import { cn } from '@/shared/utils/utils';
 import { FolderStructureProcessor } from '@/features/upload/utils/folder-structure-processor';
@@ -40,6 +41,22 @@ interface SuggestedFilesProps {
    * suggestion. Home keeps the suggesting; browse passes its own plain label.
    */
   title?: string;
+  /**
+   * Rows rendered above the files, under the same header.
+   *
+   * How the list view shows one directory instead of two: DriveList hands the
+   * folder rows in here rather than stacking a second table above this one.
+   * Absent - on Home, and in grid layout - nothing changes.
+   */
+  leadingRows?: React.ReactNode;
+  /**
+   * How many rows precede the files, so a file's index describes its place in
+   * the table rather than in the files array. Shift-select slices `allItems` by
+   * these numbers, so being off by the folder count selects the wrong rows.
+   */
+  fileIndexOffset?: number;
+  /** Folders and files together, the range a shift-select can span. */
+  allItems?: (FileItem | Folder)[];
   sortDirection?: SortDirection;
   onToggleSort?: () => void;
   /** False while the folder still has pages the listing has not fetched. */
@@ -57,6 +74,9 @@ export function SuggestedFiles({
   hideTitle = false,
   onFilesDropped,
   title = 'Suggested files',
+  leadingRows,
+  fileIndexOffset = 0,
+  allItems,
   sortDirection,
   onToggleSort,
   canSortDescending = true,
@@ -244,7 +264,7 @@ export function SuggestedFiles({
           ) : (
             <div>
               <div className="hidden sm:block space-y-1">
-                <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2 sm:gap-3 lg:gap-4 px-3 sm:px-4 py-2 text-xs font-medium text-muted-foreground border-b border-border/50">
+                <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2 sm:gap-3 lg:gap-4 px-3 sm:px-4 py-3.5 text-sm font-medium text-muted-foreground border-b border-border/50">
                   <div className="col-span-2 sm:col-span-3 md:col-span-4 lg:col-span-4 xl:col-span-4">
                     {onToggleSort && sortDirection ? (
                       <SortByNameButton
@@ -264,13 +284,15 @@ export function SuggestedFiles({
                   <div className="col-span-2 sm:col-span-1 md:col-span-2 lg:col-span-1 xl:col-span-1"></div>
                 </div>
 
+                {leadingRows}
+
                 {files.map((file, index) => (
                   <Fragment key={file.Key}>
                     <FileItemList
                       file={file}
-                      allFiles={files}
+                      allFiles={allItems ?? files}
                       _onAction={handleFileAction}
-                      index={index}
+                      index={index + fileIndexOffset}
                     />
                     {index < files.length - 1 && (
                       <div className="mx-4" aria-hidden="true">
@@ -363,7 +385,7 @@ function SortByNameButton({
         // w-full, not a negative-margin bleed: the hover surface should stop at
         // the column boundary, or it reaches under "Last modified" and the two
         // headings look like one control.
-        'group flex w-full items-center gap-1.5 rounded-t-lg px-2 py-1.5 -ml-2 text-left font-medium transition-colors',
+        'group flex w-full items-center gap-1.5 rounded-t-lg px-2 py-1 -ml-2 -my-1 text-left text-sm font-medium transition-colors',
         blocked
           ? 'cursor-not-allowed opacity-60'
           : 'cursor-pointer hover:bg-secondary/70 hover:text-foreground'

--- a/frontend/src/features/dashboard/components/views/home/suggested-folders.tsx
+++ b/frontend/src/features/dashboard/components/views/home/suggested-folders.tsx
@@ -19,6 +19,8 @@ interface SuggestedFoldersProps {
   isLoadingMore?: boolean;
   className?: string;
   hideTitle?: boolean;
+  /** See the note on SuggestedFiles: browse is not showing suggestions. */
+  title?: string;
   onFilesDroppedToFolder?: (processedData: ProcessedDragData, targetFolder: DragDropTarget) => void;
 }
 
@@ -31,6 +33,7 @@ export const SuggestedFolders: React.FC<SuggestedFoldersProps> = ({
   isLoadingMore = false,
   className = '',
   hideTitle = false,
+  title = 'Suggested folders',
   onFilesDroppedToFolder,
 }) => {
   const [isExpanded, setIsExpanded] = useState(true);
@@ -93,7 +96,7 @@ export const SuggestedFolders: React.FC<SuggestedFoldersProps> = ({
                   />
                 </svg>
               </div>
-              <span className="text-muted-foreground">Suggested Folders</span>
+              <span className="text-muted-foreground">{title}</span>
             </div>
           </button>
         </AriaLabel>

--- a/frontend/src/features/dashboard/stores/use-multi-select-store.test.ts
+++ b/frontend/src/features/dashboard/stores/use-multi-select-store.test.ts
@@ -168,33 +168,59 @@ describe('shift+click range', () => {
 describe('mixing files and folders', () => {
   const folders = [folder('one/'), folder('two/')];
 
-  it('discards a file selection when a folder is clicked', () => {
+  it('replaces the selection on a plain click, whatever was held before', () => {
     store().selectItem(files[0]!, 'file', 0, false, false, files);
     store().selectItem(files[1]!, 'file', 1, true, false, files);
 
     store().selectItem(folders[0]!, 'folder', 0, false, false, folders);
 
-    // Bulk actions differ for files and folders, so the two cannot mix.
+    // A click with no modifier still means "just this one" - mixing is what
+    // ctrl and shift are for.
     expect(keysOf()).toEqual(['one/']);
     expect(store().selectedType).toBe('folder');
   });
 
-  it('discards the old type even when ctrl is held', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
+  // The list view shows folders and files as one table, so a selection that
+  // spans both is an ordinary thing to build rather than a rule to refuse.
+  const combined = [folders[0]!, folders[1]!, files[0]!, files[1]!];
 
-    store().selectItem(folders[0]!, 'folder', 0, true, false, folders);
+  it('adds a folder to a file selection when ctrl is held', () => {
+    store().selectItem(files[0]!, 'file', 2, false, false, combined);
 
-    expect(keysOf()).toEqual(['one/']);
+    store().selectItem(folders[0]!, 'folder', 0, true, false, combined);
+
+    expect(keysOf().sort()).toEqual(['one/', 'a.txt'].sort());
+    expect(store().selectedType).toBe('mixed');
   });
 
-  it('discards the old type even when shift is held', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
+  it('carries a shift range across the folder-file boundary', () => {
+    store().selectItem(folders[1]!, 'folder', 1, false, false, combined);
 
-    store().selectItem(folders[1]!, 'folder', 1, false, true, folders);
+    store().selectItem(files[0]!, 'file', 2, false, true, combined);
 
-    // The type check runs before the range branch, so no cross-type range is
-    // ever built.
-    expect(keysOf()).toEqual(['two/']);
+    // Everything between the anchor and the target, whichever kind it is.
+    expect(keysOf()).toEqual(['two/', 'a.txt']);
+    expect(store().selectedType).toBe('mixed');
+  });
+
+  // Callers ask "is this files only" to decide whether open, download and share
+  // apply. Mixed has to answer no without pretending to be one or the other.
+  it('reports a single kind as that kind, not as mixed', () => {
+    store().selectItem(folders[0]!, 'folder', 0, false, false, combined);
+    store().selectItem(folders[1]!, 'folder', 1, true, false, combined);
+
+    expect(store().selectedType).toBe('folder');
+  });
+
+  it('falls back to the remaining kind when the odd one out is removed', () => {
+    store().selectItem(folders[0]!, 'folder', 0, false, false, combined);
+    store().selectItem(files[0]!, 'file', 2, true, false, combined);
+    expect(store().selectedType).toBe('mixed');
+
+    // Ctrl-clicking the folder again drops it, leaving only files behind.
+    store().selectItem(folders[0]!, 'folder', 0, true, false, combined);
+
+    expect(store().selectedType).toBe('file');
   });
 
   it('identifies folders by prefix', () => {

--- a/frontend/src/features/dashboard/stores/use-multi-select-store.ts
+++ b/frontend/src/features/dashboard/stores/use-multi-select-store.ts
@@ -5,8 +5,14 @@
  * - Single click to select items
  * - Ctrl+Click to toggle selection
  * - Shift+Click to select range from last clicked item (keeps only items in the range)
- * - Files and folders can't be selected together
+ * - Files and folders can be selected together
  * - ESC key or clicking outside (single item only) clears selection
+ *
+ * Mixed selection exists because the list view shows folders and files as one
+ * table. Refusing to hold both meant a shift-drag down that table silently threw
+ * away everything above the boundary, which reads as a bug rather than a rule.
+ * The index passed in is therefore an index into that combined list, not into
+ * whichever half the item came from.
  */
 
 import { create } from 'zustand';
@@ -16,9 +22,17 @@ import { Folder } from '../types/folder';
 type SelectableItem = FileItem | Folder;
 type ItemType = 'file' | 'folder';
 
+/**
+ * What is currently held. `mixed` is the honest answer for a selection spanning
+ * both, and callers already treat anything that is not `file` as "not files
+ * only" - the toolbar greys open, download and share on exactly that test, and
+ * leaves delete enabled, which is the behaviour a mixed selection wants.
+ */
+type SelectionType = ItemType | 'mixed';
+
 interface MultiSelectState {
   selectedItems: SelectableItem[];
-  selectedType: ItemType | null;
+  selectedType: SelectionType | null;
   lastSelectedIndex: number | null;
 
   // Actions
@@ -34,6 +48,26 @@ interface MultiSelectState {
   isSelected: (item: SelectableItem) => boolean;
   getSelectionCount: () => number;
 }
+
+const isFolder = (item: SelectableItem): boolean => 'Prefix' in item && Boolean(item.Prefix);
+
+/**
+ * Read back off the items rather than tracked separately.
+ *
+ * A stored type and a stored list are two records of one fact, and the moment a
+ * range spans both kinds they disagree. Deriving it means the answer cannot
+ * drift from what is actually held.
+ */
+const typeOf = (items: SelectableItem[]): SelectionType | null => {
+  if (items.length === 0) return null;
+
+  const folders = items.filter(isFolder).length;
+
+  if (folders === 0) return 'file';
+  if (folders === items.length) return 'folder';
+
+  return 'mixed';
+};
 
 const getItemKey = (item: SelectableItem): string => {
   if ('Key' in item && item.Key) {
@@ -53,25 +87,17 @@ export const useMultiSelectStore = create<MultiSelectState>((set, get) => ({
   selectItem: (item, type, index, ctrlKey, shiftKey, allItems) => {
     const state = get();
 
-    // If selecting a different type, clear selection
-    if (state.selectedType && state.selectedType !== type) {
-      set({
-        selectedItems: [item],
-        selectedType: type,
-        lastSelectedIndex: index,
-      });
-      return;
-    }
-
-    // Shift+Click: Select range from last clicked item to current item
-    if (shiftKey && state.lastSelectedIndex !== null && state.selectedType === type) {
+    // Shift+Click: Select range from last clicked item to current item.
+    // No longer gated on the anchor matching this item's type - the range runs
+    // over the combined list, so crossing from folders into files is ordinary.
+    if (shiftKey && state.lastSelectedIndex !== null) {
       const start = Math.min(state.lastSelectedIndex, index);
       const end = Math.max(state.lastSelectedIndex, index);
       const rangeItems = allItems.slice(start, end + 1);
 
       set({
         selectedItems: rangeItems,
-        selectedType: type,
+        selectedType: typeOf(rangeItems),
         // Don't update lastSelectedIndex - keep the anchor point fixed
       });
       return;
@@ -91,14 +117,15 @@ export const useMultiSelectStore = create<MultiSelectState>((set, get) => ({
         );
         set({
           selectedItems: newSelection,
-          selectedType: newSelection.length > 0 ? type : null,
+          selectedType: typeOf(newSelection),
           lastSelectedIndex: index,
         });
       } else {
         // Add to selection
+        const newSelection = [...state.selectedItems, item];
         set({
-          selectedItems: [...state.selectedItems, item],
-          selectedType: type,
+          selectedItems: newSelection,
+          selectedType: typeOf(newSelection),
           lastSelectedIndex: index,
         });
       }

--- a/frontend/src/features/dashboard/utils/sort-items.test.ts
+++ b/frontend/src/features/dashboard/utils/sort-items.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The ordering people mean by "alphabetical", which is not the one S3 gives.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sortByName, canSortDescending } from './sort-items';
+
+const named = (...names: string[]) => names.map((name) => ({ name }));
+const names = (items: { name: string }[]) => items.map((i) => i.name);
+
+describe('sortByName', () => {
+  it('orders ascending', () => {
+    expect(names(sortByName(named('cherry', 'apple', 'banana'), 'asc'))).toEqual([
+      'apple',
+      'banana',
+      'cherry',
+    ]);
+  });
+
+  it('orders descending', () => {
+    expect(names(sortByName(named('apple', 'cherry', 'banana'), 'desc'))).toEqual([
+      'cherry',
+      'banana',
+      'apple',
+    ]);
+  });
+
+  // The reason ascending is sorted at all rather than left as S3 returned it.
+  // In UTF-8 binary order every capital precedes every lowercase, so the raw
+  // listing puts Budget.xlsx above annual.pdf.
+  it('folds case instead of banishing lowercase below every capital', () => {
+    expect(names(sortByName(named('annual.pdf', 'Budget.xlsx', 'contract.doc'), 'asc'))).toEqual([
+      'annual.pdf',
+      'Budget.xlsx',
+      'contract.doc',
+    ]);
+  });
+
+  it('reads digit runs as numbers', () => {
+    expect(names(sortByName(named('file10.txt', 'file2.txt', 'file1.txt'), 'asc'))).toEqual([
+      'file1.txt',
+      'file2.txt',
+      'file10.txt',
+    ]);
+  });
+
+  // Two names differing only in case tie under a case-folding collator. Sort is
+  // stable, so they hold their position rather than swapping on each render.
+  it('leaves tied names in the order they arrived', () => {
+    const input = named('Report.pdf', 'report.pdf');
+
+    expect(names(sortByName(input, 'asc'))).toEqual(['Report.pdf', 'report.pdf']);
+  });
+
+  it('does not disturb the array it was given', () => {
+    const input = named('cherry', 'apple');
+    sortByName(input, 'asc');
+
+    expect(names(input)).toEqual(['cherry', 'apple']);
+  });
+
+  it('handles an empty list', () => {
+    expect(sortByName([], 'asc')).toEqual([]);
+  });
+});
+
+describe('canSortDescending', () => {
+  // Descending needs the whole folder: the last object in the bucket could
+  // belong at the top, and nothing in a partial listing reveals that.
+  it('is refused while the folder is still truncated', () => {
+    expect(canSortDescending(true)).toBe(false);
+  });
+
+  it('is allowed once the folder is complete', () => {
+    expect(canSortDescending(false)).toBe(true);
+  });
+
+  // A folder that never reported truncation is small enough to have arrived
+  // whole in one page.
+  it('treats an unknown truncation as complete', () => {
+    expect(canSortDescending(undefined)).toBe(true);
+  });
+});

--- a/frontend/src/features/dashboard/utils/sort-items.ts
+++ b/frontend/src/features/dashboard/utils/sort-items.ts
@@ -1,0 +1,49 @@
+/**
+ * Ordering the file and folder lists by name.
+ *
+ * S3 hands listings back in UTF-8 binary order, which is *nearly* alphabetical
+ * and not quite: every capital sorts before every lowercase, so `Budget.xlsx`
+ * lands above `annual.pdf`. Nobody reads that as sorted. The listing also has no
+ * notion that `file10` should follow `file2` rather than precede it.
+ *
+ * So both directions are sorted here rather than only the reversed one, using a
+ * collator that folds case and reads digit runs as numbers - the order people
+ * mean when they say alphabetical.
+ */
+
+export type SortDirection = 'asc' | 'desc';
+
+/** Anything the drive lists. Files and folders both carry a display name. */
+interface Named {
+  name: string;
+}
+
+/**
+ * Built once. `Intl.Collator` is expensive to construct and a folder of a
+ * thousand objects would otherwise build one per comparison.
+ *
+ * `sensitivity: 'base'` folds case and accents, so `Report` and `report` tie
+ * rather than one being banished below the whole lowercase alphabet. Ties keep
+ * the order S3 gave them, because `Array.prototype.sort` is stable - two files
+ * differing only in case stay put instead of swapping on every re-render.
+ */
+const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
+
+/** A copy of `items`, ordered by name. Never sorts in place. */
+export function sortByName<T extends Named>(items: readonly T[], direction: SortDirection): T[] {
+  const sorted = [...items].sort((a, b) => collator.compare(a.name, b.name));
+
+  return direction === 'asc' ? sorted : sorted.reverse();
+}
+
+/**
+ * Whether a folder can honestly be sorted at all.
+ *
+ * Descending needs every page: the last object in the bucket could belong at
+ * the top, and there is no way to know it exists without fetching it. Ascending
+ * is safe on a partial listing because S3 pages in key order, so what has
+ * arrived is already the beginning of the answer.
+ */
+export function canSortDescending(isTruncated: boolean | undefined): boolean {
+  return isTruncated !== true;
+}

--- a/frontend/src/features/folder-navigation/folder-navigation.ts
+++ b/frontend/src/features/folder-navigation/folder-navigation.ts
@@ -1,22 +1,24 @@
 export interface FolderNavigationParams {
   prefix?: string;
-  key?: string;
   maxKeys?: number;
   continuationToken?: string;
 }
 
 /**
  * Generate URL for folder navigation with query parameters
+ *
+ * There used to be a `key` parameter alongside `prefix`, carrying the folder's
+ * own name. It was never read for its value - the breadcrumb only tested
+ * whether it existed - and every value it could hold is the last segment of the
+ * prefix sitting beside it. So it duplicated data that is transmitted on every
+ * navigation, for nothing, in an app whose whole privacy story is about keeping
+ * user paths out of query strings.
  */
 export function generateFolderUrl(params: FolderNavigationParams): string {
   const urlParams = new URLSearchParams();
 
   if (params.prefix) {
     urlParams.set('prefix', params.prefix);
-  }
-
-  if (params.key) {
-    urlParams.set('key', params.key);
   }
 
   if (params.maxKeys) {
@@ -36,7 +38,6 @@ export function generateFolderUrl(params: FolderNavigationParams): string {
 export function parseFolderParams(searchParams: URLSearchParams): FolderNavigationParams {
   return {
     prefix: searchParams.get('prefix') || undefined,
-    key: searchParams.get('key') || undefined,
     maxKeys: searchParams.get('maxKeys') ? parseInt(searchParams.get('maxKeys')!) : undefined,
     continuationToken: searchParams.get('token') || undefined,
   };
@@ -90,10 +91,7 @@ export function buildFolderClickUrl(
       ? `${folderName}/`
       : `${currentPrefix}${folderName}/`;
 
-  return generateFolderUrl({
-    prefix: newPrefix,
-    key: folderName, // Use folder name as key as per backend requirement
-  });
+  return generateFolderUrl({ prefix: newPrefix });
 }
 
 /**
@@ -102,7 +100,6 @@ export function buildFolderClickUrl(
 export function buildBreadcrumbClickUrl(pathSegments: string[], targetIndex: number): string {
   const targetSegments = pathSegments.slice(0, targetIndex + 1);
   const prefix = pathSegmentsToPrefix(targetSegments);
-  const key = targetSegments.length > 0 ? targetSegments[targetSegments.length - 1] : undefined;
 
-  return generateFolderUrl({ prefix, key });
+  return generateFolderUrl({ prefix });
 }

--- a/frontend/src/features/upload/components/delete-recovery-banner.test.tsx
+++ b/frontend/src/features/upload/components/delete-recovery-banner.test.tsx
@@ -83,7 +83,7 @@ function standingIn(prefix: string) {
       },
       [prefix]: { folders: [], files: [], isTruncated: false },
     },
-    status: { '/': 'ready', [prefix]: 'ready' },
+    directory: { '/': { status: 'ready' }, [prefix]: { status: 'ready' } },
   });
 }
 
@@ -374,7 +374,7 @@ describe('recovering from inside the folder', () => {
           isTruncated: false,
         },
       },
-      status: { '/': 'ready' },
+      directory: { '/': { status: 'ready' } },
     });
     listFromPrefix.mockResolvedValue(['a.txt']);
     render(<DeleteRecoveryBanner />);

--- a/frontend/src/hooks/use-sort-preference.ts
+++ b/frontend/src/hooks/use-sort-preference.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { SortDirection } from '@/features/dashboard/utils/sort-items';
+
+const SORT_STORAGE_KEY = 'opndrive-sort-preference';
+const DEFAULT_DIRECTION: SortDirection = 'asc';
+
+/**
+ * Shared across every instance, the same way the layout preference is.
+ *
+ * The header renders the control and the page renders the rows, and they are
+ * not in a parent-child relationship, so a hook holding only component state
+ * would let the two disagree about which way the list is sorted.
+ */
+let globalDirection: SortDirection = DEFAULT_DIRECTION;
+const listeners = new Set<(direction: SortDirection) => void>();
+
+function isDirection(value: unknown): value is SortDirection {
+  return value === 'asc' || value === 'desc';
+}
+
+/** The direction the file list is sorted in, remembered between visits. */
+export function useSortPreference() {
+  const [direction, setDirectionState] = useState<SortDirection>(globalDirection);
+
+  useEffect(() => {
+    const update = (next: SortDirection) => setDirectionState(next);
+    listeners.add(update);
+
+    return () => {
+      listeners.delete(update);
+    };
+  }, []);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(SORT_STORAGE_KEY);
+
+      if (isDirection(saved)) {
+        globalDirection = saved;
+        setDirectionState(saved);
+        listeners.forEach((listener) => listener(saved));
+      }
+    } catch (error) {
+      // A browser refusing storage is not a reason to break sorting; it just
+      // means the choice lasts as long as the tab does.
+      console.warn('Failed to read the sort preference:', error);
+    }
+  }, []);
+
+  const setDirection = useCallback((next: SortDirection) => {
+    try {
+      localStorage.setItem(SORT_STORAGE_KEY, next);
+    } catch (error) {
+      console.warn('Failed to save the sort preference:', error);
+    }
+
+    // Outside the try on purpose: the list must reorder even where the write
+    // failed, or the control looks broken in a private window.
+    globalDirection = next;
+    setDirectionState(next);
+    listeners.forEach((listener) => listener(next));
+  }, []);
+
+  return { direction, setDirection };
+}

--- a/frontend/src/lib/privacy/storage-keys.ts
+++ b/frontend/src/lib/privacy/storage-keys.ts
@@ -70,6 +70,13 @@ export const STORAGE_KEYS: readonly StorageKeyEntry[] = [
     lifetime: 'Until you clear it',
   },
   {
+    key: 'opndrive-sort-preference',
+    mechanisms: ['localStorage'],
+    category: 'necessary',
+    purpose: 'Whether the file list is sorted A to Z or Z to A',
+    lifetime: 'Until you clear it',
+  },
+  {
     key: 'delete-recovery-storage',
     mechanisms: ['localStorage'],
     category: 'necessary',

--- a/frontend/src/shared/utils/time-utils.ts
+++ b/frontend/src/shared/utils/time-utils.ts
@@ -70,3 +70,18 @@ export function formatTimeWithTooltip(date: Date | undefined): {
 
   return { display, tooltip };
 }
+
+/**
+ * What a row shows in a date column when the listing carries no date.
+ *
+ * S3 has no creation date to fall back on - objects carry `LastModified` and
+ * nothing else - and folders are not objects at all. A delimited listing
+ * returns them as `CommonPrefixes`, which hold the prefix string and no
+ * metadata whatsoever, so there is nothing to read even when a folder marker
+ * object exists in the bucket.
+ *
+ * So the rule is the same for both kinds: print the date when the listing
+ * actually has one, and say "not applicable" when it does not, the way the size
+ * column already does for folders. A blank cell just looks broken.
+ */
+export const NO_DATE = '—';


### PR DESCRIPTION
Makes My Drive's list view one table instead of two, sortable by name, and clears out a set of long-standing rough edges found along the way.

## Sorting

Click **Name** in the list header to sort A→Z / Z→A. The choice is remembered between visits.

Both directions are sorted explicitly. I'd assumed A→Z was free because S3 returns keys in order — it isn't. S3 sorts by UTF-8 binary, where every capital precedes every lowercase, so the raw listing puts `Budget.xlsx` above `annual.pdf`. Both directions now use a collator that folds case and reads digit runs as numbers, so `file2` comes before `file10`.

Z→A is disabled while a folder is still truncated, with a tooltip saying why: S3 pages in key order, so a partial listing is a truthful beginning of the ascending answer but says nothing about what belongs at the top.

Sorting runs before the 100-row chunking — after it, "sort A→Z" would have meant "sort the first hundred".

## One table

Folders and files now share one table in list view, as Drive does. Grid view keeps the two sections, because folder and file cards are different shapes and interleaving them only makes the grid ragged.

`DriveList` owns that decision. Folders needed a row form to sit in the table, so `FolderItemList` renders one into the same column grid a file row uses, with an em dash for size (S3 reports none, and totalling the objects underneath would cost a LIST per row).

Selection had to follow. The store refused to hold both kinds, which in one table meant a shift-drag past the last folder silently dropped everything above it. It now holds a mixed selection and reports `'mixed'`, which the toolbar already reads correctly — open/download/share grey out, delete stays enabled.

## Naming

My Drive called its own contents "Suggested files" and labelled the modified date "Last Opened", something S3 never records. Sections are named by the page showing them now, and My Drive keeps naming them inside folders rather than only at the root. Header text is larger with real vertical padding.

## Cleanups

- One red: `--danger` held byte-identical values to `--destructive`, 3 uses against 54. Folded in.
- Dropped the `key` query param — it carried a folder's own name beside a prefix that already ended in it, and nothing read it for its value.
- `robots.txt` had the same rule three times when `*` already covered them.
- R2's endpoint field offered a literal `{{accountId}}` as its placeholder.
- **Provider pages no longer bounce a signed-in visitor to the dashboard.** They exist to be found in search, and redirecting meant the page Google indexed was the one page a returning user never saw — and anyone with a bucket connected couldn't reach the form for a second one.
- Opening a row menu from the keyboard now selects the row, as the mouse does. Radix opens on keydown and preventDefaults, so no click was ever synthesised.
- The drive store held status and failure in four parallel maps keyed by the same prefix, with nothing forcing them to agree — that had already caused one bug. Now one value per key.

## Checking it

List view in My Drive: folders and files in one table, click **Name** to flip direction, arrow follows, survives a reload. A folder with mixed-case names is the interesting one. Ctrl-click a folder and a file together — open/download/share should grey out, delete shouldn't. Tab to a row's three-dot menu, press Enter: the row should select.

1256 tests pass, typecheck clean, 0 lint errors, clean build. Not yet checked in a browser.