### PR TITLE
feat: add bucket crud operations and tagging functionality to s3-api

### DIFF
--- a/.changeset/buckets.md
+++ b/.changeset/buckets.md
@@ -1,0 +1,12 @@
+---
+'@opndrive/s3-api': patch
+---
+
+Add bucket create/delete and tagging APIs.
+
+- `createBucket(bucketName)` - creates a bucket, handling the `us-east-1`
+  location-constraint quirk automatically.
+- `deleteBucket(bucketName)` - deletes a bucket. Never empties it first; returns
+  `{ status: 'not-empty' }` instead of throwing if the bucket still has content.
+- `getBucketTags`, `setBucketTags` (full replace), `addOrUpdateBucketTags`
+  (merge), `removeBucketTags` (subtract) - full CRUD for bucket tags.

--- a/s3-api/CHANGELOG.md
+++ b/s3-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.1.0
 
+- **Empty Bump:** For version sync only. No Major changes
+
 ## [3.0.0] - 2026-08-02
 
 ### Changed

--- a/s3-api/src/core/index.ts
+++ b/s3-api/src/core/index.ts
@@ -9,21 +9,28 @@ import {
   S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import {
+  AddOrUpdateBucketTagsParams,
+  BucketTag,
+  CreateBucketResult,
   Credentials,
   DeleteBatchResult,
+  DeleteBucketResult,
   DirectoryStructure,
   DownloadFileParams,
+  GetBucketTagsResult,
   ListBucketParams,
   ListBucketResult,
   logTypes,
   MoveFileParams,
   MultipartUploadParams,
   PresignedUploadParams,
+  RemoveBucketTagsParams,
   RenameFileParams,
   RenameFolderParams,
   RenameFolderResult,
   SearchParams,
   SearchResult,
+  SetBucketTagsParams,
   SignedUrlParams,
   userTypes,
 } from './types.js';
@@ -146,6 +153,18 @@ export abstract class BaseS3ApiProvider {
   abstract getRegion(): string;
 
   abstract getBuckets(params: ListBucketParams): Promise<ListBucketResult>;
+
+  abstract createBucket(bucketName: string): Promise<CreateBucketResult>;
+
+  abstract deleteBucket(bucketName: string): Promise<DeleteBucketResult>;
+
+  abstract getBucketTags(bucketName: string): Promise<GetBucketTagsResult>;
+
+  abstract setBucketTags(params: SetBucketTagsParams): Promise<void>;
+
+  abstract addOrUpdateBucketTags(params: AddOrUpdateBucketTagsParams): Promise<BucketTag[]>;
+
+  abstract removeBucketTags(params: RemoveBucketTagsParams): Promise<BucketTag[]>;
 
   abstract getS3Client(): S3Client;
 }

--- a/s3-api/src/core/types.ts
+++ b/s3-api/src/core/types.ts
@@ -191,6 +191,61 @@ export interface ListBucketResult {
   isTruncated?: boolean;
 }
 
+export interface CreateBucketResult {
+  status: 'completed';
+  bucketName: string;
+  /** Convenience for `status === 'completed'`. */
+  completed: true;
+}
+
+/**
+ * - `completed`  - the bucket was empty and has been deleted.
+ * - `not-empty`  - S3 refused because the bucket still has objects, versions,
+ *   or delete markers. Nothing was touched - deleteBucket never empties a
+ *   bucket itself, callers must do that first (e.g. via deleteBatch).
+ */
+export type DeleteBucketStatus = 'completed' | 'not-empty';
+
+export interface DeleteBucketResult {
+  status: DeleteBucketStatus;
+  bucketName: string;
+  /** Convenience for `status === 'completed'`. */
+  completed: boolean;
+}
+
+/** A single tag on a bucket. */
+export interface BucketTag {
+  key: string;
+  value: string;
+}
+
+export interface GetBucketTagsResult {
+  tags: BucketTag[];
+}
+
+export interface SetBucketTagsParams {
+  bucketName: string;
+  /**
+   * Full replacement tag set - mirrors S3's PutBucketTagging semantics
+   * exactly, this REPLACES every tag currently on the bucket, it does not
+   * merge. Pass [] to remove every tag. Use addOrUpdateBucketTags /
+   * removeBucketTags for merge/subtract semantics.
+   */
+  tags: BucketTag[];
+}
+
+export interface AddOrUpdateBucketTagsParams {
+  bucketName: string;
+  /** Tags to merge in. Existing keys not listed here are preserved; keys listed here overwrite the existing value. */
+  tags: BucketTag[];
+}
+
+export interface RemoveBucketTagsParams {
+  bucketName: string;
+  /** Keys to remove. Keys not present in the current tag set are silently ignored. */
+  keys: string[];
+}
+
 // Uploader
 
 export type UploadStatus = 'queued' | 'uploading' | 'paused' | 'completed' | 'failed' | 'cancelled';

--- a/s3-api/src/index.buckets.test.ts
+++ b/s3-api/src/index.buckets.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Bucket-level coverage for `BYOS3ApiProvider`: getBuckets, createBucket,
+ * deleteBucket, getBucketTags, setBucketTags, addOrUpdateBucketTags,
+ * removeBucketTags.
+ *
+ * These import the provider from source (`./index.js`), not from `dist/`, so
+ * coverage instruments the real files and a run never depends on a stale build.
+ *
+ * The S3 client is intercepted by `aws-sdk-client-mock`, so nothing here makes a
+ * network call. Environment credentials are loaded first, then replaced with
+ * deterministic fake credentials for the mocked client.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  ListBucketsCommand,
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  GetBucketTaggingCommand,
+  PutBucketTaggingCommand,
+  DeleteBucketTaggingCommand,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import dotenv from 'dotenv';
+import { BYOS3ApiProvider } from './index.js';
+import type { Credentials } from './core/types.js';
+
+dotenv.config();
+
+const s3Mock = mockClient(S3Client);
+
+const envCreds: Credentials = {
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+  bucketName: process.env.BUCKET_NAME ?? '',
+  prefix: '',
+  region: process.env.AWS_REGION ?? '',
+};
+
+const fakeCreds: Credentials = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  bucketName: 'test-bucket',
+  prefix: 'users/alice/',
+  region: 'us-east-1',
+};
+
+function makeApi(overrides: Partial<Credentials> = {}) {
+  return new BYOS3ApiProvider({ ...envCreds, ...fakeCreds, ...overrides }, 'BYO');
+}
+
+/** Builds an S3ServiceException with a given HTTP status, as the SDK would throw. */
+function s3Error(name: string, httpStatusCode: number) {
+  return new S3ServiceException({
+    name,
+    $fault: 'client',
+    $metadata: { httpStatusCode },
+    message: name,
+  });
+}
+
+beforeEach(() => {
+  s3Mock.reset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getBuckets', () => {
+  it('passes searchTerm through as Prefix and nextToken as ContinuationToken', async () => {
+    s3Mock.on(ListBucketsCommand).resolves({
+      Buckets: [{ Name: 'reports-2026' }],
+      ContinuationToken: 'page-2',
+    });
+
+    const result = await makeApi().getBuckets({ searchTerm: 'reports', nextToken: 'page-1' });
+
+    expect(s3Mock).toHaveReceivedCommandWith(ListBucketsCommand, {
+      Prefix: 'reports',
+      ContinuationToken: 'page-1',
+    });
+    expect(result).toEqual({
+      buckets: [{ Name: 'reports-2026' }],
+      totalBuckets: 1,
+      nextToken: 'page-2',
+      isTruncated: true,
+    });
+  });
+
+  it('lists all buckets when searchTerm is omitted', async () => {
+    s3Mock.on(ListBucketsCommand).resolves({
+      Buckets: [{ Name: 'bucket-a' }, { Name: 'bucket-b' }],
+    });
+
+    const result = await makeApi().getBuckets({ nextToken: undefined });
+
+    expect(result.buckets).toEqual([{ Name: 'bucket-a' }, { Name: 'bucket-b' }]);
+    expect(result.totalBuckets).toBe(2);
+  });
+
+  it('reports isTruncated: false and an empty list for a page with no buckets', async () => {
+    s3Mock.on(ListBucketsCommand).resolves({});
+
+    const result = await makeApi().getBuckets({ nextToken: undefined });
+
+    expect(result).toEqual({
+      buckets: [],
+      totalBuckets: 0,
+      nextToken: undefined,
+      isTruncated: false,
+    });
+  });
+
+  it('propagates a listing failure', async () => {
+    s3Mock.on(ListBucketsCommand).rejects(s3Error('AccessDenied', 403));
+
+    await expect(makeApi().getBuckets({ nextToken: undefined })).rejects.toThrow();
+  });
+});
+
+describe('createBucket', () => {
+  it('creates a us-east-1 bucket without a location constraint', async () => {
+    s3Mock.on(CreateBucketCommand).resolves({});
+
+    const result = await makeApi({ region: 'us-east-1' }).createBucket('reports-2026');
+
+    expect(s3Mock).toHaveReceivedCommandWith(CreateBucketCommand, { Bucket: 'reports-2026' });
+    expect(s3Mock.commandCalls(CreateBucketCommand)[0]!.args[0].input).not.toHaveProperty(
+      'CreateBucketConfiguration'
+    );
+    expect(result).toEqual({ status: 'completed', bucketName: 'reports-2026', completed: true });
+  });
+
+  it('creates a regional bucket with the region as LocationConstraint', async () => {
+    s3Mock.on(CreateBucketCommand).resolves({});
+
+    const result = await makeApi({ region: 'ap-south-1' }).createBucket('reports-2026');
+
+    expect(s3Mock).toHaveReceivedCommandWith(CreateBucketCommand, {
+      Bucket: 'reports-2026',
+      CreateBucketConfiguration: { LocationConstraint: 'ap-south-1' },
+    });
+    expect(result).toEqual({ status: 'completed', bucketName: 'reports-2026', completed: true });
+  });
+
+  it('propagates creation failures raw', async () => {
+    s3Mock.on(CreateBucketCommand).rejects(s3Error('BucketAlreadyExists', 409));
+
+    await expect(makeApi().createBucket('reports-2026')).rejects.toThrow();
+  });
+
+  it('throws synchronously for an empty bucketName without calling S3', async () => {
+    await expect(makeApi().createBucket('')).rejects.toThrow();
+
+    expect(s3Mock).not.toHaveReceivedCommand(CreateBucketCommand);
+  });
+});
+
+describe('deleteBucket', () => {
+  it('deletes an empty bucket and reports completed', async () => {
+    s3Mock.on(DeleteBucketCommand).resolves({});
+
+    const result = await makeApi().deleteBucket('temp1');
+
+    expect(s3Mock).toHaveReceivedCommandWith(DeleteBucketCommand, { Bucket: 'temp1' });
+    expect(result).toEqual({ status: 'completed', bucketName: 'temp1', completed: true });
+  });
+
+  it('reports not-empty instead of throwing when S3 refuses a non-empty bucket', async () => {
+    s3Mock.on(DeleteBucketCommand).rejects(s3Error('BucketNotEmpty', 409));
+
+    const result = await makeApi().deleteBucket('temp1');
+
+    expect(result).toEqual({ status: 'not-empty', bucketName: 'temp1', completed: false });
+  });
+
+  it('propagates any other failure raw', async () => {
+    s3Mock.on(DeleteBucketCommand).rejects(s3Error('AccessDenied', 403));
+
+    await expect(makeApi().deleteBucket('temp1')).rejects.toThrow();
+  });
+
+  it('propagates NoSuchBucket raw', async () => {
+    s3Mock.on(DeleteBucketCommand).rejects(s3Error('NoSuchBucket', 404));
+
+    await expect(makeApi().deleteBucket('temp1')).rejects.toThrow();
+  });
+
+  it('throws synchronously for an empty bucketName without calling S3', async () => {
+    await expect(makeApi().deleteBucket('')).rejects.toThrow();
+
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteBucketCommand);
+  });
+});
+
+describe('getBucketTags', () => {
+  it('maps the SDK TagSet to BucketTag[]', async () => {
+    s3Mock.on(GetBucketTaggingCommand).resolves({
+      TagSet: [
+        { Key: 'env', Value: 'prod' },
+        { Key: 'team', Value: 'platform' },
+      ],
+    });
+
+    const result = await makeApi().getBucketTags('reports-2026');
+
+    expect(s3Mock).toHaveReceivedCommandWith(GetBucketTaggingCommand, { Bucket: 'reports-2026' });
+    expect(result).toEqual({
+      tags: [
+        { key: 'env', value: 'prod' },
+        { key: 'team', value: 'platform' },
+      ],
+    });
+  });
+
+  it('returns an empty tag list for an untagged bucket instead of throwing', async () => {
+    s3Mock.on(GetBucketTaggingCommand).rejects(s3Error('NoSuchTagSet', 404));
+
+    const result = await makeApi().getBucketTags('reports-2026');
+
+    expect(result).toEqual({ tags: [] });
+  });
+
+  it('propagates other errors raw', async () => {
+    s3Mock.on(GetBucketTaggingCommand).rejects(s3Error('AccessDenied', 403));
+
+    await expect(makeApi().getBucketTags('reports-2026')).rejects.toThrow();
+  });
+
+  it('throws synchronously for an empty bucketName without calling S3', async () => {
+    await expect(makeApi().getBucketTags('')).rejects.toThrow();
+
+    expect(s3Mock).not.toHaveReceivedCommand(GetBucketTaggingCommand);
+  });
+});
+
+describe('setBucketTags', () => {
+  it('replaces the tag set via PutBucketTagging', async () => {
+    s3Mock.on(PutBucketTaggingCommand).resolves({});
+
+    await makeApi().setBucketTags({
+      bucketName: 'reports-2026',
+      tags: [{ key: 'env', value: 'prod' }],
+    });
+
+    expect(s3Mock).toHaveReceivedCommandWith(PutBucketTaggingCommand, {
+      Bucket: 'reports-2026',
+      Tagging: { TagSet: [{ Key: 'env', Value: 'prod' }] },
+    });
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteBucketTaggingCommand);
+  });
+
+  it('clears all tags via DeleteBucketTagging when given an empty array', async () => {
+    s3Mock.on(DeleteBucketTaggingCommand).resolves({});
+
+    await makeApi().setBucketTags({ bucketName: 'reports-2026', tags: [] });
+
+    expect(s3Mock).toHaveReceivedCommandWith(DeleteBucketTaggingCommand, {
+      Bucket: 'reports-2026',
+    });
+    expect(s3Mock).not.toHaveReceivedCommand(PutBucketTaggingCommand);
+  });
+
+  it('wraps a Put failure with bucket-name context', async () => {
+    s3Mock.on(PutBucketTaggingCommand).rejects(s3Error('AccessDenied', 403));
+
+    await expect(
+      makeApi().setBucketTags({ bucketName: 'reports-2026', tags: [{ key: 'env', value: 'prod' }] })
+    ).rejects.toThrow(/reports-2026/);
+  });
+
+  it('throws synchronously for an empty bucketName without calling S3', async () => {
+    await expect(makeApi().setBucketTags({ bucketName: '', tags: [] })).rejects.toThrow();
+
+    expect(s3Mock).not.toHaveReceivedCommand(PutBucketTaggingCommand);
+    expect(s3Mock).not.toHaveReceivedCommand(DeleteBucketTaggingCommand);
+  });
+});
+
+describe('addOrUpdateBucketTags', () => {
+  it('overwrites listed keys and preserves the rest', async () => {
+    s3Mock.on(GetBucketTaggingCommand).resolves({
+      TagSet: [
+        { Key: 'env', Value: 'prod' },
+        { Key: 'team', Value: 'platform' },
+      ],
+    });
+    s3Mock.on(PutBucketTaggingCommand).resolves({});
+
+    const result = await makeApi().addOrUpdateBucketTags({
+      bucketName: 'reports-2026',
+      tags: [
+        { key: 'team', value: 'growth' },
+        { key: 'owner', value: 'alice' },
+      ],
+    });
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { key: 'env', value: 'prod' },
+        { key: 'team', value: 'growth' },
+        { key: 'owner', value: 'alice' },
+      ])
+    );
+    expect(result).toHaveLength(3);
+    expect(s3Mock).toHaveReceivedCommandWith(PutBucketTaggingCommand, {
+      Bucket: 'reports-2026',
+      Tagging: {
+        TagSet: expect.arrayContaining([
+          { Key: 'env', Value: 'prod' },
+          { Key: 'team', Value: 'growth' },
+          { Key: 'owner', Value: 'alice' },
+        ]),
+      },
+    });
+  });
+
+  it('treats an untagged bucket as an empty starting set', async () => {
+    s3Mock.on(GetBucketTaggingCommand).rejects(s3Error('NoSuchTagSet', 404));
+    s3Mock.on(PutBucketTaggingCommand).resolves({});
+
+    const result = await makeApi().addOrUpdateBucketTags({
+      bucketName: 'reports-2026',
+      tags: [{ key: 'env', value: 'prod' }],
+    });
+
+    expect(result).toEqual([{ key: 'env', value: 'prod' }]);
+  });
+
+  it('does not enforce any provider-specific tag-count cap client-side, letting the write attempt and the provider reject it', async () => {
+    const existing = Array.from({ length: 50 }, (_, i) => ({ Key: `k${i}`, Value: 'v' }));
+    s3Mock.on(GetBucketTaggingCommand).resolves({ TagSet: existing });
+    s3Mock.on(PutBucketTaggingCommand).rejects(s3Error('InvalidTag', 400));
+
+    await expect(
+      makeApi().addOrUpdateBucketTags({
+        bucketName: 'reports-2026',
+        tags: [{ key: 'one-too-many', value: 'v' }],
+      })
+    ).rejects.toThrow();
+
+    expect(s3Mock).toHaveReceivedCommand(PutBucketTaggingCommand);
+  });
+
+  it('throws synchronously for an empty bucketName without calling S3', async () => {
+    await expect(makeApi().addOrUpdateBucketTags({ bucketName: '', tags: [] })).rejects.toThrow();
+
+    expect(s3Mock).not.toHaveReceivedCommand(GetBucketTaggingCommand);
+  });
+});
+
+describe('removeBucketTags', () => {
+  it('removes only the given keys and preserves the rest', async () => {
+    s3Mock.on(GetBucketTaggingCommand).resolves({
+      TagSet: [
+        { Key: 'env', Value: 'prod' },
+        { Key: 'team', Value: 'platform' },
+        { Key: 'owner', Value: 'alice' },
+      ],
+    });
+    s3Mock.on(PutBucketTaggingCommand).resolves({});
+
+    const result = await makeApi().removeBucketTags({
+      bucketName: 'reports-2026',
+      keys: ['team'],
+    });
+
+    expect(result).toEqual([
+      { key: 'env', value: 'prod' },
+      { key: 'owner', value: 'alice' },
+    ]);
+    expect(s3Mock).toHaveReceivedCommandWith(PutBucketTaggingCommand, {
+      Bucket: 'reports-2026',
+      Tagging: {
+        TagSet: [
+          { Key: 'env', Value: 'prod' },
+          { Key: 'owner', Value: 'alice' },
+        ],
+      },
+    });
+  });
+
+  it('ignores keys that are not present and still re-issues the write', async () => {
+    s3Mock.on(GetBucketTaggingCommand).resolves({ TagSet: [{ Key: 'env', Value: 'prod' }] });
+    s3Mock.on(PutBucketTaggingCommand).resolves({});
+
+    const result = await makeApi().removeBucketTags({
+      bucketName: 'reports-2026',
+      keys: ['does-not-exist'],
+    });
+
+    expect(result).toEqual([{ key: 'env', value: 'prod' }]);
+    expect(s3Mock).toHaveReceivedCommandWith(PutBucketTaggingCommand, {
+      Bucket: 'reports-2026',
+      Tagging: { TagSet: [{ Key: 'env', Value: 'prod' }] },
+    });
+  });
+
+  it('routes to DeleteBucketTagging when removing the last tag', async () => {
+    s3Mock.on(GetBucketTaggingCommand).resolves({ TagSet: [{ Key: 'env', Value: 'prod' }] });
+    s3Mock.on(DeleteBucketTaggingCommand).resolves({});
+
+    const result = await makeApi().removeBucketTags({
+      bucketName: 'reports-2026',
+      keys: ['env'],
+    });
+
+    expect(result).toEqual([]);
+    expect(s3Mock).toHaveReceivedCommandWith(DeleteBucketTaggingCommand, {
+      Bucket: 'reports-2026',
+    });
+    expect(s3Mock).not.toHaveReceivedCommand(PutBucketTaggingCommand);
+  });
+
+  it('throws synchronously for an empty bucketName without calling S3', async () => {
+    await expect(makeApi().removeBucketTags({ bucketName: '', keys: [] })).rejects.toThrow();
+
+    expect(s3Mock).not.toHaveReceivedCommand(GetBucketTaggingCommand);
+  });
+});

--- a/s3-api/src/index.listing.test.ts
+++ b/s3-api/src/index.listing.test.ts
@@ -15,7 +15,6 @@ import { mockClient } from 'aws-sdk-client-mock';
 import {
   S3Client,
   ListObjectsV2Command,
-  ListBucketsCommand,
   HeadObjectCommand,
   S3ServiceException,
 } from '@aws-sdk/client-s3';
@@ -412,58 +411,6 @@ describe('search', () => {
     await expect(
       makeApi().search({ prefix: 'docs/', searchTerm: 'x', nextToken: undefined })
     ).rejects.toThrow();
-  });
-});
-
-describe('getBuckets', () => {
-  it('passes searchTerm through as Prefix and nextToken as ContinuationToken', async () => {
-    s3Mock.on(ListBucketsCommand).resolves({
-      Buckets: [{ Name: 'reports-2026' }],
-      ContinuationToken: 'page-2',
-    });
-
-    const result = await makeApi().getBuckets({ searchTerm: 'reports', nextToken: 'page-1' });
-
-    expect(s3Mock).toHaveReceivedCommandWith(ListBucketsCommand, {
-      Prefix: 'reports',
-      ContinuationToken: 'page-1',
-    });
-    expect(result).toEqual({
-      buckets: [{ Name: 'reports-2026' }],
-      totalBuckets: 1,
-      nextToken: 'page-2',
-      isTruncated: true,
-    });
-  });
-
-  it('lists all buckets when searchTerm is omitted', async () => {
-    s3Mock.on(ListBucketsCommand).resolves({
-      Buckets: [{ Name: 'bucket-a' }, { Name: 'bucket-b' }],
-    });
-
-    const result = await makeApi().getBuckets({ nextToken: undefined });
-
-    expect(result.buckets).toEqual([{ Name: 'bucket-a' }, { Name: 'bucket-b' }]);
-    expect(result.totalBuckets).toBe(2);
-  });
-
-  it('reports isTruncated: false and an empty list for a page with no buckets', async () => {
-    s3Mock.on(ListBucketsCommand).resolves({});
-
-    const result = await makeApi().getBuckets({ nextToken: undefined });
-
-    expect(result).toEqual({
-      buckets: [],
-      totalBuckets: 0,
-      nextToken: undefined,
-      isTruncated: false,
-    });
-  });
-
-  it('propagates a listing failure', async () => {
-    s3Mock.on(ListBucketsCommand).rejects(s3Error('AccessDenied', 403));
-
-    await expect(makeApi().getBuckets({ nextToken: undefined })).rejects.toThrow();
   });
 });
 

--- a/s3-api/src/index.ts
+++ b/s3-api/src/index.ts
@@ -1,20 +1,27 @@
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
+  AddOrUpdateBucketTagsParams,
+  BucketTag,
+  CreateBucketResult,
   Credentials,
   DeleteBatchError,
   DeleteBatchResult,
+  DeleteBucketResult,
   DirectoryStructure,
   DownloadFileParams,
+  GetBucketTagsResult,
   MoveFileParams,
   MultipartUploadConfig,
   MultipartUploadParams,
   PresignedUploadParams,
+  RemoveBucketTagsParams,
   RenameFileParams,
   RenameFolderParams,
   RenameFolderError,
   RenameFolderResult,
   SearchParams,
   SearchResult,
+  SetBucketTagsParams,
   SignedUrlParams,
   userTypes,
   ListBucketParams,
@@ -33,8 +40,14 @@ import {
   GetObjectCommand,
   DeleteObjectCommand,
   CopyObjectCommand,
+  CreateBucketCommand,
+  BucketLocationConstraint,
   S3ServiceException,
   DeleteObjectsCommand,
+  DeleteBucketCommand,
+  DeleteBucketTaggingCommand,
+  GetBucketTaggingCommand,
+  PutBucketTaggingCommand,
   ObjectIdentifier,
   S3Client,
   ListBucketsCommand,
@@ -626,6 +639,166 @@ export class BYOS3ApiProvider extends BaseS3ApiProvider {
       nextToken: response.ContinuationToken,
       isTruncated: response.ContinuationToken !== undefined,
     };
+  }
+
+  async createBucket(bucketName: string): Promise<CreateBucketResult> {
+    if (!bucketName) {
+      throw new Error('createBucket: bucketName is required');
+    }
+
+    const input =
+      this.credentials.region === 'us-east-1'
+        ? { Bucket: bucketName }
+        : {
+            Bucket: bucketName,
+            CreateBucketConfiguration: {
+              LocationConstraint: this.credentials.region as BucketLocationConstraint,
+            },
+          };
+
+    await this.s3.send(new CreateBucketCommand(input));
+
+    return { status: 'completed', bucketName, completed: true };
+  }
+
+  /**
+   * Deletes a bucket. Never empties it first - S3 itself already checks
+   * every current object, noncurrent version, and delete marker before
+   * allowing DeleteBucket, so re-implementing that check client-side would
+   * just be a redundant, racy round trip. Callers that want to empty a
+   * bucket before deleting it should do so explicitly (e.g. via
+   * listFromPrefix + deleteBatch) before calling this method.
+   *
+   * Returns a structured result instead of throwing for the one anticipated
+   * non-completion outcome (`status: 'not-empty'`, S3's BucketNotEmpty, 409)
+   * so callers can show a clear message without a try/catch. Every other
+   * error (NoSuchBucket, AccessDenied, throttling, ...) propagates raw.
+   */
+  async deleteBucket(bucketName: string): Promise<DeleteBucketResult> {
+    if (!bucketName) {
+      throw new Error('deleteBucket: bucketName is required');
+    }
+
+    try {
+      await this.s3.send(new DeleteBucketCommand({ Bucket: bucketName }));
+      return { status: 'completed', bucketName, completed: true };
+    } catch (err) {
+      if (err instanceof S3ServiceException && err.name === 'BucketNotEmpty') {
+        return { status: 'not-empty', bucketName, completed: false };
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Reads a bucket's tag set. S3 responds with a 404 NoSuchTagSet error -
+   * not an empty TagSet - when the bucket has zero tags, so that specific
+   * case is translated to `{ tags: [] }`. Every other error (AccessDenied,
+   * NoSuchBucket, throttling, ...) propagates raw: silently returning an
+   * empty tag set on a permissions failure would make "I can't read this
+   * bucket's tags" look exactly like "this bucket has no tags".
+   */
+  async getBucketTags(bucketName: string): Promise<GetBucketTagsResult> {
+    if (!bucketName) {
+      throw new Error('getBucketTags: bucketName is required');
+    }
+
+    try {
+      const response = await this.s3.send(new GetBucketTaggingCommand({ Bucket: bucketName }));
+      const tags: BucketTag[] = (response.TagSet ?? []).map((t) => ({
+        key: t.Key ?? '',
+        value: t.Value ?? '',
+      }));
+      return { tags };
+    } catch (err) {
+      if (
+        err instanceof S3ServiceException &&
+        (err.name === 'NoSuchTagSet' || err.$metadata?.httpStatusCode === 404)
+      ) {
+        return { tags: [] };
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Full replace of a bucket's tag set. Mirrors S3's PutBucketTagging
+   * semantics exactly - this replaces every existing tag, it does not
+   * merge. See addOrUpdateBucketTags / removeBucketTags for merge/subtract.
+   *
+   * `tags: []` is routed to DeleteBucketTaggingCommand instead of calling
+   * PutBucketTagging with an empty TagSet, since PutBucketTagging's TagSet
+   * is a required, non-empty list - DeleteBucketTagging is the documented
+   * way to clear all tags.
+   */
+  async setBucketTags(params: SetBucketTagsParams): Promise<void> {
+    const { bucketName, tags } = params;
+    if (!bucketName) {
+      throw new Error('setBucketTags: bucketName is required');
+    }
+
+    try {
+      if (tags.length === 0) {
+        await this.s3.send(new DeleteBucketTaggingCommand({ Bucket: bucketName }));
+        return;
+      }
+
+      await this.s3.send(
+        new PutBucketTaggingCommand({
+          Bucket: bucketName,
+          Tagging: { TagSet: tags.map((t) => ({ Key: t.key, Value: t.value })) },
+        })
+      );
+    } catch (err) {
+      throw new Error(`Set bucket tags failed for ${bucketName}: ${err}`);
+    }
+  }
+
+  /**
+   * Merges `tags` into the bucket's existing tag set via read-modify-write,
+   * since PutBucketTagging always replaces the whole set. Keys present in
+   * `tags` overwrite the existing value for that key; every other existing
+   * key is preserved. Returns the resulting full tag set so callers don't
+   * need a follow-up getBucketTags call.
+   *
+   * Not atomic: a concurrent tag write between the read and the write here
+   * can be lost (last-writer-wins) - S3 bucket tagging has no conditional-
+   * write/ETag primitive to guard against that.
+   */
+  async addOrUpdateBucketTags(params: AddOrUpdateBucketTagsParams): Promise<BucketTag[]> {
+    const { bucketName, tags } = params;
+    if (!bucketName) {
+      throw new Error('addOrUpdateBucketTags: bucketName is required');
+    }
+
+    const existing = await this.getBucketTags(bucketName);
+    const merged = new Map(existing.tags.map((t) => [t.key, t.value]));
+    for (const t of tags) merged.set(t.key, t.value);
+
+    const result: BucketTag[] = Array.from(merged, ([key, value]) => ({ key, value }));
+
+    await this.setBucketTags({ bucketName, tags: result });
+    return result;
+  }
+
+  /**
+   * Removes the given keys from the bucket's existing tag set via
+   * read-modify-write. Keys not present are ignored. Removing every tag
+   * (remaining set is empty) is routed to DeleteBucketTaggingCommand, via
+   * the same branch in setBucketTags.
+   */
+  async removeBucketTags(params: RemoveBucketTagsParams): Promise<BucketTag[]> {
+    const { bucketName, keys } = params;
+    if (!bucketName) {
+      throw new Error('removeBucketTags: bucketName is required');
+    }
+
+    const existing = await this.getBucketTags(bucketName);
+    const toRemove = new Set(keys);
+    const remaining = existing.tags.filter((t) => !toRemove.has(t.key));
+
+    await this.setBucketTags({ bucketName, tags: remaining });
+    return remaining;
   }
 
   getS3Client(): S3Client {


### PR DESCRIPTION
This pull request adds comprehensive support for S3 bucket management APIs, including bucket creation, deletion, and full CRUD operations for bucket tags. It introduces new methods and types to the core API and implements them for the BYOS3ApiProvider. Additionally, it updates documentation and removes outdated tests related to bucket listing.

**New Bucket Management APIs:**

- Added methods to the `BaseS3ApiProvider` and implemented them in `BYOS3ApiProvider` for creating (`createBucket`) and deleting (`deleteBucket`) buckets, with special handling for the `us-east-1` region and reporting if a bucket is not empty instead of throwing errors. [[1]](diffhunk://#diff-5fd5ac903edddb2809877ab56356e2ccc2130f8b3a534596cf090f79cb5429c7R157-R168) [[2]](diffhunk://#diff-28dcd7e490815264d7a772b31fc7deb1350e81e54314f76b6d2cb237e5d43badR644-R803)

**Bucket Tagging (CRUD) APIs:**

- Introduced full CRUD methods for bucket tags: `getBucketTags`, `setBucketTags` (full replace), `addOrUpdateBucketTags` (merge), and `removeBucketTags` (subtract), along with corresponding parameter and result types. These are now part of the core API and implemented for S3. [[1]](diffhunk://#diff-5fd5ac903edddb2809877ab56356e2ccc2130f8b3a534596cf090f79cb5429c7R157-R168) [[2]](diffhunk://#diff-0d976bb8372655a1378e03c28a7266c6dc3c88891c64dfdfa78f034d7050f82cR194-R248) [[3]](diffhunk://#diff-28dcd7e490815264d7a772b31fc7deb1350e81e54314f76b6d2cb237e5d43badR644-R803)

**Type and Interface Additions:**

- Defined new types and interfaces in `types.ts` for bucket operations, including `CreateBucketResult`, `DeleteBucketResult`, `BucketTag`, and parameter/result types for tag operations.

**Documentation Updates:**

- Updated the changeset and changelog to document the new APIs and note a version sync. [[1]](diffhunk://#diff-766ac4bbfb4bb1f2be475d16b1ba7ba9b265f9142252271b2ce41c093d253b77R1-R12) [[2]](diffhunk://#diff-50790ef009802d55dcbf2c4c383084de5d256579cb9f892cbcfaacddd82992b2R5-R6)

**Test Cleanup:**

- Removed outdated or now-irrelevant tests for bucket listing from `index.listing.test.ts` to reflect the new API structure.

These changes significantly enhance the S3 API's bucket management capabilities and lay the groundwork for more advanced bucket operations.