### PR TITLE
fix: server-render the landing page, and clear the drive cache on connect

### DIFF
--- a/.changeset/public-landing-page.md
+++ b/.changeset/public-landing-page.md
@@ -1,0 +1,21 @@
+---
+'frontend': patch
+---
+
+Server-render the landing page, and stop createSession navigating
+
+`isLoading` starts true, so `AuthProvider` renders a `Loading...` placeholder
+for any route not on its public list — which is the whole body of the page a
+crawler sees. `/privacy`, `/terms` and `/connect` were exempt for that reason.
+The landing page was not, so the hero, the features and the FAQ were all
+invisible without JavaScript. It is on the list now.
+
+That also means the page renders before a session has been looked for, so the
+main call to action no longer has a loading state: it reads "Get Started" and
+goes to /connect until a session turns up, rather than server-rendering a
+disabled button labelled "Loading..." as the page's primary CTA.
+
+`createSession` no longer pushes to /dashboard. Its only caller is
+ConnectWizard, which lives at /connect/[provider] and navigates itself once the
+session resolves — so the branch could only have fired from `/` or `/login`,
+neither of which has a connect form, and `/login` is not a route.

--- a/.changeset/public-landing-page.md
+++ b/.changeset/public-landing-page.md
@@ -5,7 +5,7 @@
 Server-render the landing page, and stop createSession navigating
 
 `isLoading` starts true, so `AuthProvider` renders a `Loading...` placeholder
-for any route not on its public list — which is the whole body of the page a
+for any route not on its public list, which is the whole body of the page a
 crawler sees. `/privacy`, `/terms` and `/connect` were exempt for that reason.
 The landing page was not, so the hero, the features and the FAQ were all
 invisible without JavaScript. It is on the list now.
@@ -17,5 +17,5 @@ disabled button labelled "Loading..." as the page's primary CTA.
 
 `createSession` no longer pushes to /dashboard. Its only caller is
 ConnectWizard, which lives at /connect/[provider] and navigates itself once the
-session resolves — so the branch could only have fired from `/` or `/login`,
+session resolves, so the branch could only have fired from `/` or `/login`,
 neither of which has a connect form, and `/login` is not a route.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -28,7 +28,7 @@ const navItems = [
 
 export default function LandingPage() {
   const router = useRouter();
-  const { userCreds, isLoading } = useAuth();
+  const { userCreds } = useAuth();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [showMobileNav, setShowMobileNav] = useState(false);
 
@@ -62,12 +62,17 @@ export default function LandingPage() {
    *
    * The session comes from the auth context rather than a second, hand-copied
    * read of the `s3_user_session` key, which is the sort of duplicate that
-   * survives a rename of the original. `AuthProvider` holds this page back
-   * until the restore has finished, so `userCreds` is settled by the time any
-   * of this renders; the loading label is what shows if that ever changes.
+   * survives a rename of the original.
+   *
+   * There is deliberately no loading state. This page is public now, so the
+   * server renders it before any session has been looked for - and a hero
+   * button reading "Loading..." is what a crawler would have indexed as the
+   * call to action. It says "Get Started" and goes to /connect until a session
+   * turns up, which is the right answer for almost everyone who lands here and
+   * a harmless one for the rest: /connect offers them the way back in.
    */
   const hasSession = userCreds !== null;
-  const ctaLabel = isLoading ? 'Loading...' : hasSession ? 'Go to Dashboard' : 'Get Started';
+  const ctaLabel = hasSession ? 'Go to Dashboard' : 'Get Started';
 
   const handleGetStarted = () => {
     router.push(hasSession ? '/dashboard' : '/connect');
@@ -176,7 +181,6 @@ export default function LandingPage() {
                     setIsMobileMenuOpen(false);
                     handleGetStarted();
                   }}
-                  disabled={isLoading}
                   className="w-full bg-primary text-primary-foreground hover:bg-primary/90 px-4 py-2.5 text-sm font-medium rounded-md transition-colors"
                 >
                   {ctaLabel}
@@ -195,14 +199,14 @@ export default function LandingPage() {
         />
       )}
 
-      <HeroSection handleGetStarted={handleGetStarted} isLoading={isLoading} ctaLabel={ctaLabel} />
+      <HeroSection handleGetStarted={handleGetStarted} ctaLabel={ctaLabel} />
       {/* Add top padding after hero section for mobile navbar */}
       <div className="lg:pt-0" style={{ paddingTop: showMobileNav ? '3.5rem' : '0' }}>
         <Navbar />
         <FeaturesSection />
         <WorkSmarterSection />
         <FAQSection />
-        <CTASection handleGetStarted={handleGetStarted} isLoading={isLoading} ctaLabel={ctaLabel} />
+        <CTASection handleGetStarted={handleGetStarted} ctaLabel={ctaLabel} />
         <SiteFooter />
       </div>
     </main>

--- a/frontend/src/app/privacy/legal-pages-ssr.test.tsx
+++ b/frontend/src/app/privacy/legal-pages-ssr.test.tsx
@@ -98,10 +98,22 @@ describe('connect pages render for crawlers', () => {
   );
 });
 
+// The landing page is the pitch - hero, features, FAQ - and was the one public
+// page still gated. It sat in the list below, grouped with the dashboard as if
+// it were something to protect.
+describe('the landing page renders for crawlers', () => {
+  it('renders real content on /', () => {
+    const html = renderThroughProviders('/', <div>landing content</div>);
+
+    expect(html).not.toContain('Loading...');
+    expect(html).toContain('landing content');
+  });
+});
+
 describe('every other route keeps the gate it had', () => {
   // The placeholder exists so the dashboard never renders without a session.
   // Only pages that must be readable before anyone has a session are exempt.
-  it.each(['/dashboard', '/dashboard/search', '/dashboard/settings', '/'])(
+  it.each(['/dashboard', '/dashboard/search', '/dashboard/settings'])(
     'still shows the placeholder on %s',
     (pathname) => {
       const html = renderThroughProviders(pathname, <div>protected content</div>);

--- a/frontend/src/app/privacy/legal-pages-ssr.test.tsx
+++ b/frontend/src/app/privacy/legal-pages-ssr.test.tsx
@@ -41,6 +41,7 @@ let mockPathname = '/privacy';
 import { AuthProvider } from '@/context/auth-context';
 import PrivacyPolicyPage from './page';
 import TermsOfServicePage from '../terms/page';
+import LandingPage from '../page';
 
 function renderThroughProviders(pathname: string, page: React.ReactElement): string {
   mockPathname = pathname;
@@ -102,11 +103,21 @@ describe('connect pages render for crawlers', () => {
 // page still gated. It sat in the list below, grouped with the dashboard as if
 // it were something to protect.
 describe('the landing page renders for crawlers', () => {
-  it('renders real content on /', () => {
-    const html = renderThroughProviders('/', <div>landing content</div>);
+  const html = renderThroughProviders('/', <LandingPage />);
 
+  it('is not replaced by the auth loading placeholder', () => {
     expect(html).not.toContain('Loading...');
-    expect(html).toContain('landing content');
+  });
+
+  it('renders the pitch into the markup', () => {
+    expect(html).toContain('Open-source web interface for S3 compatible storage');
+  });
+
+  // The call to action is the point of the page, and it is rendered before any
+  // session has been looked for. If it ever goes back to reporting that, this
+  // is what a crawler would index in its place.
+  it('renders a real call to action rather than a loading state', () => {
+    expect(html).toContain('Get Started');
   });
 });
 

--- a/frontend/src/context/auth-context.test.tsx
+++ b/frontend/src/context/auth-context.test.tsx
@@ -469,3 +469,107 @@ describe('restoring a session does not navigate', () => {
     expect(pushMock).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Public pages render before a session has been looked for.
+ *
+ * `isLoading` starts true, so the placeholder is what the server renders for
+ * any route not on the public list - the page's entire body is the word
+ * "Loading...", which is also what a crawler indexes. `/privacy`, `/terms` and
+ * `/connect` were on the list for that reason; the landing page, which is the
+ * whole pitch, was not.
+ */
+describe('public routes render without waiting for the session', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    localStorage.clear();
+    route.current = '/dashboard';
+  });
+
+  it.each(['/', '/privacy', '/terms', '/connect', '/connect/cloudflare-r2'])(
+    'renders %s straight away',
+    (pathname) => {
+      route.current = pathname;
+
+      render(
+        <AuthProvider>
+          <SessionControls />
+        </AuthProvider>
+      );
+
+      // No waitFor: the point is that this is in the very first render.
+      expect(screen.getByText('logout')).toBeDefined();
+      expect(screen.queryByText('Loading...')).toBeNull();
+    }
+  );
+
+  // A stored session is what makes the restore genuinely asynchronous: with
+  // nothing to restore it resolves before the first render returns, and the
+  // placeholder never appears on any route.
+  const storedCreds = JSON.stringify({
+    accessKeyId: 'AKIA_A',
+    secretAccessKey: 'secret-a',
+    region: 'us-east-1',
+  });
+
+  it.each(['/dashboard', '/dashboard/browse'])('still gates %s behind the restore', (pathname) => {
+    // '/' would match every route if the child test treated it as a bare
+    // prefix. It looks for a '/' after the route, and nothing begins with '//'.
+    route.current = pathname;
+    localStorage.setItem(STORAGE_KEY, storedCreds);
+
+    render(
+      <AuthProvider>
+        <SessionControls />
+      </AuthProvider>
+    );
+
+    expect(screen.getByText('Loading...')).toBeDefined();
+  });
+
+  it('renders / straight away even with a session to restore', () => {
+    route.current = '/';
+    localStorage.setItem(STORAGE_KEY, storedCreds);
+
+    render(
+      <AuthProvider>
+        <SessionControls />
+      </AuthProvider>
+    );
+
+    expect(screen.getByText('logout')).toBeDefined();
+    expect(screen.queryByText('Loading...')).toBeNull();
+  });
+});
+
+/**
+ * Establishing a session is not a reason to navigate either.
+ *
+ * `createSession` used to push to /dashboard from `/` or `/login`. Its only
+ * caller is ConnectWizard, which lives at /connect/[provider] and navigates
+ * itself once this resolves - so the branch could never fire, and `/login` is
+ * not a route at all.
+ */
+describe('createSession does not navigate', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    localStorage.clear();
+    route.current = '/connect/cloudflare-r2';
+    s3.fetchDirectoryStructure.mockResolvedValue({ files: [], folders: [] });
+  });
+
+  it.each(['/', '/login', '/connect/cloudflare-r2'])(
+    'leaves navigation to the caller from %s',
+    async (pathname) => {
+      route.current = pathname;
+      await renderProvider();
+
+      await act(async () => {
+        screen.getByText('connect').click();
+      });
+
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      expect(pushMock).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -120,6 +120,18 @@ async function initializeUploadManagers(
   // on the restore-at-startup path, where nothing is in flight yet.
   useUploadStore.getState().abortAllDeleteOperations();
 
+  // The listing cache needs it most of all, and was the one thing this did not
+  // clear. `fetchData` returns early when a prefix is already 'ready' or has
+  // rows cached, so connecting a second bucket without logging out first left
+  // the dashboard showing the previous bucket's file and folder names, and
+  // never refetching them until a full page reload.
+  //
+  // That path stopped being obscure when the connect pages stopped redirecting
+  // a signed-in visitor away: adding a second bucket is a thing people can now
+  // walk into from a bookmark. This also drops the in-flight request ids, so a
+  // listing issued for the old bucket cannot land as the new one's.
+  useDriveStore.getState().clearAllData();
+
   // This is the ONE place upload concurrency is set. The executor deliberately
   // has no pool of its own - two components each believing they control how
   // many uploads are in flight is how "3 at a time" becomes six.

--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -169,9 +169,16 @@ const STORAGE_KEY = 's3_user_session';
  * /connect is a landing page we actively want ranked. A crawler that is served
  * `Loading...` indexes `Loading...`.
  *
- * Matching covers children, so /connect/cloudflare-r2 is public too.
+ * `/` is in the list for exactly that reason, and was the conspicuous omission:
+ * the marketing page - the hero, the features, the FAQ, the whole pitch - was
+ * the one public page still serving `Loading...` as its entire body to anyone
+ * who arrived without JavaScript, crawlers included.
+ *
+ * Matching covers children, so /connect/cloudflare-r2 is public too. It does
+ * not make `/` match everything: the child test looks for a `/` *after* the
+ * route, and no path begins with `//`.
  */
-const PUBLIC_ROUTES = ['/privacy', '/terms', '/connect'];
+const PUBLIC_ROUTES = ['/', '/privacy', '/terms', '/connect'];
 
 function isPublicRoute(pathname: string | null): boolean {
   if (pathname === null) return false;
@@ -310,10 +317,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setSignedUrlUploadManager(signedUrlManager);
       localStorage.setItem(STORAGE_KEY, JSON.stringify(creds));
 
-      // You can redirect somewhere after login
-      if (pathname === '/' || pathname === '/login') {
-        router.push('/dashboard');
-      }
+      // Deliberately does not navigate. The one caller is ConnectWizard, which
+      // lives at /connect/[provider] and pushes to /dashboard itself once this
+      // resolves - so the branch this replaced could only ever have fired from
+      // `/` or `/login`, and neither has a form on it. `/login` is not even a
+      // route. Navigation belongs to the caller that knows why it called.
     } catch (error) {
       console.error('Login failed', error);
 

--- a/frontend/src/features/landing-page/components/cta-section.tsx
+++ b/frontend/src/features/landing-page/components/cta-section.tsx
@@ -4,7 +4,12 @@ import { DiscordCtaBanner } from '@/shared/components/discord/discord-cta-banner
 
 interface CTASectionProps {
   handleGetStarted: () => void;
-  /** The blog's copies own their navigation and disable the button while it runs. */
+  /**
+   * The blog's copies own their navigation and hold this true from the click
+   * until the route changes, so the button reads as busy rather than sitting
+   * disabled under a label that still invites a press. The landing page has
+   * nothing to wait for and leaves it alone.
+   */
   isLoading?: boolean;
   /**
    * Named by the page, which is the only thing that knows the destination.
@@ -49,7 +54,7 @@ export default function CTASection({
               disabled={isLoading}
               className="bg-primary hover:bg-primary/90 text-primary-foreground px-6 sm:px-8 md:px-10 lg:px-12 py-2.5 sm:py-3 md:py-4 text-sm sm:text-base md:text-lg font-medium min-w-[120px] sm:min-w-[140px] md:min-w-[160px]"
             >
-              {ctaLabel}
+              {isLoading ? 'Loading...' : ctaLabel}
             </Button>
           </div>
 

--- a/frontend/src/features/landing-page/components/cta-section.tsx
+++ b/frontend/src/features/landing-page/components/cta-section.tsx
@@ -4,7 +4,8 @@ import { DiscordCtaBanner } from '@/shared/components/discord/discord-cta-banner
 
 interface CTASectionProps {
   handleGetStarted: () => void;
-  isLoading: boolean;
+  /** The blog's copies own their navigation and disable the button while it runs. */
+  isLoading?: boolean;
   /**
    * Named by the page, which is the only thing that knows the destination.
    * The blog's copies of this section always route to /connect, so they take
@@ -15,7 +16,7 @@ interface CTASectionProps {
 
 export default function CTASection({
   handleGetStarted,
-  isLoading,
+  isLoading = false,
   ctaLabel = 'Get Started',
 }: CTASectionProps) {
   return (

--- a/frontend/src/features/landing-page/components/hero-section.tsx
+++ b/frontend/src/features/landing-page/components/hero-section.tsx
@@ -22,12 +22,11 @@ const navItems = [
 
 interface HeroSectionProps {
   handleGetStarted: () => void;
-  isLoading: boolean;
   /** Named by the page, which is the only thing that knows the destination. */
   ctaLabel: string;
 }
 
-export default function HeroSection({ handleGetStarted, isLoading, ctaLabel }: HeroSectionProps) {
+export default function HeroSection({ handleGetStarted, ctaLabel }: HeroSectionProps) {
   const router = useRouter();
   const effectiveTheme = useEffectiveTheme();
 
@@ -75,7 +74,6 @@ export default function HeroSection({ handleGetStarted, isLoading, ctaLabel }: H
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mt-6 sm:mt-8 justify-center lg:justify-start">
               <Button
                 onClick={handleGetStarted}
-                disabled={isLoading}
                 className="bg-primary text-primary-foreground hover:bg-primary/90 px-6 sm:px-8 lg:px-10 py-3 sm:py-3.5 lg:py-4 text-sm sm:text-base lg:text-lg font-medium w-full sm:w-auto text-center min-w-[140px] sm:min-w-[160px]"
               >
                 {ctaLabel}


### PR DESCRIPTION
Stacked on #190 — **base that branch, not main.** Merge #190 first and this retargets to main.

The two follow-ups I flagged on #190, plus a bug the review found in the flow #190 opens up.

## Changes

**`/` is now a public route.** `isLoading` starts true, so `AuthProvider` renders `Loading...` as the entire body for any route not on its public list. `/privacy`, `/terms` and `/connect` were exempt for that reason — the landing page wasn't, so the hero, features and FAQ were invisible without JavaScript on the one page whose job is to be found. A test asserted this, grouping `/` with `/dashboard` as if it were protected.

Listing `/` doesn't make everything public: the child test looks for a `/` *after* the route, and nothing starts with `//`.

**The CTA loses its loading state.** Now that the page server-renders, the old label would have shipped a disabled button reading "Loading..." as the primary CTA. It says "Get Started" and goes to `/connect` until a session turns up — right for almost everyone landing here, harmless for the rest since `/connect` offers them the way back.

**`createSession` no longer navigates.** Its only caller is `ConnectWizard`, which pushes to `/dashboard` itself. The branch could only fire from `/` or `/login` — neither has a connect form, and `/login` isn't a route.

**Connecting a second bucket no longer shows the first one's files.** `createSession` never cleared the drive store, and `fetchData` short-circuits on a populated cache — so bucket B's dashboard showed bucket A's names until a full reload. `initializeUploadManagers` already cleared the search cache and in-flight deletes on exactly this reasoning; the listing cache was the one thing it missed. #190 is what makes this easy to walk into.

## Testing

- View source on `/` with JS disabled — hero copy and "Get Started" should be in the HTML, not "Loading...".
- `/dashboard` should still show the placeholder until the session restores.
- Connect bucket A, go to `/connect` without logging out, connect bucket B — dashboard should show B's files, not A's.
- Connect from a provider page — still lands on the dashboard.

1271 tests pass, typecheck clean, 0 lint errors, clean build.