### PR TITLE
fix: size the sidebar nav icons on the icon, not on a box around it

### DIFF
--- a/.changeset/sidebar-icons.md
+++ b/.changeset/sidebar-icons.md
@@ -1,0 +1,17 @@
+---
+'frontend': patch
+---
+
+Size the sidebar nav icons on the icon rather than on a box around it
+
+The size classes sat on a wrapper `div` and the icon inside was given none.
+`react-icons` default to a width and height of `1em`, so the icon inherited the
+row's `text-sm` and drew at 14px inside a slot reserved for 20. It read as
+misaligned for the same reason: an svg is inline-level, so it sat on the text
+baseline in the corner of that box with the line-height gap beneath it, rather
+than centred against its label.
+
+The size is on the icon now and the wrapper is gone. The row is already
+`flex items-center`, so a direct child is centred by the row itself and there is
+no intermediate element left to get it wrong. Icons are 20px against a 14px
+label, which is the usual pairing, and 16px for a nested item.

--- a/.changeset/sidebar-icons.md
+++ b/.changeset/sidebar-icons.md
@@ -6,10 +6,10 @@ Size the sidebar nav icons on the icon rather than on a box around it
 
 The size classes sat on a wrapper `div` and the icon inside was given none.
 `react-icons` default to a width and height of `1em`, so the icon inherited the
-row's `text-sm` and drew at 14px inside a slot reserved for 20. It read as
-misaligned for the same reason: an svg is inline-level, so it sat on the text
-baseline in the corner of that box with the line-height gap beneath it, rather
-than centred against its label.
+row's `text-sm` and drew at 14px inside a slot reserved for 20. It looked
+misaligned for the same reason: Tailwind's preflight makes an svg
+`display: block`, so those 14px sat in the top left corner of the 20px box. The
+row centred the box, and nothing centred the icon inside it.
 
 The size is on the icon now and the wrapper is gone. The row is already
 `flex items-center`, so a direct child is centred by the row itself and there is

--- a/frontend/src/features/dashboard/components/layout/sidebar/sidebar-dropdown.tsx
+++ b/frontend/src/features/dashboard/components/layout/sidebar/sidebar-dropdown.tsx
@@ -27,14 +27,14 @@ export const SidebarDropdown: React.FC<SidebarDropdownProps> = ({
         )}
       >
         <div className="flex items-center flex-1 min-w-0">
-          <div
+          {/* Same fix as SidebarItem: the size belongs on the icon, and the
+              row is already centring its children. */}
+          <item.icon
             className={cn(
               'flex-shrink-0 mr-3 h-5 w-5',
               (itemIsActive || hasActiveChild) && 'text-primary-foreground'
             )}
-          >
-            <item.icon />
-          </div>
+          />
           <span className="truncate">{item.title}</span>
           {item.badge && (
             <span

--- a/frontend/src/features/dashboard/components/layout/sidebar/sidebar-item.test.tsx
+++ b/frontend/src/features/dashboard/components/layout/sidebar/sidebar-item.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * The nav icon has to be the thing that is sized.
+ *
+ * The size classes used to sit on a wrapper `div` around the icon, and the icon
+ * itself was given nothing. `react-icons` default to a width and height of
+ * `1em`, so it inherited the row's `text-sm` and drew at 14px inside a slot
+ * reserved for 20 - small, and sitting on the text baseline in the corner of
+ * that box rather than centred, because an svg is inline-level.
+ *
+ * These pin the size onto the icon. The centring is structural: the row is
+ * `flex items-center`, so a direct child is centred by the row itself and there
+ * is no wrapper left to get it wrong.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SidebarItem } from './sidebar-item';
+import type { SidebarItem as SidebarItemType } from './types/sidebar';
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: { children: React.ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+// Stands in for a react-icons component, which spreads className onto its svg.
+function TestIcon({ className }: { className?: string }) {
+  return <svg data-testid="nav-icon" className={className} />;
+}
+
+const item: SidebarItemType = {
+  title: 'My Drive',
+  href: '/browse',
+  icon: TestIcon,
+};
+
+function renderItem(over: Partial<Parameters<typeof SidebarItem>[0]> = {}) {
+  return render(
+    <SidebarItem
+      item={item}
+      basePath="/dashboard"
+      isActive={() => false}
+      onItemClick={() => {}}
+      {...over}
+    />
+  );
+}
+
+describe('the sidebar icon carries its own size', () => {
+  it('sizes the icon rather than a box around it', () => {
+    renderItem();
+
+    const icon = screen.getByTestId('nav-icon');
+
+    expect(icon.getAttribute('class')).toContain('h-5');
+    expect(icon.getAttribute('class')).toContain('w-5');
+  });
+
+  it('leaves no wrapper between the row and the icon', () => {
+    // A wrapper is what let the icon sit uncentred: the row centres its own
+    // children, and a block div in between does not pass that on.
+    const { container } = renderItem();
+    const icon = screen.getByTestId('nav-icon');
+
+    expect(icon.parentElement).toBe(container.querySelector('a'));
+  });
+
+  it('uses the smaller size for a nested item', () => {
+    renderItem({ isInDropdown: true });
+
+    const icon = screen.getByTestId('nav-icon');
+
+    expect(icon.getAttribute('class')).toContain('h-4');
+    expect(icon.getAttribute('class')).toContain('w-4');
+  });
+
+  it('still recolours the icon on the active row', () => {
+    // react-icons fill with currentColor, so this has to reach the svg.
+    renderItem({ isActive: () => true });
+
+    expect(screen.getByTestId('nav-icon').getAttribute('class')).toContain(
+      'text-primary-foreground'
+    );
+  });
+});

--- a/frontend/src/features/dashboard/components/layout/sidebar/sidebar-item.test.tsx
+++ b/frontend/src/features/dashboard/components/layout/sidebar/sidebar-item.test.tsx
@@ -1,20 +1,23 @@
 /**
  * The nav icon has to be the thing that is sized.
  *
- * The size classes used to sit on a wrapper `div` around the icon, and the icon
- * itself was given nothing. `react-icons` default to a width and height of
- * `1em`, so it inherited the row's `text-sm` and drew at 14px inside a slot
- * reserved for 20 - small, and sitting on the text baseline in the corner of
- * that box rather than centred, because an svg is inline-level.
+ * The size classes used to sit on a wrapper `div` and the icon inside was given
+ * nothing. `react-icons` default to a width and height of `1em`, so it
+ * inherited the row's `text-sm` and drew at 14px. The wrapper reserved 20, and
+ * Tailwind's preflight makes an svg `display: block`, so those 14px sat in the
+ * top left corner of that box: the row centred the box, and nothing centred the
+ * icon inside it. Small and high, from one cause.
  *
- * These pin the size onto the icon. The centring is structural: the row is
- * `flex items-center`, so a direct child is centred by the row itself and there
- * is no wrapper left to get it wrong.
+ * These pin the size onto the icon itself, and pin the absence of a sized box
+ * around it, which is the half that made it look off-centre. Both rows are
+ * covered because they carry the same markup and drifting apart is how this
+ * comes back.
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { SidebarItem } from './sidebar-item';
+import { SidebarDropdown } from './sidebar-dropdown';
 import type { SidebarItem as SidebarItemType } from './types/sidebar';
 
 vi.mock('next/link', () => ({
@@ -54,13 +57,16 @@ describe('the sidebar icon carries its own size', () => {
     expect(icon.getAttribute('class')).toContain('w-5');
   });
 
-  it('leaves no wrapper between the row and the icon', () => {
-    // A wrapper is what let the icon sit uncentred: the row centres its own
-    // children, and a block div in between does not pass that on.
+  it('leaves no sized box around the icon', () => {
+    // Asserting on the box rather than on parentage: an unrelated wrapper added
+    // later is harmless, a wrapper carrying the size is the actual regression.
     const { container } = renderItem();
-    const icon = screen.getByTestId('nav-icon');
 
-    expect(icon.parentElement).toBe(container.querySelector('a'));
+    const sizedBoxes = Array.from(container.querySelectorAll('div')).filter((el) =>
+      el.className.split(' ').some((c) => c === 'h-4' || c === 'h-5')
+    );
+
+    expect(sizedBoxes).toHaveLength(0);
   });
 
   it('uses the smaller size for a nested item', () => {
@@ -79,5 +85,29 @@ describe('the sidebar icon carries its own size', () => {
     expect(screen.getByTestId('nav-icon').getAttribute('class')).toContain(
       'text-primary-foreground'
     );
+  });
+});
+
+describe('the dropdown row sizes its icon the same way', () => {
+  it('sizes the icon rather than a box around it', () => {
+    const { container } = render(
+      <SidebarDropdown
+        item={{ ...item, children: [] }}
+        isOpen={false}
+        onToggle={() => {}}
+        basePath="/dashboard"
+        isActive={() => false}
+        onItemClick={() => {}}
+      />
+    );
+
+    const icon = screen.getByTestId('nav-icon');
+
+    expect(icon.getAttribute('class')).toContain('h-5');
+    expect(
+      Array.from(container.querySelectorAll('div')).filter((el) =>
+        el.className.split(' ').includes('h-5')
+      )
+    ).toHaveLength(0);
   });
 });

--- a/frontend/src/features/dashboard/components/layout/sidebar/sidebar-item.tsx
+++ b/frontend/src/features/dashboard/components/layout/sidebar/sidebar-item.tsx
@@ -27,12 +27,16 @@ export const SidebarItem: React.FC<SidebarItemProps> = ({
     >
       {/*
         Sized on the icon, not on a box around it.
-        `react-icons` default to width and height of 1em, so an icon given no
-        size of its own inherits the `text-sm` above and draws at 14px inside a
-        slot reserved for 20. It also read as misaligned: an svg is inline, so
-        it sat on the text baseline in the corner of that box with the
-        line-height gap beneath it. The link is already `flex items-center`, so
-        as a direct child the icon centres itself and the wrapper is not needed.
+
+        `react-icons` default to a width and height of 1em, so an icon given no
+        size of its own inherits the `text-sm` on the row and draws at 14px.
+        The wrapper it used to sit in reserved 20, and Tailwind's preflight
+        makes an svg `display: block`, so those 14px sat in the top left corner
+        of that 20px box. The row centred the box; nothing centred the icon
+        inside it. That is why it looked both small and high.
+
+        The row is already `flex items-center`, so as a direct child the icon is
+        centred by the row and there is no box left to be the wrong size.
       */}
       <item.icon
         className={cn(

--- a/frontend/src/features/dashboard/components/layout/sidebar/sidebar-item.tsx
+++ b/frontend/src/features/dashboard/components/layout/sidebar/sidebar-item.tsx
@@ -25,15 +25,22 @@ export const SidebarItem: React.FC<SidebarItemProps> = ({
           : 'text-secondary-foreground hover:text-foreground hover:bg-accent'
       )}
     >
-      <div
+      {/*
+        Sized on the icon, not on a box around it.
+        `react-icons` default to width and height of 1em, so an icon given no
+        size of its own inherits the `text-sm` above and draws at 14px inside a
+        slot reserved for 20. It also read as misaligned: an svg is inline, so
+        it sat on the text baseline in the corner of that box with the
+        line-height gap beneath it. The link is already `flex items-center`, so
+        as a direct child the icon centres itself and the wrapper is not needed.
+      */}
+      <item.icon
         className={cn(
           'flex-shrink-0 mr-3',
           isInDropdown ? 'h-4 w-4' : 'h-5 w-5',
           itemIsActive && 'text-primary-foreground'
         )}
-      >
-        <item.icon />
-      </div>
+      />
       <span className="truncate">{item.title}</span>
       {item.badge && (
         <span


### PR DESCRIPTION
Off `main`, independent of #190/#191/#192/#193. Starting point for the refactoring PR.

## The bug

Both symptoms came from one line. The size classes sat on a wrapper `div` and the icon inside was given nothing:

```tsx
<div className="flex-shrink-0 mr-3 h-5 w-5">
  <item.icon />
</div>
```

`react-icons` default to `width="1em" height="1em"`, so the icon inherited the row's `text-sm` and drew at **14px inside a slot reserved for 20**.

It looked off-centre for the same reason. Tailwind's preflight sets `svg { display: block }`, so those 14px sat in the top-left corner of the 20px box. The row centred the box; nothing centred the icon inside it. Small and high, from one cause.

## The fix

The size goes on the icon and the wrapper is gone. The row is already `flex items-center`, so a direct child is centred by the row itself and there's no intermediate element left to get it wrong. The active colour moves onto the icon too, where `currentColor` picks it up the same way.

Icons are 20px against a 14px label, which is the usual pairing, and 16px for a nested item. I'd land this before considering anything larger: the fix alone is a 43% jump from what's on screen now, and 24px starts to dominate a 14px label rather than balance it.

`SidebarDropdown` had the identical bug and is fixed with it.

## Testing

- Sidebar icons should sit level with their labels and read noticeably larger.
- Active row: icon still takes the active colour.
- No collapsed icon-only mode exists, so `mr-3` is unaffected.

5 new tests, mutation-checked: restoring the old wrapper fails four of them. 1242 tests pass, typecheck clean, 0 lint errors, clean build.