### PR TITLE
chore: make both maintainers code owners of everything

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,20 @@
-# Default owner for everything not matched below
-* @yash-sangwan
+# Default owners for everything not matched below.
+#
+# Both maintainers, which is what makes the review requirement mean something:
+# GitHub never requests a review from the PR's own author, so listing both puts
+# each maintainer's work in front of the other one automatically. With a single
+# owner, that maintainer's own pull requests had no code owner left to ask.
+#
+# Approval from ONE listed owner satisfies the requirement. CODEOWNERS cannot
+# ask for two.
+* @yash-sangwan @Rakesh-46-VR
 
 # Coverage ratchet. The thresholds in this file are the only thing stopping
 # covered behaviour from being quietly dropped, and CI will faithfully enforce
-# whatever number is committed - including a lowered one. Requiring a second
-# maintainer here makes the ratchet one-way in practice, not just on paper.
-# Later rules win in CODEOWNERS, so this must stay below the `*` entry.
+# whatever number is committed - including a lowered one.
+#
+# This now names the same two owners as the `*` rule above, so it no longer
+# changes who has to approve. It is kept as the record of why this file is
+# worth guarding, and as the place to narrow ownership again if the two lists
+# ever diverge. Later rules win in CODEOWNERS, so it must stay below `*`.
 /s3-api/vitest.config.ts @yash-sangwan @Rakesh-46-VR


### PR DESCRIPTION
The default rule named one owner:

```
* @yash-sangwan
```

GitHub never requests a review from a pull request's own author, so that maintainer's own work had no code owner left to ask and the requirement had nothing to bind on. Naming both puts each maintainer's changes in front of the other one automatically.

```
* @yash-sangwan @Rakesh-46-VR
```

Approval from **one** listed owner satisfies the rule. CODEOWNERS cannot ask for two, and the comments now say so rather than implying otherwise.

The `/s3-api/vitest.config.ts` rule now names the same pair as the default, so it no longer changes who has to approve. Its comment said it was "requiring a second maintainer", which is no longer what it does. The rule is kept as the record of why that file is worth guarding, and as the place to narrow ownership again if the two lists ever diverge.

## Note on when this takes effect

GitHub reads CODEOWNERS from the **base** branch, so nothing changes until this is on `main` - including for any pull request already open.

The "Require review from Code Owners" setting has already been turned on.

## Testing

No code changes, so nothing to run. Worth confirming after merge: open a pull request touching any file and check that the other maintainer is auto-requested as a reviewer.