### PR TITLE
fix: let signed-in visitors read the public pages, and six rough edges

### DIFF
--- a/.changeset/public-pages-and-rough-edges.md
+++ b/.changeset/public-pages-and-rough-edges.md
@@ -1,0 +1,33 @@
+---
+'frontend': patch
+---
+
+Let signed-in visitors read the public pages, and clear out five rough edges
+
+The landing page, /connect and every provider page used to bounce a visitor with
+a connected bucket straight to the dashboard. All three exist to be read - the
+connect pages carry their own metadata and canonical URLs so they can be found
+in search - which meant the page Google indexed was the one page a returning
+user could never see, and anyone with one bucket connected could not reach the
+form to add a second. They stay put now, and a "Go to Dashboard" control appears
+for whoever has a session. The landing page's main button carries it rather than
+growing a second button beside it: that button already sent returning visitors
+to their drive, it just said "Get Started" while doing so.
+
+Opening a row's overflow menu from the keyboard now selects the row, as the
+mouse already did. Radix opens the menu from its own keydown handler and calls
+preventDefault, so the click that selection hung off was never synthesised and
+the toolbar showed nothing.
+
+Folder navigation no longer puts a `key` parameter in the URL. It carried the
+folder's own name beside a prefix that already ended in it, and nothing read it
+for its value - duplicated data on every navigation, in an app whose privacy
+story is about keeping paths out of query strings.
+
+Cloudflare R2's endpoint field showed a literal `{{accountId}}`, our own
+templating syntax, as the example to type. It reads the way Cloudflare's docs
+write it now.
+
+`--danger` held byte-identical values to `--destructive` in every theme, three
+uses against fifty-four, and is gone. robots.txt repeated one rule three times
+where `*` already covered every bot.

--- a/.dockerignore
+++ b/.dockerignore
@@ -32,3 +32,7 @@ docs/**
 
 Dockerfile
 .dockerignore
+
+# Local agent tooling, never part of the image.
+.agents
+skills-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ copilot-instructions.md
 # Local maintainer tooling for bulk-creating GitHub issues
 .github/issues.json
 .github/push-issues.cjs
+
+# Local agent tooling: installed skills and the lockfile pinning them.
+# Per-developer, not part of the project's build or runtime.
+.agents/
+skills-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -54,3 +54,7 @@ Thumbs.db
 # Minified files
 **/*.min.js
 **/*.bundle.js
+
+# Local agent tooling
+.agents/
+skills-lock.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,6 +69,10 @@ export default [
       // Minified files
       '**/*.min.js',
       '**/*.bundle.js',
+
+      // Local agent tooling
+      '.agents/**',
+      'skills-lock.json',
     ],
   },
 

--- a/frontend/src/app/dashboard/browse/page.tsx
+++ b/frontend/src/app/dashboard/browse/page.tsx
@@ -96,7 +96,6 @@ function BrowsePageContent() {
   const params = parseFolderParams(searchParams);
   const {
     prefix: prefixParam = '',
-    key: keyParam = '',
     maxKeys: _maxKeys,
     continuationToken: _continuationToken,
   } = params;
@@ -162,7 +161,7 @@ function BrowsePageContent() {
       const folderName = folder.name;
       if (folderName) {
         // Use utility function to build URL
-        const url = buildFolderClickUrl(prefixParam, folderName, keyParam);
+        const url = buildFolderClickUrl(prefixParam, folderName);
         router.push(url);
       }
     }
@@ -318,17 +317,13 @@ function BrowsePageContent() {
       {pathSegments.length > 0 && (
         <EnhancedFolderBreadcrumb
           pathSegments={pathSegments}
-          currentKey={keyParam}
-          onNavigate={(prefix: string, key?: string) => {
+          onNavigate={(prefix: string) => {
             const params = new URLSearchParams();
             if (prefix) {
               params.set('prefix', prefix);
             }
-            if (key) {
-              params.set('key', key);
-            }
 
-            const url = prefix || key ? `/dashboard/browse?${params.toString()}` : '/dashboard';
+            const url = prefix ? `/dashboard/browse?${params.toString()}` : '/dashboard';
             router.push(url);
           }}
         />

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -137,10 +137,7 @@ export default function HomePage() {
   const handleFolderClick = (folder: Folder) => {
     if (folder.Prefix && folder.name) {
       // Navigate to the folder using the enhanced browse route
-      const url = generateFolderUrl({
-        prefix: `${folder.name}/`,
-        key: folder.name,
-      });
+      const url = generateFolderUrl({ prefix: `${folder.name}/` });
       router.push(url);
     }
   };

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -70,11 +70,6 @@
   --success-foreground: #ffffff;
   --success-surface: #e6f4ea;
 
-  /* Error state for form validation and failed connections */
-  --danger: #d93025;
-  --danger-surface: #fce8e6;
-  --danger-border: #f6aea9;
-
   /* Informational banner, softer than a warning and calmer than primary */
   --info-surface: #e8f0fe;
   --info-border: #d2e3fc;
@@ -114,6 +109,12 @@
      white-on-white. */
   --destructive: #d93025;
   --destructive-foreground: #ffffff;
+  /* Tints of the same red, for the surface and border of an error panel.
+     These were a second scale called `danger` holding byte-identical values,
+     which is one retune away from the app having two different reds and no
+     rule for which belongs where. */
+  --destructive-surface: #fce8e6;
+  --destructive-border: #f6aea9;
 }
 
 @theme inline {
@@ -142,9 +143,6 @@
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
   --color-success-surface: var(--success-surface);
-  --color-danger: var(--danger);
-  --color-danger-surface: var(--danger-surface);
-  --color-danger-border: var(--danger-border);
   --color-info-surface: var(--info-surface);
   --color-info-border: var(--info-border);
   --color-info-foreground: var(--info-foreground);
@@ -165,6 +163,8 @@
   --color-provider-custom-soft: var(--provider-custom-soft);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-destructive-surface: var(--destructive-surface);
+  --color-destructive-border: var(--destructive-border);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -225,10 +225,6 @@
   --success-foreground: #202124;
   --success-surface: rgba(129, 201, 149, 0.16);
 
-  --danger: #f28b82;
-  --danger-surface: rgba(242, 139, 130, 0.14);
-  --danger-border: rgba(242, 139, 130, 0.32);
-
   --info-surface: rgba(138, 180, 248, 0.12);
   --info-border: rgba(138, 180, 248, 0.28);
   --info-foreground: #aecbfa;
@@ -241,6 +237,8 @@
      dark here the way --primary-foreground does. */
   --destructive: #f28b82;
   --destructive-foreground: #202124;
+  --destructive-surface: rgba(242, 139, 130, 0.14);
+  --destructive-border: rgba(242, 139, 130, 0.32);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -300,10 +298,6 @@
     --success-foreground: #202124;
     --success-surface: rgba(129, 201, 149, 0.16);
 
-    --danger: #f28b82;
-    --danger-surface: rgba(242, 139, 130, 0.14);
-    --danger-border: rgba(242, 139, 130, 0.32);
-
     --info-surface: rgba(138, 180, 248, 0.12);
     --info-border: rgba(138, 180, 248, 0.28);
     --info-foreground: #aecbfa;
@@ -313,6 +307,8 @@
     --step-pending-border: #5f6368;
     --destructive: #f28b82;
     --destructive-foreground: #202124;
+    --destructive-surface: rgba(242, 139, 130, 0.14);
+    --destructive-border: rgba(242, 139, 130, 0.32);
   }
 }
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -14,6 +14,7 @@ import CTASection from '@/features/landing-page/components/cta-section';
 import ThemeToggleCustom from '@/shared/components/layout/ThemeToggleCustom';
 import { SiteFooter } from '@/shared/components/layout/site-footer';
 import { useOpndriveStars } from '@/hooks/use-github-stars';
+import { useAuth } from '@/hooks/use-auth';
 import { DOCS_URL } from '@/config/links';
 
 const navItems = [
@@ -27,7 +28,7 @@ const navItems = [
 
 export default function LandingPage() {
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
+  const { userCreds, isLoading } = useAuth();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [showMobileNav, setShowMobileNav] = useState(false);
 
@@ -51,23 +52,25 @@ export default function LandingPage() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const handleGetStarted = async () => {
-    setIsLoading(true);
+  /**
+   * Where the main call to action goes, and what it admits to doing.
+   *
+   * It has always sent a visitor with a connected bucket to their drive rather
+   * than back through the connect flow - it just did so while still reading
+   * "Get Started", so the one button whose label people rely on was the one
+   * that did not describe itself. The label now names the destination.
+   *
+   * The session comes from the auth context rather than a second, hand-copied
+   * read of the `s3_user_session` key, which is the sort of duplicate that
+   * survives a rename of the original. `AuthProvider` holds this page back
+   * until the restore has finished, so `userCreds` is settled by the time any
+   * of this renders; the loading label is what shows if that ever changes.
+   */
+  const hasSession = userCreds !== null;
+  const ctaLabel = isLoading ? 'Loading...' : hasSession ? 'Go to Dashboard' : 'Get Started';
 
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 300));
-
-      const stored = localStorage.getItem('s3_user_session');
-      if (stored) {
-        router.push('/dashboard');
-      } else {
-        router.push('/connect');
-      }
-    } catch (error) {
-      console.error('Error during navigation:', error);
-    } finally {
-      setIsLoading(false);
-    }
+  const handleGetStarted = () => {
+    router.push(hasSession ? '/dashboard' : '/connect');
   };
 
   const handleNavClick = (href: string) => {
@@ -176,7 +179,7 @@ export default function LandingPage() {
                   disabled={isLoading}
                   className="w-full bg-primary text-primary-foreground hover:bg-primary/90 px-4 py-2.5 text-sm font-medium rounded-md transition-colors"
                 >
-                  {isLoading ? 'Loading...' : 'Get Started'}
+                  {ctaLabel}
                 </button>
               </div>
             </div>
@@ -192,14 +195,14 @@ export default function LandingPage() {
         />
       )}
 
-      <HeroSection handleGetStarted={handleGetStarted} isLoading={isLoading} />
+      <HeroSection handleGetStarted={handleGetStarted} isLoading={isLoading} ctaLabel={ctaLabel} />
       {/* Add top padding after hero section for mobile navbar */}
       <div className="lg:pt-0" style={{ paddingTop: showMobileNav ? '3.5rem' : '0' }}>
         <Navbar />
         <FeaturesSection />
         <WorkSmarterSection />
         <FAQSection />
-        <CTASection handleGetStarted={handleGetStarted} isLoading={isLoading} />
+        <CTASection handleGetStarted={handleGetStarted} isLoading={isLoading} ctaLabel={ctaLabel} />
         <SiteFooter />
       </div>
     </main>

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -6,22 +6,12 @@ export default function robots(): MetadataRoute.Robots {
 
   return {
     rules: [
+      // One rule, not three. Googlebot and Bingbot each had a byte-identical
+      // copy of this block, including the comment, and `*` already covers them
+      // both - so the only thing the duplicates added was three places to keep
+      // in step.
       {
         userAgent: '*',
-        allow: '/',
-        // /connect and its provider pages are public landing pages and need to
-        // be crawlable. /dashboard is private and useless to a crawler.
-        disallow: ['/api/', '/dashboard/'],
-      },
-      {
-        userAgent: 'Googlebot',
-        allow: '/',
-        // /connect and its provider pages are public landing pages and need to
-        // be crawlable. /dashboard is private and useless to a crawler.
-        disallow: ['/api/', '/dashboard/'],
-      },
-      {
-        userAgent: 'Bingbot',
         allow: '/',
         // /connect and its provider pages are public landing pages and need to
         // be crawlable. /dashboard is private and useless to a crawler.

--- a/frontend/src/config/providers.ts
+++ b/frontend/src/config/providers.ts
@@ -39,6 +39,14 @@ export interface S3Provider {
   regions: RegionOption[];
   /** True when the endpoint cannot be derived and the user must supply it. */
   requiresCustomEndpoint: boolean;
+  /**
+   * What to show in an empty endpoint field.
+   *
+   * The template was being used for this, so R2 offered the user a literal
+   * `{{accountId}}` - our own templating syntax, leaking onto a page we are
+   * trying to rank. This is written the way the provider's own docs write it.
+   */
+  endpointPlaceholder?: string;
   seo: {
     title: string;
     description: string;
@@ -114,6 +122,7 @@ export const S3_PROVIDERS: readonly S3Provider[] = [
     name: 'Cloudflare R2',
     tagline: 'S3 API with no egress fees',
     endpoint: 'https://{{accountId}}.r2.cloudflarestorage.com',
+    endpointPlaceholder: 'https://<account-id>.r2.cloudflarestorage.com',
     defaultRegion: 'auto',
     regions: [
       { value: 'auto', label: 'Automatic - auto' },

--- a/frontend/src/config/providers.ts
+++ b/frontend/src/config/providers.ts
@@ -40,11 +40,14 @@ export interface S3Provider {
   /** True when the endpoint cannot be derived and the user must supply it. */
   requiresCustomEndpoint: boolean;
   /**
-   * What to show in an empty endpoint field.
+   * What to show in an empty endpoint field, for a provider whose endpoint
+   * cannot be derived from anything we ask for.
    *
-   * The template was being used for this, so R2 offered the user a literal
-   * `{{accountId}}` - our own templating syntax, leaking onto a page we are
-   * trying to rank. This is written the way the provider's own docs write it.
+   * `endpoint` is a template and was being used for this directly, so R2
+   * offered the user a literal `{{accountId}}` - our own templating syntax,
+   * presented as the thing to type, on a page we are trying to rank. Where
+   * the region is the only variable, `resolveEndpoint` fills it in and the
+   * hint under the field carries the real URL, so only R2 needs one of these.
    */
   endpointPlaceholder?: string;
   seo: {

--- a/frontend/src/context/auth-context.test.tsx
+++ b/frontend/src/context/auth-context.test.tsx
@@ -23,9 +23,16 @@ import type { SearchResult } from '@opndrive/s3-api';
 
 const pushMock = vi.fn();
 
+/**
+ * The route the provider believes it is on. Mutable because restoring a
+ * session behaves differently per route, and a fixed '/dashboard' hid that:
+ * the redirect this used to perform could never fire under test.
+ */
+const route = vi.hoisted(() => ({ current: '/dashboard' }));
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock }),
-  usePathname: () => '/dashboard',
+  usePathname: () => route.current,
 }));
 
 /**
@@ -396,5 +403,69 @@ describe('credentials are proved before a session is built on them', () => {
     // A stored session that cannot list is a dashboard that cannot load, and
     // the user is no longer on the page that could fix it.
     await waitFor(() => expect(localStorage.getItem('s3_user_session')).toBeNull());
+  });
+});
+
+/**
+ * Restoring a session is not a reason to navigate.
+ *
+ * The provider used to push to /dashboard whenever it found stored credentials
+ * while the user sat on `/`, `/connect` or a provider page. All three are pages
+ * with something to read - the landing page is the pitch, and the connect pages
+ * exist to be found in search - so a returning visitor was bounced off the
+ * exact page they had arrived at, and someone with one bucket connected could
+ * not reach the form to add a second.
+ *
+ * It also read far more into the signal than was there: there is no account
+ * here, so "has a session" means only that keys are in this browser's
+ * localStorage, which a shared machine satisfies just as well as present
+ * intent.
+ *
+ * These pin the absence of that redirect. The old `usePathname` mock returned
+ * '/dashboard' unconditionally, so the behaviour was never covered either way.
+ */
+describe('restoring a session does not navigate', () => {
+  const storedCreds = JSON.stringify({
+    accessKeyId: 'AKIA_A',
+    secretAccessKey: 'secret-a',
+    region: 'us-east-1',
+  });
+
+  beforeEach(() => {
+    pushMock.mockClear();
+    localStorage.clear();
+    route.current = '/dashboard';
+  });
+
+  it.each(['/', '/connect', '/connect/cloudflare-r2'])(
+    'leaves a signed-in visitor on %s',
+    async (pathname) => {
+      route.current = pathname;
+      localStorage.setItem(STORAGE_KEY, storedCreds);
+
+      await renderProvider();
+
+      expect(pushMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it('still restores the session it found', async () => {
+    route.current = '/connect';
+    localStorage.setItem(STORAGE_KEY, storedCreds);
+
+    await renderProvider();
+
+    // Not navigating is only correct if the session is genuinely live: the
+    // "Go to Dashboard" control on these pages renders off exactly this.
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(storedCreds);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when there is no session to restore', async () => {
+    route.current = '/';
+
+    await renderProvider();
+
+    expect(pushMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -254,14 +254,25 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             setUserCreds(creds);
             setApiS3(api);
 
-            // Only redirect to dashboard if user is on home page/connect page
-            // Otherwise, stay on current route (preserve the URL after refresh)
-            // Provider pages count as /connect here. Landing on
-            // /connect/cloudflare-r2 with a live session should behave the same
-            // as landing on /connect with one.
-            if (pathname === '/' || pathname === '/connect' || pathname.startsWith('/connect/')) {
-              router.push('/dashboard');
-            }
+            // Restoring a session deliberately does not navigate anywhere.
+            //
+            // It used to push to /dashboard from `/`, `/connect` and the
+            // provider pages. All three are pages with something to read: the
+            // landing page is the pitch, and /connect and /connect/[provider]
+            // exist to be found in search. Bouncing a visitor off them meant
+            // the page Google indexed was the one page a returning user could
+            // never see, and someone with a bucket already connected could not
+            // reach the form to add a second.
+            //
+            // It also read far more into the signal than was there. There is
+            // no account here - "signed in" means access keys are sitting in
+            // this browser's localStorage, which a shared machine or a visit
+            // three months ago satisfies just as well as present intent.
+            //
+            // Signed-in visitors get a "Go to Dashboard" control on those
+            // pages instead, so the way through is visible without the choice
+            // being made for them. Connecting a bucket still navigates, in
+            // ConnectWizard, because that is a thing the user just asked for.
           } else {
             throw new Error('Invalid credentials in storage');
           }

--- a/frontend/src/features/connect/components/connect-shell.tsx
+++ b/frontend/src/features/connect/components/connect-shell.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { ArrowLeft, Check } from 'lucide-react';
 import { ConnectNotice } from './connect-notice';
 import { SiteFooter } from '@/shared/components/layout/site-footer';
+import { DashboardLink } from '@/shared/components/layout/dashboard-link';
 
 /** The three things someone does, in order, to get into their bucket. */
 export const CONNECT_STEPS = ['Choose provider', 'Add credentials', 'Open your drive'] as const;
@@ -48,13 +49,20 @@ export function ConnectShell({
             <span className="text-base font-semibold tracking-tight text-foreground">Opndrive</span>
           </Link>
 
-          <Link
-            href={backHref ?? '/'}
-            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-            {backLabel ?? 'Back to home'}
-          </Link>
+          <div className="flex items-center gap-2">
+            <Link
+              href={backHref ?? '/'}
+              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              {backLabel ?? 'Back to home'}
+            </Link>
+
+            {/* The one client leaf in this frame. Someone who already has a
+                bucket connected can be here to add a second, so the way back
+                into the drive is offered rather than forced. */}
+            <DashboardLink />
+          </div>
         </div>
       </header>
 

--- a/frontend/src/features/connect/components/connect-wizard.test.ts
+++ b/frontend/src/features/connect/components/connect-wizard.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { buildCredentials, formatPrefix } from './connect-wizard';
-import { getProviderBySlug, resolveEndpoint } from '@/config/providers';
+import { getProviderBySlug, resolveEndpoint, S3_PROVIDERS } from '@/config/providers';
 
 const aws = getProviderBySlug('aws-s3')!;
 const wasabi = getProviderBySlug('wasabi')!;
@@ -142,5 +142,41 @@ describe('resolveEndpoint', () => {
 
   it('is empty for a provider with no template at all', () => {
     expect(resolveEndpoint(minio, 'us-east-1')).toBe('');
+  });
+});
+
+/**
+ * What the endpoint field offers when it is empty.
+ *
+ * `endpoint` is a template, and using it directly as the placeholder is how R2
+ * came to present a literal `{{accountId}}` as the thing to type. Wasabi and
+ * Backblaze had the same hole with `{{region}}`; they are filled in by
+ * `resolveEndpoint` and shown in the hint under the field instead.
+ *
+ * The other half of that bug: three providers declare `endpoint: ''`, so a
+ * chain that reached for the template with `??` rather than `||` resolved to
+ * the empty string and left a required field with no example at all.
+ */
+describe('the endpoint placeholder', () => {
+  const placeholderFor = (provider: (typeof S3_PROVIDERS)[number]) =>
+    provider.endpointPlaceholder ?? 'https://storage.example.com';
+
+  it.each(S3_PROVIDERS.map((p) => [p.slug, p] as const))(
+    'gives %s something to look at that is not a template',
+    (_slug, provider) => {
+      const placeholder = placeholderFor(provider);
+
+      expect(placeholder).not.toBe('');
+      expect(placeholder).not.toContain('{{');
+    }
+  );
+
+  it('spells R2 out, because its account id is never derivable', () => {
+    expect(placeholderFor(r2)).toBe('https://<account-id>.r2.cloudflarestorage.com');
+  });
+
+  it('leaves region-only providers to the derived hint', () => {
+    expect(wasabi.endpointPlaceholder).toBeUndefined();
+    expect(resolveEndpoint(wasabi, 'eu-west-1')).toBe('https://s3.eu-west-1.wasabisys.com');
   });
 });

--- a/frontend/src/features/connect/components/connect-wizard.tsx
+++ b/frontend/src/features/connect/components/connect-wizard.tsx
@@ -198,9 +198,7 @@ export function ConnectWizard({ provider }: ConnectWizardProps) {
             required={provider.requiresCustomEndpoint}
             spellCheck={false}
             className={FIELD}
-            placeholder={
-              provider.endpointPlaceholder ?? provider.endpoint ?? 'https://storage.example.com'
-            }
+            placeholder={provider.endpointPlaceholder ?? 'https://storage.example.com'}
             value={form.endpoint}
             onChange={(event) => update({ endpoint: event.target.value })}
           />

--- a/frontend/src/features/connect/components/connect-wizard.tsx
+++ b/frontend/src/features/connect/components/connect-wizard.tsx
@@ -232,9 +232,9 @@ export function ConnectWizard({ provider }: ConnectWizardProps) {
         {failure && (
           <div
             role="alert"
-            className="rounded-lg border border-danger-border bg-danger-surface px-3 py-2.5"
+            className="rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2.5"
           >
-            <p className="text-sm font-medium text-danger">{failure.title}</p>
+            <p className="text-sm font-medium text-destructive">{failure.title}</p>
             <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{failure.detail}</p>
           </div>
         )}

--- a/frontend/src/features/connect/components/connect-wizard.tsx
+++ b/frontend/src/features/connect/components/connect-wizard.tsx
@@ -198,7 +198,9 @@ export function ConnectWizard({ provider }: ConnectWizardProps) {
             required={provider.requiresCustomEndpoint}
             spellCheck={false}
             className={FIELD}
-            placeholder={provider.endpoint || 'https://storage.example.com'}
+            placeholder={
+              provider.endpointPlaceholder ?? provider.endpoint ?? 'https://storage.example.com'
+            }
             value={form.endpoint}
             onChange={(event) => update({ endpoint: event.target.value })}
           />

--- a/frontend/src/features/dashboard/components/layout/breadcrumb/enhanced-folder-breadcrumb.tsx
+++ b/frontend/src/features/dashboard/components/layout/breadcrumb/enhanced-folder-breadcrumb.tsx
@@ -5,37 +5,27 @@ import { Breadcrumb, type BreadcrumbItem } from '@/shared/components/ui/breadcru
 
 interface EnhancedFolderBreadcrumbProps {
   pathSegments: string[];
-  currentKey?: string;
-  onNavigate?: (prefix: string, key?: string) => void;
+  onNavigate?: (prefix: string) => void;
 }
 
 export function EnhancedFolderBreadcrumb({
   pathSegments,
-  currentKey,
   onNavigate,
 }: EnhancedFolderBreadcrumbProps) {
   const router = useRouter();
 
   const handleNavigation = (segments: string[]) => {
     const newPrefix = segments.length > 0 ? segments.join('/') + '/' : '';
-    const newKey = segments.length > 0 ? segments[segments.length - 1] : undefined;
 
     if (onNavigate) {
-      onNavigate(newPrefix, newKey);
+      onNavigate(newPrefix);
     } else {
       // Default navigation behavior
       const params = new URLSearchParams();
       if (newPrefix) {
         params.set('prefix', newPrefix);
       }
-      if (newKey && currentKey) {
-        params.set('key', newKey);
-      }
-
-      const url =
-        newPrefix || (newKey && currentKey)
-          ? `/dashboard/browse?${params.toString()}`
-          : '/dashboard';
+      const url = newPrefix ? `/dashboard/browse?${params.toString()}` : '/dashboard';
       router.push(url);
     }
   };

--- a/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
@@ -9,7 +9,7 @@ import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
-import { getItemKeyIntent } from './item-keyboard';
+import { getItemKeyIntent, opensMenuOnKey } from './item-keyboard';
 
 interface FileItemGridProps {
   file: FileItem;
@@ -58,6 +58,12 @@ export function FileItemGrid({
     if (!isTouchDevice) {
       selectItem(file, 'file', index, false, false, allFiles);
     }
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!opensMenuOnKey(event)) return;
+
+    selectItem(file, 'file', index, false, false, allFiles);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
@@ -222,6 +228,7 @@ export function FileItemGrid({
                 className="p-1 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
                 aria-label={`More actions for ${file.name}`}
                 onPointerDown={handleMenuPointerDown}
+                onKeyDown={handleMenuKeyDown}
                 onClick={handleMenuClick}
               >
                 <HiOutlineDotsVertical size={18} className=" text-muted-foreground" />

--- a/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
@@ -8,7 +8,7 @@ import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
-import { getItemKeyIntent } from './item-keyboard';
+import { getItemKeyIntent, opensMenuOnKey } from './item-keyboard';
 
 interface FileItemListProps {
   file: FileItem;
@@ -57,6 +57,12 @@ export function FileItemList({
     if (!isTouchDevice) {
       selectItem(file, 'file', index, false, false, allFiles);
     }
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!opensMenuOnKey(event)) return;
+
+    selectItem(file, 'file', index, false, false, allFiles);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
@@ -243,6 +249,7 @@ export function FileItemList({
                 className="p-1.5 sm:p-2 rounded-full cursor-pointer hover:bg-secondary/80 transition-colors"
                 aria-label={`More actions for ${file.name}`}
                 onPointerDown={handleMenuPointerDown}
+                onKeyDown={handleMenuKeyDown}
                 onClick={handleMenuClick}
               >
                 <HiOutlineDotsVertical

--- a/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
@@ -8,7 +8,7 @@ import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { getEffectiveExtension, getFileExtensionWithoutDot } from '@/config/file-extensions';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { useFilePreview } from '@/context/file-preview-context';
-import { getItemKeyIntent } from './item-keyboard';
+import { getItemKeyIntent, opensMenuOnKey } from './item-keyboard';
 
 interface FileItemMobileProps {
   file: FileItem;
@@ -60,6 +60,12 @@ export function FileItemMobile({
     if (!isTouchDevice) {
       selectItem(file, 'file', index, false, false, allFiles);
     }
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!opensMenuOnKey(event)) return;
+
+    selectItem(file, 'file', index, false, false, allFiles);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
@@ -254,6 +260,7 @@ export function FileItemMobile({
             className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
             aria-label={`More actions for ${file.name}`}
             onPointerDown={handleMenuPointerDown}
+            onKeyDown={handleMenuKeyDown}
             onClick={handleMenuClick}
           >
             <HiOutlineDotsVertical size={20} className="text-muted-foreground" />

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
@@ -6,7 +6,7 @@ import { FolderOverflowMenu } from '../menus/folder-overflow-menu';
 import { Folder } from '@/features/dashboard/types/folder';
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
-import { getItemKeyIntent } from './item-keyboard';
+import { getItemKeyIntent, opensMenuOnKey } from './item-keyboard';
 
 interface FolderItemMobileProps {
   folder: Folder;
@@ -53,6 +53,12 @@ export function FolderItemMobile({
     if (!isTouchDevice) {
       selectItem(folder, 'folder', index, false, false, allFolders);
     }
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!opensMenuOnKey(event)) return;
+
+    selectItem(folder, 'folder', index, false, false, allFolders);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
@@ -219,6 +225,7 @@ export function FolderItemMobile({
           <button
             className="flex-shrink-0 p-2 cursor-pointer rounded-full hover:bg-secondary/80 transition-colors ml-2"
             onPointerDown={handleMenuPointerDown}
+            onKeyDown={handleMenuKeyDown}
             onClick={handleMenuClick}
             aria-label={`More actions for ${folder.name}`}
           >

--- a/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
@@ -9,7 +9,7 @@ import { FolderOverflowMenu } from '../menus/folder-overflow-menu';
 import { Folder, FolderMenuAction } from '@/features/dashboard/types/folder';
 import { formatTimeWithTooltip } from '@/shared/utils/time-utils';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
-import { getItemKeyIntent } from './item-keyboard';
+import { getItemKeyIntent, opensMenuOnKey } from './item-keyboard';
 
 interface FolderItemProps {
   folder: Folder;
@@ -164,6 +164,12 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     }
   };
 
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!opensMenuOnKey(event)) return;
+
+    selectItem(folder, 'folder', index, false, false, allFolders);
+  };
+
   const handleMenuClick = (event: React.MouseEvent) => {
     // Still load-bearing after the selection moved off it: the row opens the
     // item on click, so the click that opened the menu must not reach it.
@@ -240,6 +246,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
               "
               aria-label={`More actions for ${folder.name}`}
               onPointerDown={handleMenuPointerDown}
+              onKeyDown={handleMenuKeyDown}
               onClick={handleMenuClick}
             >
               <MoreVerticalIcon size={16} />

--- a/frontend/src/features/dashboard/components/ui/items/item-keyboard.ts
+++ b/frontend/src/features/dashboard/components/ui/items/item-keyboard.ts
@@ -22,3 +22,18 @@ export function getItemKeyIntent(event: React.KeyboardEvent<HTMLElement>): ItemK
 
   return event.ctrlKey || event.metaKey || event.shiftKey ? 'select' : 'open';
 }
+
+/**
+ * Whether this press is about to open a row's overflow menu.
+ *
+ * Radix opens the menu from its own `onKeyDown` and calls `preventDefault`,
+ * which stops the browser synthesising the click that the mouse path selects
+ * on. So tabbing to the button and pressing Enter opened a menu over an
+ * unselected row, and the toolbar never appeared to say what it would act on.
+ *
+ * These are the three keys Radix itself opens on, listed here rather than in
+ * each row component so they cannot drift apart from one another.
+ */
+export function opensMenuOnKey(event: React.KeyboardEvent<HTMLElement>): boolean {
+  return event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown';
+}

--- a/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
@@ -258,11 +258,28 @@ describe('the keyboard opens the menu and selects too', () => {
     expect(selection()).toHaveLength(0);
   });
 
-  it('selects a file row from the keyboard as well', () => {
-    render(<FileItemList file={file()} allFiles={[file()]} />);
+  // Same five rows the mouse block covers. The key list is shared now, but
+  // each component still wires its own onKeyDown, and a row that forgets to
+  // is exactly the drift this file exists to catch.
+  it('selects a folder row on mobile layout', () => {
+    render(<FolderItemMobile folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.keyDown(menuButton('Reports'), { key: 'Enter' });
+
+    expect(selection()).toHaveLength(1);
+    expect(useMultiSelectStore.getState().selectedType).toBe('folder');
+  });
+
+  it.each([
+    ['list', FileItemList],
+    ['grid', FileItemGrid],
+    ['mobile', FileItemMobile],
+  ])('selects a file row in the %s layout', (_label, Component) => {
+    render(<Component file={file()} allFiles={[file()]} />);
 
     fireEvent.keyDown(menuButton('budget.xlsx'), { key: 'Enter' });
 
     expect(selection()).toHaveLength(1);
+    expect(useMultiSelectStore.getState().selectedType).toBe('file');
   });
 });

--- a/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
@@ -233,3 +233,36 @@ describe('presses that do not open the menu do not select', () => {
     expect(selection()).toHaveLength(1);
   });
 });
+
+/**
+ * Opening the same menu from the keyboard has to select the same row.
+ *
+ * Radix opens on keydown and preventDefaults, so no click is synthesised and
+ * the mouse path never ran - a keyboard user got a menu over an unselected row
+ * with no toolbar to say what it would act on.
+ */
+describe('the keyboard opens the menu and selects too', () => {
+  it.each(['Enter', ' ', 'ArrowDown'])('selects on %s', (key) => {
+    render(<FolderItem folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.keyDown(menuButton('Reports'), { key });
+
+    expect(selection()).toHaveLength(1);
+  });
+
+  it('ignores keys that do not open the menu', () => {
+    render(<FolderItem folder={folder()} allFolders={[folder()]} />);
+
+    fireEvent.keyDown(menuButton('Reports'), { key: 'a' });
+
+    expect(selection()).toHaveLength(0);
+  });
+
+  it('selects a file row from the keyboard as well', () => {
+    render(<FileItemList file={file()} allFiles={[file()]} />);
+
+    fireEvent.keyDown(menuButton('budget.xlsx'), { key: 'Enter' });
+
+    expect(selection()).toHaveLength(1);
+  });
+});

--- a/frontend/src/features/folder-navigation/folder-navigation.ts
+++ b/frontend/src/features/folder-navigation/folder-navigation.ts
@@ -1,22 +1,24 @@
 export interface FolderNavigationParams {
   prefix?: string;
-  key?: string;
   maxKeys?: number;
   continuationToken?: string;
 }
 
 /**
  * Generate URL for folder navigation with query parameters
+ *
+ * There used to be a `key` parameter alongside `prefix`, carrying the folder's
+ * own name. It was never read for its value - the breadcrumb only tested
+ * whether it existed - and every value it could hold is the last segment of the
+ * prefix sitting beside it. So it duplicated data that is transmitted on every
+ * navigation, for nothing, in an app whose whole privacy story is about keeping
+ * user paths out of query strings.
  */
 export function generateFolderUrl(params: FolderNavigationParams): string {
   const urlParams = new URLSearchParams();
 
   if (params.prefix) {
     urlParams.set('prefix', params.prefix);
-  }
-
-  if (params.key) {
-    urlParams.set('key', params.key);
   }
 
   if (params.maxKeys) {
@@ -36,7 +38,6 @@ export function generateFolderUrl(params: FolderNavigationParams): string {
 export function parseFolderParams(searchParams: URLSearchParams): FolderNavigationParams {
   return {
     prefix: searchParams.get('prefix') || undefined,
-    key: searchParams.get('key') || undefined,
     maxKeys: searchParams.get('maxKeys') ? parseInt(searchParams.get('maxKeys')!) : undefined,
     continuationToken: searchParams.get('token') || undefined,
   };
@@ -90,10 +91,7 @@ export function buildFolderClickUrl(
       ? `${folderName}/`
       : `${currentPrefix}${folderName}/`;
 
-  return generateFolderUrl({
-    prefix: newPrefix,
-    key: folderName, // Use folder name as key as per backend requirement
-  });
+  return generateFolderUrl({ prefix: newPrefix });
 }
 
 /**
@@ -102,7 +100,6 @@ export function buildFolderClickUrl(
 export function buildBreadcrumbClickUrl(pathSegments: string[], targetIndex: number): string {
   const targetSegments = pathSegments.slice(0, targetIndex + 1);
   const prefix = pathSegmentsToPrefix(targetSegments);
-  const key = targetSegments.length > 0 ? targetSegments[targetSegments.length - 1] : undefined;
 
-  return generateFolderUrl({ prefix, key });
+  return generateFolderUrl({ prefix });
 }

--- a/frontend/src/features/folder-navigation/folder-navigation.ts
+++ b/frontend/src/features/folder-navigation/folder-navigation.ts
@@ -81,11 +81,7 @@ export function getParentPrefix(prefix: string): string {
 /**
  * Build navigation URL for folder click
  */
-export function buildFolderClickUrl(
-  currentPrefix: string,
-  folderName: string,
-  _currentKey?: string
-): string {
+export function buildFolderClickUrl(currentPrefix: string, folderName: string): string {
   const newPrefix =
     currentPrefix === '/' || currentPrefix === ''
       ? `${folderName}/`

--- a/frontend/src/features/landing-page/components/cta-section.tsx
+++ b/frontend/src/features/landing-page/components/cta-section.tsx
@@ -3,11 +3,21 @@ import Image from 'next/image';
 import { DiscordCtaBanner } from '@/shared/components/discord/discord-cta-banner';
 
 interface CTASectionProps {
-  handleGetStarted: () => Promise<void>;
+  handleGetStarted: () => void;
   isLoading: boolean;
+  /**
+   * Named by the page, which is the only thing that knows the destination.
+   * The blog's copies of this section always route to /connect, so they take
+   * the default rather than growing session logic of their own.
+   */
+  ctaLabel?: string;
 }
 
-export default function CTASection({ handleGetStarted, isLoading }: CTASectionProps) {
+export default function CTASection({
+  handleGetStarted,
+  isLoading,
+  ctaLabel = 'Get Started',
+}: CTASectionProps) {
   return (
     <section id="get-started" className="py-12 sm:py-16 md:py-20 lg:py-24 bg-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-0 lg:px-8">
@@ -38,7 +48,7 @@ export default function CTASection({ handleGetStarted, isLoading }: CTASectionPr
               disabled={isLoading}
               className="bg-primary hover:bg-primary/90 text-primary-foreground px-6 sm:px-8 md:px-10 lg:px-12 py-2.5 sm:py-3 md:py-4 text-sm sm:text-base md:text-lg font-medium min-w-[120px] sm:min-w-[140px] md:min-w-[160px]"
             >
-              {isLoading ? 'Loading...' : 'Get Started'}
+              {ctaLabel}
             </Button>
           </div>
 

--- a/frontend/src/features/landing-page/components/hero-section.tsx
+++ b/frontend/src/features/landing-page/components/hero-section.tsx
@@ -21,11 +21,13 @@ const navItems = [
 ];
 
 interface HeroSectionProps {
-  handleGetStarted: () => Promise<void>;
+  handleGetStarted: () => void;
   isLoading: boolean;
+  /** Named by the page, which is the only thing that knows the destination. */
+  ctaLabel: string;
 }
 
-export default function HeroSection({ handleGetStarted, isLoading }: HeroSectionProps) {
+export default function HeroSection({ handleGetStarted, isLoading, ctaLabel }: HeroSectionProps) {
   const router = useRouter();
   const effectiveTheme = useEffectiveTheme();
 
@@ -76,7 +78,7 @@ export default function HeroSection({ handleGetStarted, isLoading }: HeroSection
                 disabled={isLoading}
                 className="bg-primary text-primary-foreground hover:bg-primary/90 px-6 sm:px-8 lg:px-10 py-3 sm:py-3.5 lg:py-4 text-sm sm:text-base lg:text-lg font-medium w-full sm:w-auto text-center min-w-[140px] sm:min-w-[160px]"
               >
-                {isLoading ? 'Loading...' : 'Get Started'}
+                {ctaLabel}
               </Button>
               <Button
                 variant="outline"

--- a/frontend/src/features/landing-page/components/navbar.tsx
+++ b/frontend/src/features/landing-page/components/navbar.tsx
@@ -7,6 +7,7 @@ import { FaGithub } from 'react-icons/fa';
 import { useOpndriveStars } from '@/hooks/use-github-stars';
 import { DiscordCommunityLink } from '@/shared/components/discord/discord-community-link';
 import { DOCS_URL } from '@/config/links';
+import { DashboardLink } from '@/shared/components/layout/dashboard-link';
 
 const navItems = [
   { label: 'Home', href: '#hero' },
@@ -129,6 +130,10 @@ export default function Navbar() {
               />
 
               <ThemeToggleCustom />
+
+              {/* Only renders for a visitor who already has a bucket
+                  connected. The nav is otherwise the same signed in or out. */}
+              <DashboardLink />
             </div>
           </div>
         </nav>

--- a/frontend/src/shared/components/layout/dashboard-link.tsx
+++ b/frontend/src/shared/components/layout/dashboard-link.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { useAuth } from '@/hooks/use-auth';
+
+/**
+ * The way back into the drive, for a visitor who already has one connected.
+ *
+ * These pages used to redirect such a visitor to the dashboard on sight. They
+ * no longer do - a page worth ranking is a page worth letting someone read -
+ * so the route through has to be visible instead of automatic.
+ *
+ * Renders nothing until a session has actually been found. `userCreds` is null
+ * on the server and on the first client render alike, because the provider
+ * only reads localStorage in an effect, so there is no hydration mismatch to
+ * guard against here; waiting for `isLoading` to clear just avoids showing a
+ * link, hiding it, and showing it again while the restore is in flight.
+ */
+export function DashboardLink({ className }: { className?: string }) {
+  const { userCreds, isLoading } = useAuth();
+
+  if (isLoading || !userCreds) return null;
+
+  return (
+    <Link
+      href="/dashboard"
+      className={
+        className ??
+        'inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90'
+      }
+    >
+      Go to Dashboard
+      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+    </Link>
+  );
+}


### PR DESCRIPTION
Split out of #184 — cleanups only, no sorting or table changes.

## Changes

**Public pages no longer redirect signed-in visitors.** `/`, `/connect` and `/connect/[provider]` used to bounce anyone with stored credentials to the dashboard. All three exist to be read, so the page Google indexes was the one page a returning user never saw — and anyone with a bucket connected couldn't reach the form to add a second. A `DashboardLink` now appears instead. On the landing page the existing button carries it: it already sent returning visitors to their drive, it just said "Get Started" while doing it.

**Keyboard selects the row when opening its menu.** Radix opens on keydown and preventDefaults, so no click was synthesised and selection never ran — a keyboard user got a menu over an unselected row with no toolbar.

**Dropped the `key` query param.** It carried a folder's own name beside a prefix already ending in it, and nothing read its value.

**R2 endpoint placeholder** showed a literal `{{accountId}}`. Wasabi and Backblaze showed `{{region}}`. Now uses `resolveEndpoint`, which already handled this.

**`--danger` folded into `--destructive`** — byte-identical values, 3 uses against 54.

**robots.txt** had one rule three times where `*` already covered it.

## Testing

- Sign in, then visit `/`, `/connect`, `/connect/cloudflare-r2` — should stay put, with "Go to Dashboard" in the header/nav. Landing button should read "Go to Dashboard".
- Signed out: same pages behave as before, button reads "Get Started".
- Connect a bucket — still lands on the dashboard.
- Tab to a row's ⋮ and press Enter — row selects, toolbar appears. All five row types (folder, folder mobile, file list/grid/mobile).
- Open a folder — no `key=` in the URL.
- Connect form: MinIO and Custom endpoint show an example placeholder; Wasabi/Backblaze show a real URL in the hint; R2 shows `<account-id>`.

1258 tests pass, typecheck clean, 0 lint errors, clean build.