### PR TITLE
refactor: hold a request's status and its reason as one value

### DIFF
--- a/.changeset/request-state.md
+++ b/.changeset/request-state.md
@@ -1,0 +1,17 @@
+---
+'frontend': patch
+---
+
+Hold a drive request's status and its failure reason as one value
+
+The store kept `status`, `recentStatus`, `failures` and `recentFailures` as four
+maps keyed by the same prefix, with nothing forcing any two of them to agree.
+That had already caused a bug: with one shared failures map, the directory
+listing finishing erased why the recent list had failed, and the recent list
+fell back to a generic "something went wrong". Splitting the map per request
+kind fixed that instance without fixing the shape.
+
+Each key now holds one `RequestState`, so a reason is only ever written with the
+status it explains, and the error path is a single write rather than two. No
+behaviour change: the `AsyncState` selectors already hid the store's shape from
+every page, so nothing outside `data-context` and its tests moved.

--- a/frontend/src/context/data-context-deleted-folder.test.ts
+++ b/frontend/src/context/data-context-deleted-folder.test.ts
@@ -61,7 +61,11 @@ describe('forgetting the folder itself', () => {
         'docs/': listing(['docs/2024/'], ['docs/a.txt']),
         'docs/2024/': listing([], ['docs/2024/b.txt']),
       },
-      status: { '/': 'ready', 'docs/': 'ready', 'docs/2024/': 'ready' },
+      directory: {
+        '/': { status: 'ready' },
+        'docs/': { status: 'ready' },
+        'docs/2024/': { status: 'ready' },
+      },
       loadMoreStatus: { 'docs/': 'ready' },
     });
   });
@@ -75,7 +79,7 @@ describe('forgetting the folder itself', () => {
   it('drops the statuses too, so nothing is served as ready', () => {
     store().removeDeletedFolder('docs/');
 
-    expect(store().status).toEqual({ '/': 'ready' });
+    expect(store().directory).toEqual({ '/': { status: 'ready' } });
     expect(store().loadMoreStatus).toEqual({});
   });
 
@@ -107,14 +111,14 @@ describe('the parent listing', () => {
   it('loses the folder but stays cached, so it still renders', () => {
     useDriveStore.setState({
       cache: { '/': listing(['docs/', 'photos/'], ['readme.md']) },
-      status: { '/': 'ready' },
+      directory: { '/': { status: 'ready' } },
     });
 
     store().removeDeletedFolder('docs/');
 
     expect(store().cache['/'].folders.map((f) => f.Prefix)).toEqual(['photos/']);
     expect(store().cache['/'].files.map((f) => f.Key)).toEqual(['readme.md']);
-    expect(store().status['/']).toBe('ready');
+    expect(store().directory['/']?.status).toBe('ready');
   });
 
   it('is found through the bucket prefix the session is pinned to', () => {
@@ -162,7 +166,7 @@ describe('the recents on the home page', () => {
           folderOffset: 10,
         },
       },
-      recentStatus: { '/': 'ready', 'docs/': 'ready' },
+      recent: { '/': { status: 'ready' }, 'docs/': { status: 'ready' } },
     });
   });
 
@@ -186,7 +190,7 @@ describe('the recents on the home page', () => {
     store().removeDeletedFolder('docs/');
 
     expect(store().recentCache['docs/']).toBeUndefined();
-    expect(store().recentStatus).toEqual({ '/': 'ready' });
+    expect(store().recent).toEqual({ '/': { status: 'ready' } });
   });
 });
 
@@ -241,7 +245,7 @@ describe('a read still in the air', () => {
       rootPrefix: '/',
       currentPrefix: '/',
       cache: { '/': { ...listing(['docs/']), isTruncated: true, nextToken: 'page-2' } },
-      status: { '/': 'ready' },
+      directory: { '/': { status: 'ready' } },
     });
 
     // "Show more" is already running when the delete lands
@@ -267,18 +271,18 @@ describe('a read still in the air', () => {
       rootPrefix: '/',
       currentPrefix: '/',
       cache: { '/': listing(['docs/', 'photos/']) },
-      status: { '/': 'ready' },
+      directory: { '/': { status: 'ready' } },
     });
 
     const reading = store().fetchData({ sync: true });
-    expect(store().status['/']).toBe('loading');
+    expect(store().directory['/']?.status).toBe('loading');
 
     store().removeDeletedFolder('docs/');
 
     page.resolve({ files: [], folders: [{ Prefix: 'docs/' }] });
     await reading;
 
-    expect(store().status['/']).toBe('ready');
+    expect(store().directory['/']?.status).toBe('ready');
     expect(store().cache['/'].folders.map((f) => f.Prefix)).toEqual(['photos/']);
   });
 
@@ -301,7 +305,7 @@ describe('a read still in the air', () => {
 
     // A resurrected entry reads as ready and gets served to whoever walks back in
     expect(store().cache['docs/2024/']).toBeUndefined();
-    expect(store().status['docs/2024/']).toBeUndefined();
+    expect(store().directory['docs/2024/']?.status).toBeUndefined();
   });
 });
 

--- a/frontend/src/context/data-context.test.ts
+++ b/frontend/src/context/data-context.test.ts
@@ -96,7 +96,7 @@ describe('returning to a folder whose request is still open', () => {
 
     expect(fetchDirectoryStructure).toHaveBeenCalledTimes(1);
     expect(cachedKeys()).toEqual(['a.txt', 'b.txt']);
-    expect(store().status['/']).toBe('ready');
+    expect(store().directory['/']?.status).toBe('ready');
   });
 
   it('gives the second caller the first caller result', async () => {
@@ -186,7 +186,7 @@ describe('returning to a folder whose request is still open', () => {
 
     // A folder that loaded fine must not render as failed because an older
     // request for it happened to give up afterwards.
-    expect(store().status['/']).toBe('ready');
+    expect(store().directory['/']?.status).toBe('ready');
     expect(cachedKeys()).toEqual(['fresh.txt']);
   });
 });
@@ -439,8 +439,8 @@ describe('a listing that fails', () => {
 
     await store().fetchData({ sync: false });
 
-    expect(useDriveStore.getState().status['/']).toBe('error');
-    expect(useDriveStore.getState().failures['/']?.kind).toBe('permissions');
+    expect(useDriveStore.getState().directory['/']?.status).toBe('error');
+    expect(useDriveStore.getState().directory['/']?.failure?.kind).toBe('permissions');
   });
 
   it('keeps the reason specific enough to act on', async () => {
@@ -450,21 +450,21 @@ describe('a listing that fails', () => {
 
     // A blocked CORS preflight and a wrong secret key are different problems
     // fixed in different places, so they must not arrive as the same message.
-    expect(useDriveStore.getState().failures['/']?.kind).toBe('network');
+    expect(useDriveStore.getState().directory['/']?.failure?.kind).toBe('network');
   });
 
   it('forgets the reason once the folder loads', async () => {
     fetchDirectoryStructure.mockRejectedValueOnce(sdkError('AccessDenied', 403));
     await store().fetchData({ sync: false });
-    expect(useDriveStore.getState().failures['/']).toBeDefined();
+    expect(useDriveStore.getState().directory['/']?.failure).toBeDefined();
 
     // What Retry does. A stale reason left behind would render over a folder
     // that had just come back fine.
     fetchDirectoryStructure.mockResolvedValueOnce(page(['a.txt']));
     await store().fetchData({ sync: true });
 
-    expect(useDriveStore.getState().status['/']).toBe('ready');
-    expect(useDriveStore.getState().failures['/']).toBeUndefined();
+    expect(useDriveStore.getState().directory['/']?.status).toBe('ready');
+    expect(useDriveStore.getState().directory['/']?.failure).toBeUndefined();
   });
 
   it('does not carry a failure into the next session', async () => {
@@ -473,7 +473,7 @@ describe('a listing that fails', () => {
 
     store().clearAllData();
 
-    expect(useDriveStore.getState().failures).toEqual({});
+    expect(useDriveStore.getState().directory).toEqual({});
   });
 
   // The superseding rule already covered the status; the reason has to follow
@@ -489,8 +489,8 @@ describe('a listing that fails', () => {
     slowFailure.reject(sdkError('AccessDenied', 403));
     await first;
 
-    expect(useDriveStore.getState().status['/']).toBe('ready');
-    expect(useDriveStore.getState().failures['/']).toBeUndefined();
+    expect(useDriveStore.getState().directory['/']?.status).toBe('ready');
+    expect(useDriveStore.getState().directory['/']?.failure).toBeUndefined();
   });
 });
 
@@ -522,9 +522,9 @@ describe('two requests for one prefix', () => {
 
     const state = useDriveStore.getState();
 
-    expect(state.recentStatus['/']).toBe('error');
+    expect(state.recent['/']?.status).toBe('error');
     // Not 'unknown': the recent list still has to be able to say it was denied.
-    expect(state.recentFailures['/']?.kind).toBe('permissions');
+    expect(state.recent['/']?.failure?.kind).toBe('permissions');
   });
 
   it('keeps the directory failure when the recent listing succeeds', async () => {
@@ -539,7 +539,7 @@ describe('two requests for one prefix', () => {
 
     const state = useDriveStore.getState();
 
-    expect(state.status['/']).toBe('error');
-    expect(state.failures['/']?.kind).toBe('bucket');
+    expect(state.directory['/']?.status).toBe('error');
+    expect(state.directory['/']?.failure?.kind).toBe('bucket');
   });
 });

--- a/frontend/src/context/data-context.tsx
+++ b/frontend/src/context/data-context.tsx
@@ -31,42 +31,44 @@ type RecentDataWithCache = RecentData & {
 
 type Status = 'idle' | 'loading' | 'ready' | 'error';
 
+/**
+ * One request's outcome, held as a single value.
+ *
+ * Status and reason used to live in separate maps keyed by the same prefix, and
+ * nothing forced them to agree. That is not theoretical: with one shared
+ * failures map, the directory listing finishing erased why the recent list had
+ * failed, and the recent list fell back to a generic "something went wrong".
+ * Splitting the map per request kind fixed that instance without fixing the
+ * shape - four maps that must stay in step are still four maps that can fall
+ * out of step.
+ *
+ * Together they cannot drift: a reason is only ever written with the status it
+ * explains, and replacing the status replaces the reason with it.
+ */
+type RequestState = {
+  status: Status;
+  /** Only meaningful with status 'error'. Cleared by any other status. */
+  failure?: ConnectionFailure;
+};
+
 type Store = {
   apiS3: BYOS3ApiProvider | null;
   setApiS3: (api: BYOS3ApiProvider) => void;
   cache: Record<string, PrefixData>;
   recentCache: Record<string, RecentDataWithCache>;
-  status: Record<string, Status>;
-  recentStatus: Record<string, Status>;
+  directory: Record<string, RequestState>;
+  recent: Record<string, RequestState>;
   loadMoreStatus: Record<string, Status>;
-  /**
-   * Why the last request for a key failed, one map per request kind.
-   *
-   * The catch blocks below used to be bare `catch {}`, so the reason was gone
-   * before anyone could render it - which is half of why a failed listing was
-   * indistinguishable from one still loading.
-   *
-   * Split the same way `status` and `recentStatus` are, and for a sharper
-   * reason: `refreshCurrentData` runs both requests against the same prefix at
-   * once. Sharing one map by prefix meant the directory listing succeeding
-   * erased why the recent list had just failed, and the recent list then fell
-   * back to a generic "something went wrong" - the exact vagueness this change
-   * exists to remove. Each status setter owns its own map, so a status and its
-   * reason cannot drift apart.
-   */
-  failures: Record<string, ConnectionFailure>;
-  recentFailures: Record<string, ConnectionFailure>;
   currentPrefix: string | null;
   rootPrefix: string | null;
 
   setPrefixData: (prefix: string, data: PrefixData) => void;
   setRecentData: (prefix: string, data: RecentDataWithCache) => void;
   setCurrentPrefix: (prefix: string) => void;
-  setStatus: (prefix: string, s: Status) => void;
-  setRecentStatus: (prefix: string, s: Status) => void;
+  /** Writes a status and its reason as one value. */
+  setDirectoryState: (prefix: string, status: Status, failure?: ConnectionFailure) => void;
+  setRecentState: (prefix: string, status: Status, failure?: ConnectionFailure) => void;
   setLoadMoreStatus: (prefix: string, s: Status) => void;
-  setFailure: (prefix: string, failure: ConnectionFailure) => void;
-  setRecentFailure: (prefix: string, failure: ConnectionFailure) => void;
   setRootPrefix: (prefix: string) => void;
   clearAllData: () => void;
   removeDeletedFolder: (prefix: string) => void;
@@ -294,11 +296,9 @@ export const useDriveStore = create<Store>((set, get) => ({
   apiS3: null,
   cache: {},
   recentCache: {},
-  status: {},
-  recentStatus: {},
+  directory: {},
+  recent: {},
   loadMoreStatus: {},
-  failures: {},
-  recentFailures: {},
   rootPrefix: null,
   currentPrefix: null,
 
@@ -314,29 +314,17 @@ export const useDriveStore = create<Store>((set, get) => ({
       recentCache: { ...state.recentCache, [prefix]: data },
     })),
 
-  setStatus: (prefix, s) =>
-    set((state) => {
-      // A key that is loading or ready has no current failure. Leaving the old
-      // one behind would let a retry that succeeded still render its reason.
-      const failures = { ...state.failures };
-      if (s !== 'error') delete failures[prefix];
+  setDirectoryState: (prefix, status, failure) =>
+    set((state) => ({
+      // The reason travels with the status, so a stale one cannot outlive the
+      // failure it describes - a retry that succeeded used to keep rendering it.
+      directory: { ...state.directory, [prefix]: { status, failure } },
+    })),
 
-      return { status: { ...state.status, [prefix]: s }, failures };
-    }),
-
-  setFailure: (prefix, failure) =>
-    set((state) => ({ failures: { ...state.failures, [prefix]: failure } })),
-
-  setRecentFailure: (prefix, failure) =>
-    set((state) => ({ recentFailures: { ...state.recentFailures, [prefix]: failure } })),
-
-  setRecentStatus: (prefix, s) =>
-    set((state) => {
-      const recentFailures = { ...state.recentFailures };
-      if (s !== 'error') delete recentFailures[prefix];
-
-      return { recentStatus: { ...state.recentStatus, [prefix]: s }, recentFailures };
-    }),
+  setRecentState: (prefix, status, failure) =>
+    set((state) => ({
+      recent: { ...state.recent, [prefix]: { status, failure } },
+    })),
 
   setLoadMoreStatus: (prefix, s) =>
     set((state) => ({ loadMoreStatus: { ...state.loadMoreStatus, [prefix]: s } })),
@@ -360,11 +348,9 @@ export const useDriveStore = create<Store>((set, get) => ({
       apiS3: null,
       cache: {},
       recentCache: {},
-      status: {},
-      recentStatus: {},
+      directory: {},
+      recent: {},
       loadMoreStatus: {},
-      failures: {},
-      recentFailures: {},
       currentPrefix: null,
       rootPrefix: null,
     });
@@ -394,8 +380,8 @@ export const useDriveStore = create<Store>((set, get) => ({
     for (const map of [
       current.cache,
       current.recentCache,
-      current.status,
-      current.recentStatus,
+      current.directory,
+      current.recent,
       current.loadMoreStatus,
     ]) {
       for (const key of Object.keys(map)) {
@@ -413,15 +399,15 @@ export const useDriveStore = create<Store>((set, get) => ({
     set((state) => {
       const cache = { ...state.cache };
       const recentCache = { ...state.recentCache };
-      const status = { ...state.status };
-      const recentStatus = { ...state.recentStatus };
+      const directory = { ...state.directory };
+      const recent = { ...state.recent };
       const loadMoreStatus = { ...state.loadMoreStatus };
 
       for (const key of gone) {
         delete cache[key];
         delete recentCache[key];
-        delete status[key];
-        delete recentStatus[key];
+        delete directory[key];
+        delete recent[key];
         delete loadMoreStatus[key];
       }
 
@@ -439,17 +425,17 @@ export const useDriveStore = create<Store>((set, get) => ({
       // 'loading' for good: a listing stuck behind its skeleton, and a "Show
       // more" that refuses to run again because it thinks one is still going.
       // What is already cached is what there is to show, so say so.
-      if (status[parentKey] === 'loading') {
-        if (cache[parentKey]) status[parentKey] = 'ready';
-        else delete status[parentKey];
+      if (directory[parentKey]?.status === 'loading') {
+        if (cache[parentKey]) directory[parentKey] = { status: 'ready' };
+        else delete directory[parentKey];
       }
-      if (recentStatus[parentKey] === 'loading') {
-        if (recentCache[parentKey]) recentStatus[parentKey] = 'ready';
-        else delete recentStatus[parentKey];
+      if (recent[parentKey]?.status === 'loading') {
+        if (recentCache[parentKey]) recent[parentKey] = { status: 'ready' };
+        else delete recent[parentKey];
       }
       if (loadMoreStatus[parentKey] === 'loading') delete loadMoreStatus[parentKey];
 
-      return { cache, recentCache, status, recentStatus, loadMoreStatus };
+      return { cache, recentCache, directory, recent, loadMoreStatus };
     });
 
     // The search cache is deliberately left alone. clearCache also drops the
@@ -460,16 +446,8 @@ export const useDriveStore = create<Store>((set, get) => ({
   },
 
   fetchData: async (opts = { sync: false }) => {
-    const {
-      apiS3,
-      currentPrefix,
-      rootPrefix,
-      status,
-      cache,
-      setPrefixData,
-      setStatus,
-      setFailure,
-    } = get();
+    const { apiS3, currentPrefix, rootPrefix, directory, cache, setPrefixData, setDirectoryState } =
+      get();
 
     if (!apiS3) return;
 
@@ -482,7 +460,7 @@ export const useDriveStore = create<Store>((set, get) => ({
     const keyPrefix = formattedPrefix === '' ? '/' : formattedPrefix;
 
     // Avoid duplicate concurrent fetches unless forced by sync
-    const currStatus = status[keyPrefix];
+    const currStatus = directory[keyPrefix]?.status;
 
     if (currStatus === 'ready' && !opts.sync) return;
 
@@ -492,7 +470,7 @@ export const useDriveStore = create<Store>((set, get) => ({
     // Don't auto-refetch just because isTruncated is true - let the user decide
     // with the "Show More" button.
     if (currentData && !opts.sync) {
-      if (currStatus !== 'ready') setStatus(keyPrefix, 'ready');
+      if (currStatus !== 'ready') setDirectoryState(keyPrefix, 'ready');
       return;
     }
 
@@ -504,7 +482,7 @@ export const useDriveStore = create<Store>((set, get) => ({
       const requestId = claimRequestId(latestRequestId, keyPrefix);
 
       try {
-        setStatus(keyPrefix, 'loading');
+        setDirectoryState(keyPrefix, 'loading');
 
         // Always read from the top. This branch only runs when there is no data
         // yet or a sync was forced, and either way the result replaces the cache
@@ -523,17 +501,15 @@ export const useDriveStore = create<Store>((set, get) => ({
           nextToken: data.nextToken,
           isTruncated: data.isTruncated,
         });
-        setStatus(keyPrefix, 'ready');
+        setDirectoryState(keyPrefix, 'ready');
       } catch (error) {
         // A superseded request must not report an error over a newer request's
         // result, or a folder that loaded fine renders as failed.
         if (isSuperseded(latestRequestId, keyPrefix, requestId)) return;
 
-        // Recorded before the status, because setStatus('error') is what a
-        // subscriber wakes on - setting it first would render one frame with
-        // no reason to show.
-        setFailure(keyPrefix, classifyConnectionFailure(error));
-        setStatus(keyPrefix, 'error');
+        // One write, so there is no frame in which the row knows it failed
+        // but not why.
+        setDirectoryState(keyPrefix, 'error', classifyConnectionFailure(error));
       }
     });
   },
@@ -571,16 +547,8 @@ export const useDriveStore = create<Store>((set, get) => ({
   },
 
   fetchRecentItems: async (opts = { sync: false, itemsPerType: 10 }) => {
-    const {
-      apiS3,
-      currentPrefix,
-      rootPrefix,
-      recentStatus,
-      recentCache,
-      setRecentData,
-      setRecentStatus,
-      setRecentFailure,
-    } = get();
+    const { apiS3, currentPrefix, rootPrefix, recent, recentCache, setRecentData, setRecentState } =
+      get();
 
     if (!apiS3) return;
 
@@ -589,7 +557,7 @@ export const useDriveStore = create<Store>((set, get) => ({
     const formattedPrefix = rootPrefix === '/' && currentPrefix === '/' ? '' : currentPrefix;
     const keyPrefix = formattedPrefix === '' ? '/' : formattedPrefix;
 
-    const currStatus = recentStatus[keyPrefix];
+    const currStatus = recent[keyPrefix]?.status;
     if (currStatus === 'ready' && !opts.sync) return;
 
     // Ensure itemsPerType has a default value
@@ -602,7 +570,7 @@ export const useDriveStore = create<Store>((set, get) => ({
       const requestId = claimRequestId(latestRecentRequestId, keyPrefix);
 
       try {
-        setRecentStatus(keyPrefix, 'loading');
+        setRecentState(keyPrefix, 'loading');
 
         // Fetch up to 1000 items from current directory
         const data = await apiS3.fetchDirectoryStructure(formattedPrefix, 1000);
@@ -648,12 +616,11 @@ export const useDriveStore = create<Store>((set, get) => ({
         }
 
         setRecentData(keyPrefix, recentData);
-        setRecentStatus(keyPrefix, 'ready');
+        setRecentState(keyPrefix, 'ready');
       } catch (error) {
         if (isSuperseded(latestRecentRequestId, keyPrefix, requestId)) return;
 
-        setRecentFailure(keyPrefix, classifyConnectionFailure(error));
-        setRecentStatus(keyPrefix, 'error');
+        setRecentState(keyPrefix, 'error', classifyConnectionFailure(error));
       }
     });
   },
@@ -795,45 +762,40 @@ export const useDriveStore = create<Store>((set, get) => ({
  */
 export function useDirectoryState(): AsyncState<PrefixData> {
   const currentPrefix = useDriveStore((state) => state.currentPrefix);
-  const status = useDriveStore((state) =>
-    currentPrefix ? state.status[currentPrefix] : undefined
+  const entry = useDriveStore((state) =>
+    currentPrefix ? state.directory[currentPrefix] : undefined
   );
   const data = useDriveStore((state) => (currentPrefix ? state.cache[currentPrefix] : undefined));
-  const failure = useDriveStore((state) =>
-    currentPrefix ? state.failures[currentPrefix] : undefined
-  );
   const fetchData = useDriveStore((state) => state.fetchData);
 
-  return toAsyncState(status, data, failure, () => void fetchData({ sync: true }));
+  return toAsyncState(entry, data, () => void fetchData({ sync: true }));
 }
 
 /** The same, for the recent-items list on the dashboard home. */
 export function useRecentState(): AsyncState<RecentDataWithCache> {
   const currentPrefix = useDriveStore((state) => state.currentPrefix);
-  const status = useDriveStore((state) =>
-    currentPrefix ? state.recentStatus[currentPrefix] : undefined
-  );
+  const entry = useDriveStore((state) => (currentPrefix ? state.recent[currentPrefix] : undefined));
   const data = useDriveStore((state) =>
     currentPrefix ? state.recentCache[currentPrefix] : undefined
   );
-  const failure = useDriveStore((state) =>
-    currentPrefix ? state.recentFailures[currentPrefix] : undefined
-  );
   const fetchRecentItems = useDriveStore((state) => state.fetchRecentItems);
 
-  return toAsyncState(status, data, failure, () => void fetchRecentItems({ sync: true }));
+  return toAsyncState(entry, data, () => void fetchRecentItems({ sync: true }));
 }
 
 function toAsyncState<T>(
-  status: Status | undefined,
+  entry: RequestState | undefined,
   data: T | undefined,
-  failure: ConnectionFailure | undefined,
   retry: () => void
 ): AsyncState<T> {
-  if (status === 'error') {
-    // A key can be marked failed a frame before its reason is recorded, and an
-    // 'unknown' failure still tells the user more than a skeleton would.
-    return { state: 'error', failure: failure ?? classifyConnectionFailure(undefined), retry };
+  if (entry?.status === 'error') {
+    // The reason arrives with the status now, so the fallback is only for a
+    // failure recorded before this rule existed.
+    return {
+      state: 'error',
+      failure: entry.failure ?? classifyConnectionFailure(undefined),
+      retry,
+    };
   }
 
   // Data without a ready status is a folder being re-synced: it has rows on
@@ -841,5 +803,5 @@ function toAsyncState<T>(
   // a worse answer than showing what is there.
   if (data !== undefined) return { state: 'ready', data };
 
-  return status === 'loading' ? { state: 'loading' } : { state: 'idle' };
+  return entry?.status === 'loading' ? { state: 'loading' } : { state: 'idle' };
 }

--- a/frontend/src/context/data-context.tsx
+++ b/frontend/src/context/data-context.tsx
@@ -754,11 +754,11 @@ export const useDriveStore = create<Store>((set, get) => ({
  * The directory listing for the folder the user is standing in, as one value
  * that cannot be read without deciding what a failure looks like.
  *
- * The store keeps status, data and failure in three separate maps, which is
- * fine for writing but is exactly what let both dashboard pages write
- * `status[prefix] === 'ready' ? rows : skeleton` and silently render a failed
- * listing as a skeleton forever. Narrowing happens here once, so a page reaches
- * `data` only through the branch that has any.
+ * The store keeps the request's state and its data in two maps, which is fine
+ * for writing but is exactly what let both dashboard pages ask whether a
+ * listing was ready and render a skeleton for every other answer - so a failed
+ * listing sat behind a skeleton forever. Narrowing happens here once, so a page
+ * reaches `data` only through the branch that has any.
  */
 export function useDirectoryState(): AsyncState<PrefixData> {
   const currentPrefix = useDriveStore((state) => state.currentPrefix);

--- a/frontend/src/features/upload/components/delete-recovery-banner.test.tsx
+++ b/frontend/src/features/upload/components/delete-recovery-banner.test.tsx
@@ -83,7 +83,7 @@ function standingIn(prefix: string) {
       },
       [prefix]: { folders: [], files: [], isTruncated: false },
     },
-    status: { '/': 'ready', [prefix]: 'ready' },
+    directory: { '/': { status: 'ready' }, [prefix]: { status: 'ready' } },
   });
 }
 
@@ -374,7 +374,7 @@ describe('recovering from inside the folder', () => {
           isTruncated: false,
         },
       },
-      status: { '/': 'ready' },
+      directory: { '/': { status: 'ready' } },
     });
     listFromPrefix.mockResolvedValue(['a.txt']);
     render(<DeleteRecoveryBanner />);


### PR DESCRIPTION
Split out of #184. Internal only — no behaviour change.

## Change

The drive store kept `status`, `recentStatus`, `failures` and `recentFailures` as four maps keyed by the same prefix, with nothing forcing any two to agree.

That already caused a bug once: with one shared failures map, the directory listing finishing erased why the recent list had failed, and the recent list fell back to a generic "something went wrong". Splitting the map per request kind fixed that instance without fixing the shape — four maps that must stay in step are still four maps that can fall out of step.

Each key now holds one `RequestState { status, failure? }`. A reason is only written with the status it explains, and the error path is a single write instead of two, so there's no frame where a row knows it failed but not why.

## Testing

Nothing user-visible to click through. The `AsyncState` selectors already hid the store's shape from every page, so `useDirectoryState` / `useRecentState` keep their signatures and nothing outside `data-context` and its tests moved.

Worth confirming failure states still read correctly:
- Break credentials, open a folder — should show the specific reason, not "something went wrong".
- Retry after a failure resolves — the old reason should not persist.
- Delete a folder while its listing is loading — parent shouldn't stick on a skeleton.

1237 tests pass, typecheck clean, 0 lint errors.