### PR TITLE
fix: delete a folder and its contents, not just the marker

### DIFF
--- a/.changeset/selection-integrity.md
+++ b/.changeset/selection-integrity.md
@@ -1,0 +1,53 @@
+---
+'frontend': patch
+---
+
+Delete a folder and its contents, not just the marker
+
+S3 has no directories. A folder is either inferred from a delimiter, which gives
+it a `Prefix`, or written as a zero-byte object whose key ends in a slash. The
+second kind is shaped exactly like a file - same type, same fields - and the
+trailing slash is the only thing separating them.
+
+Nothing recorded which was which, so every site that needed to tell them apart
+invented its own test. Six of them, across twenty places, and they did not
+agree. Delete was one of the places they disagreed.
+
+The list of files to delete was built with a test that excluded markers. The
+loop that then deleted them used one that did not, eleven lines further down. So
+a folder stored as an object went to the file path: the marker was removed and
+everything beneath it stayed - still stored, still billed, and no longer
+reachable by a listing with no prefix left to find it under.
+
+The loop was also an `if / else if` with no `else`. An item matching neither arm
+fell through it silently, with the confirmation already accepted and the
+selection already cleared, so the interface reported a deletion that never
+happened. Anything that cannot be deleted now says so.
+
+One module decides instead. `isFolder`, `isFolderMarker`, `isFile` and `itemKey`
+live in `shared/utils/drive-item.ts`, and the twenty hand-rolled predicates are
+gone along with the `as FileItem` and `as Folder` casts each of them needed -
+every one a place the compiler had been told to stop checking.
+
+Both types now carry a `kind` tag, set by the factory that builds them, rather
+than leaving the answer to be inferred from which optional field happened to be
+populated. It is optional, so anything restored from a cache written before it
+still resolves through the structural test. The tag records the shape an item
+was built as, which is not the same question: a marker is built by the file
+factory and carries `kind: 'file'` while being a folder, so the marker test runs
+before the tag is trusted anywhere it matters.
+
+Selection identity is fixed with it. `itemKey` read the key, then the prefix,
+then gave up and returned the empty string - so any two items carrying neither
+collapsed into one, and selecting either showed both as selected. It reads the
+`id` first now, which the factories always populate, and falls back to a
+per-object identifier that is stable for one item and unique between two.
+
+Selecting an item no longer takes a type from the caller. Components passed a
+literal `'file'` or `'folder'` alongside it, and only the plain-click path read
+it, so the same folder reported one thing when clicked and another when
+ctrl-clicked. Every path derives from the item now, and the argument is gone
+from all ninety-six call sites.
+
+Also fixed on the way past: a folder stored as an object opened a file preview
+when tapped on mobile, where that row had no such check at all.

--- a/frontend/src/app/dashboard/search/page.tsx
+++ b/frontend/src/app/dashboard/search/page.tsx
@@ -195,6 +195,7 @@ export default function SearchPage() {
 
       return {
         id: `folder-${index}`,
+        kind: 'folder',
         name: folderName,
         Prefix: folder.Key,
         lastModified: folder.LastModified || new Date(),
@@ -210,6 +211,7 @@ export default function SearchPage() {
 
       return {
         id: `file-${index}`,
+        kind: 'file',
         name: fileName,
         Key: file.Key,
         Size: file.Size, // Preserve original Size in bytes for preview checks

--- a/frontend/src/context/data-context.tsx
+++ b/frontend/src/context/data-context.tsx
@@ -199,6 +199,7 @@ function enrichFolder(obj: CommonPrefix): Folder {
   return {
     ...obj,
     id: obj.Prefix || `folder-${Date.now()}-${Math.random()}`,
+    kind: 'folder',
     name: name ?? '',
     icon: 'folder',
     location: {
@@ -241,6 +242,7 @@ function enrichFile(obj: _Object): FileItem {
   return {
     ...obj,
     id: obj.Key || `file-${Date.now()}-${Math.random()}`,
+    kind: 'file',
     name: name ?? '',
     extension: ext ?? 'unknown',
     size: formatBytes(obj.Size),

--- a/frontend/src/features/dashboard/components/ui/details/details-sidebar.tsx
+++ b/frontend/src/features/dashboard/components/ui/details/details-sidebar.tsx
@@ -8,11 +8,17 @@ import { FileItem } from '@/features/dashboard/types/file';
 import { FaFolder } from 'react-icons/fa';
 import Image from 'next/image';
 import { assets } from '@/assets';
+import { isFile } from '@/shared/utils/drive-item';
 
-const isFileItem = (item: FileItem | null): item is FileItem => {
-  if (!item) return false;
-  return ('Key' in item && !!item.Key) || ('name' in item && !!item.name);
-};
+/**
+ * Something this panel can actually describe.
+ *
+ * The old test also accepted anything carrying a `name`, which every folder
+ * does - so a folder marker reached the metadata fetch and was rendered as an
+ * ordinary file. `isFile` excludes keys ending in a slash, which is the only
+ * thing separating a marker from a file.
+ */
+const isFileItem = (item: FileItem | null): item is FileItem => isFile(item);
 
 export const DetailsSidebar = () => {
   const { close, selectedItem } = useDetails();

--- a/frontend/src/features/dashboard/components/ui/details/mobile-details-dialog.tsx
+++ b/frontend/src/features/dashboard/components/ui/details/mobile-details-dialog.tsx
@@ -13,11 +13,17 @@ import {
   DialogDescription,
   DialogTitle,
 } from '@/shared/components/ui/dialog';
+import { isFile } from '@/shared/utils/drive-item';
 
-const isFileItem = (item: FileItem | null): item is FileItem => {
-  if (!item) return false;
-  return ('Key' in item && !!item.Key) || ('name' in item && !!item.name);
-};
+/**
+ * Something this panel can actually describe.
+ *
+ * The old test also accepted anything carrying a `name`, which every folder
+ * does - so a folder marker reached the metadata fetch and was rendered as an
+ * ordinary file. `isFile` excludes keys ending in a slash, which is the only
+ * thing separating a marker from a file.
+ */
+const isFileItem = (item: FileItem | null): item is FileItem => isFile(item);
 
 export const MobileDetailsDialog = () => {
   const { isOpen, selectedItem, close } = useDetails();

--- a/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
@@ -10,6 +10,7 @@ import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { getItemKeyIntent, opensMenuOnKey } from './item-keyboard';
+import { isFile } from '@/shared/utils/drive-item';
 
 interface FileItemGridProps {
   file: FileItem;
@@ -56,14 +57,14 @@ export function FileItemGrid({
 
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     if (!isTouchDevice) {
-      selectItem(file, 'file', index, false, false, allFiles);
+      selectItem(file, index, false, false, allFiles);
     }
   };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (!opensMenuOnKey(event)) return;
 
-    selectItem(file, 'file', index, false, false, allFiles);
+    selectItem(file, index, false, false, allFiles);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
@@ -77,7 +78,7 @@ export function FileItemGrid({
     const timer = setTimeout(() => {
       setIsLongPress(true);
       // Trigger selection on long press - start selection mode with ctrlKey=true to toggle/add
-      selectItem(file, 'file', index, true, false, allFiles); // true = toggle/add to selection
+      selectItem(file, index, true, false, allFiles); // true = toggle/add to selection
       // Haptic feedback if available (wrapped in try-catch to avoid console errors)
       try {
         if (navigator.vibrate) {
@@ -107,7 +108,7 @@ export function FileItemGrid({
       if (hasSelection) {
         event.preventDefault();
         event.stopPropagation();
-        selectItem(file, 'file', index, true, false, allFiles); // true = toggle/add to selection
+        selectItem(file, index, true, false, allFiles); // true = toggle/add to selection
         setIsLongPress(false);
         return; // Stop here, don't open file
       }
@@ -121,20 +122,20 @@ export function FileItemGrid({
       }
 
       // No selection and not a long press - open file
-      if (!file.Key?.endsWith('/')) {
+      if (isFile(file)) {
         openFilePreview(file, allFiles);
       }
       setIsLongPress(false);
     } else {
       // Desktop: Single click to select
-      selectItem(file, 'file', index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
+      selectItem(file, index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
     }
   };
 
   const handleDoubleClick = () => {
     // Only open preview for non-folder items on double click (desktop only)
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-    if (!isTouchDevice && !file.Key?.endsWith('/')) {
+    if (!isTouchDevice && isFile(file)) {
       openFilePreview(file, allFiles);
     }
   };
@@ -147,11 +148,11 @@ export function FileItemGrid({
     event.preventDefault();
 
     if (intent === 'select') {
-      selectItem(file, 'file', index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
+      selectItem(file, index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
       return;
     }
 
-    if (!file.Key?.endsWith('/')) {
+    if (isFile(file)) {
       openFilePreview(file, allFiles);
     }
   };

--- a/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-list.tsx
@@ -11,6 +11,7 @@ import { useFilePreviewActions } from '@/hooks/use-file-preview-actions';
 import { getEffectiveExtension } from '@/config/file-extensions';
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { getItemKeyIntent, opensMenuOnKey } from './item-keyboard';
+import { isFile } from '@/shared/utils/drive-item';
 
 interface FileItemListProps {
   file: FileItem;
@@ -44,9 +45,7 @@ export function FileItemList({
    * the whole table - but a folder has nothing to preview, so it is dropped
    * here rather than handed to a viewer that would not know what to do with it.
    */
-  const previewableFiles = allFiles.filter(
-    (item): item is FileItem => !('Prefix' in item && Boolean(item.Prefix))
-  );
+  const previewableFiles = allFiles.filter(isFile);
 
   const selected = isSelected(file);
   const hasSelection = getSelectionCount() > 0;
@@ -73,14 +72,14 @@ export function FileItemList({
 
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     if (!isTouchDevice) {
-      selectItem(file, 'file', index, false, false, allFiles);
+      selectItem(file, index, false, false, allFiles);
     }
   };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (!opensMenuOnKey(event)) return;
 
-    selectItem(file, 'file', index, false, false, allFiles);
+    selectItem(file, index, false, false, allFiles);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
@@ -94,7 +93,7 @@ export function FileItemList({
     const timer = setTimeout(() => {
       setIsLongPress(true);
       // Trigger selection on long press - start selection mode with ctrlKey=true to toggle/add
-      selectItem(file, 'file', index, true, false, allFiles); // true = toggle/add to selection
+      selectItem(file, index, true, false, allFiles); // true = toggle/add to selection
       // Haptic feedback if available (wrapped in try-catch to avoid console errors)
       try {
         if (navigator.vibrate) {
@@ -124,7 +123,7 @@ export function FileItemList({
       if (hasSelection) {
         event.preventDefault();
         event.stopPropagation();
-        selectItem(file, 'file', index, true, false, allFiles); // true = toggle/add to selection
+        selectItem(file, index, true, false, allFiles); // true = toggle/add to selection
         setIsLongPress(false);
         return; // Stop here, don't open file
       }
@@ -138,20 +137,20 @@ export function FileItemList({
       }
 
       // No selection and not a long press - open file
-      if (!file.Key?.endsWith('/')) {
+      if (isFile(file)) {
         openFilePreview(file, previewableFiles);
       }
       setIsLongPress(false);
     } else {
       // Desktop: Single click to select
-      selectItem(file, 'file', index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
+      selectItem(file, index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
     }
   };
 
   const handleDoubleClick = () => {
     // Only open preview for non-folder items on double click (desktop only)
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-    if (!isTouchDevice && !file.Key?.endsWith('/')) {
+    if (!isTouchDevice && isFile(file)) {
       openFilePreview(file, previewableFiles);
     }
   };
@@ -164,11 +163,11 @@ export function FileItemList({
     event.preventDefault();
 
     if (intent === 'select') {
-      selectItem(file, 'file', index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
+      selectItem(file, index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
       return;
     }
 
-    if (!file.Key?.endsWith('/')) {
+    if (isFile(file)) {
       openFilePreview(file, previewableFiles);
     }
   };

--- a/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-mobile.tsx
@@ -10,6 +10,7 @@ import { getEffectiveExtension, getFileExtensionWithoutDot } from '@/config/file
 import { useMultiSelectStore } from '../../../stores/use-multi-select-store';
 import { useFilePreview } from '@/context/file-preview-context';
 import { getItemKeyIntent, opensMenuOnKey } from './item-keyboard';
+import { isFile } from '@/shared/utils/drive-item';
 
 interface FileItemMobileProps {
   file: FileItem;
@@ -63,14 +64,14 @@ export function FileItemMobile({
 
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     if (!isTouchDevice) {
-      selectItem(file, 'file', index, false, false, allFiles);
+      selectItem(file, index, false, false, allFiles);
     }
   };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (!opensMenuOnKey(event)) return;
 
-    selectItem(file, 'file', index, false, false, allFiles);
+    selectItem(file, index, false, false, allFiles);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
@@ -87,7 +88,7 @@ export function FileItemMobile({
     const timer = setTimeout(() => {
       setIsLongPress(true);
       // Trigger selection on long press
-      selectItem(file, 'file', index, true, false, allFiles);
+      selectItem(file, index, true, false, allFiles);
       // Haptic feedback if available (wrapped in try-catch to avoid console errors)
       try {
         if (navigator.vibrate) {
@@ -133,7 +134,7 @@ export function FileItemMobile({
     // If there's already a selection, add to it (like Ctrl+Click for multi-select)
     if (hasCurrentSelection) {
       // Use ctrlKey=true to add to selection (or toggle if already selected)
-      selectItem(file, 'file', index, true, false, allFiles);
+      selectItem(file, index, true, false, allFiles);
       setIsLongPress(false);
       return;
     }
@@ -156,7 +157,7 @@ export function FileItemMobile({
     event.preventDefault();
 
     if (intent === 'select') {
-      selectItem(file, 'file', index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
+      selectItem(file, index, event.ctrlKey || event.metaKey, event.shiftKey, allFiles);
       return;
     }
 
@@ -164,6 +165,11 @@ export function FileItemMobile({
   };
 
   const handleFileOpen = () => {
+    // A folder has nothing to preview. The desktop rows have always checked
+    // this before opening; this one never did, so tapping a folder stored as
+    // an object opened a viewer over it.
+    if (!isFile(file)) return;
+
     // Use the same preview logic as the overflow menu's "Open" action
     const previewableFile = {
       id: file.id,
@@ -177,16 +183,14 @@ export function FileItemMobile({
     // `allFiles` carries the folders too, because shift-select ranges span the
     // whole table - but a folder has nothing to preview, so it is dropped here
     // rather than handed to a viewer that would not know what to do with it.
-    const previewableFiles = allFiles
-      .filter((item): item is FileItem => !('Prefix' in item && Boolean(item.Prefix)))
-      .map((f) => ({
-        id: f.id,
-        name: f.name,
-        key: f.Key,
-        size: typeof f.Size === 'number' ? f.Size : 0,
-        lastModified: f.lastModified,
-        type: f.extension || getFileExtensionWithoutDot(f.name),
-      }));
+    const previewableFiles = allFiles.filter(isFile).map((f) => ({
+      id: f.id,
+      name: f.name,
+      key: f.Key,
+      size: typeof f.Size === 'number' ? f.Size : 0,
+      lastModified: f.lastModified,
+      type: f.extension || getFileExtensionWithoutDot(f.name),
+    }));
 
     openPreview(
       previewableFile,
@@ -261,9 +265,7 @@ export function FileItemMobile({
       {/* Menu Button */}
       <FileOverflowMenu
         file={file}
-        allFiles={allFiles.filter(
-          (item): item is FileItem => !('Prefix' in item && Boolean(item.Prefix))
-        )}
+        allFiles={allFiles.filter(isFile)}
         additionalActions={additionalActions}
         insertAdditionalActionsAfter={insertAdditionalActionsAfter}
         triggerLabel="More actions"

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-list.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-list.tsx
@@ -64,7 +64,7 @@ export const FolderItemList: React.FC<FolderItemListProps> = ({
     setIsLongPress(false);
     const timer = setTimeout(() => {
       setIsLongPress(true);
-      selectItem(folder, 'folder', index, true, false, allItems);
+      selectItem(folder, index, true, false, allItems);
       try {
         if (navigator.vibrate) {
           navigator.vibrate(50);
@@ -90,7 +90,7 @@ export const FolderItemList: React.FC<FolderItemListProps> = ({
       if (hasSelection) {
         event.preventDefault();
         event.stopPropagation();
-        selectItem(folder, 'folder', index, true, false, allItems);
+        selectItem(folder, index, true, false, allItems);
         setIsLongPress(false);
         return;
       }
@@ -105,7 +105,7 @@ export const FolderItemList: React.FC<FolderItemListProps> = ({
       onClick?.(folder);
       setIsLongPress(false);
     } else {
-      selectItem(folder, 'folder', index, event.ctrlKey || event.metaKey, event.shiftKey, allItems);
+      selectItem(folder, index, event.ctrlKey || event.metaKey, event.shiftKey, allItems);
     }
   };
 
@@ -123,7 +123,7 @@ export const FolderItemList: React.FC<FolderItemListProps> = ({
     event.preventDefault();
 
     if (intent === 'select') {
-      selectItem(folder, 'folder', index, event.ctrlKey || event.metaKey, event.shiftKey, allItems);
+      selectItem(folder, index, event.ctrlKey || event.metaKey, event.shiftKey, allItems);
       return;
     }
 
@@ -140,14 +140,14 @@ export const FolderItemList: React.FC<FolderItemListProps> = ({
 
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     if (!isTouchDevice) {
-      selectItem(folder, 'folder', index, false, false, allItems);
+      selectItem(folder, index, false, false, allItems);
     }
   };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (!opensMenuOnKey(event)) return;
 
-    selectItem(folder, 'folder', index, false, false, allItems);
+    selectItem(folder, index, false, false, allItems);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {

--- a/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item-mobile.tsx
@@ -56,14 +56,14 @@ export function FolderItemMobile({
 
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     if (!isTouchDevice) {
-      selectItem(folder, 'folder', index, false, false, allFolders);
+      selectItem(folder, index, false, false, allFolders);
     }
   };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (!opensMenuOnKey(event)) return;
 
-    selectItem(folder, 'folder', index, false, false, allFolders);
+    selectItem(folder, index, false, false, allFolders);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {
@@ -80,7 +80,7 @@ export function FolderItemMobile({
     const timer = setTimeout(() => {
       setIsLongPress(true);
       // Trigger selection on long press
-      selectItem(folder, 'folder', index, true, false, allFolders);
+      selectItem(folder, index, true, false, allFolders);
       // Haptic feedback if available (wrapped in try-catch to avoid console errors)
       try {
         if (navigator.vibrate) {
@@ -125,7 +125,7 @@ export function FolderItemMobile({
 
     // If there's already a selection, add to it (toggle like Ctrl+Click)
     if (hasCurrentSelection) {
-      selectItem(folder, 'folder', index, true, false, allFolders);
+      selectItem(folder, index, true, false, allFolders);
       setIsLongPress(false);
       return;
     }
@@ -148,14 +148,7 @@ export function FolderItemMobile({
     event.preventDefault();
 
     if (intent === 'select') {
-      selectItem(
-        folder,
-        'folder',
-        index,
-        event.ctrlKey || event.metaKey,
-        event.shiftKey,
-        allFolders
-      );
+      selectItem(folder, index, event.ctrlKey || event.metaKey, event.shiftKey, allFolders);
       return;
     }
 

--- a/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/folder-item.tsx
@@ -53,7 +53,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     const timer = setTimeout(() => {
       setIsLongPress(true);
       // Trigger selection on long press - start selection mode with ctrlKey=true to toggle/add
-      selectItem(folder, 'folder', index, true, false, allFolders); // true = toggle/add to selection
+      selectItem(folder, index, true, false, allFolders); // true = toggle/add to selection
       // Haptic feedback if available (wrapped in try-catch to avoid console errors)
       try {
         if (navigator.vibrate) {
@@ -83,7 +83,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
       if (hasSelection) {
         event.preventDefault();
         event.stopPropagation();
-        selectItem(folder, 'folder', index, true, false, allFolders); // true = toggle/add to selection
+        selectItem(folder, index, true, false, allFolders); // true = toggle/add to selection
         setIsLongPress(false);
         return; // Stop here, don't open folder
       }
@@ -101,14 +101,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
       setIsLongPress(false);
     } else {
       // Desktop: Single click to select
-      selectItem(
-        folder,
-        'folder',
-        index,
-        event.ctrlKey || event.metaKey,
-        event.shiftKey,
-        allFolders
-      );
+      selectItem(folder, index, event.ctrlKey || event.metaKey, event.shiftKey, allFolders);
     }
   };
 
@@ -128,14 +121,7 @@ export const FolderItem: React.FC<FolderItemProps> = ({
     event.preventDefault();
 
     if (intent === 'select') {
-      selectItem(
-        folder,
-        'folder',
-        index,
-        event.ctrlKey || event.metaKey,
-        event.shiftKey,
-        allFolders
-      );
+      selectItem(folder, index, event.ctrlKey || event.metaKey, event.shiftKey, allFolders);
       return;
     }
 
@@ -160,14 +146,14 @@ export const FolderItem: React.FC<FolderItemProps> = ({
 
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     if (!isTouchDevice) {
-      selectItem(folder, 'folder', index, false, false, allFolders);
+      selectItem(folder, index, false, false, allFolders);
     }
   };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (!opensMenuOnKey(event)) return;
 
-    selectItem(folder, 'folder', index, false, false, allFolders);
+    selectItem(folder, index, false, false, allFolders);
   };
 
   const handleMenuClick = (event: React.MouseEvent) => {

--- a/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/item-menu-selection.test.tsx
@@ -56,6 +56,13 @@ function folder(overrides: Partial<Folder> = {}): Folder {
   };
 }
 
+/**
+ * A file, and by default a real one.
+ *
+ * `Key` has to carry a name that is not a trailing slash: the kind of a
+ * selection is derived from the item now, and a key ending in `/` is how a
+ * folder stored as an object is spelled. `id` is what identity reads first.
+ */
 function file(overrides: Partial<FileItem> = {}): FileItem {
   return {
     id: 'budget',
@@ -292,6 +299,37 @@ describe('the keyboard opens the menu and selects too', () => {
     fireEvent.keyDown(menuButton('budget.xlsx'), { key: 'Enter' });
 
     expect(selection()).toHaveLength(1);
+    expect(useMultiSelectStore.getState().selectedType).toBe('file');
+  });
+});
+
+/**
+ * The row a component renders in does not decide what was selected.
+ *
+ * These components used to pass a hardcoded `'file'` or `'folder'` alongside
+ * the item, and a row could therefore disagree with the thing it was holding.
+ * The argument is gone and the kind comes off the item, so a folder reaching a
+ * file row is now selected as a folder - which is what this pins.
+ */
+describe('the kind is read off the item, not off the row', () => {
+  it('calls a folder stored as an object a folder, from a file row', () => {
+    // A zero-byte object whose key ends in a slash is a folder. It reaches
+    // FileItemList, which announces it as a file, and used to be selected as
+    // one - so the toolbar offered open, download and share on a folder.
+    const photos = file({ id: 'archive/photos/', name: 'Photos', Key: 'archive/photos/' });
+    render(<FileItemList file={photos} allFiles={[photos]} />);
+
+    pressMenu(menuButton('Photos'));
+
+    expect(selection()).toHaveLength(1);
+    expect(useMultiSelectStore.getState().selectedType).toBe('folder');
+  });
+
+  it('still calls an ordinary file a file from the same row', () => {
+    render(<FileItemList file={file()} allFiles={[file()]} />);
+
+    pressMenu(menuButton('budget.xlsx'));
+
     expect(useMultiSelectStore.getState().selectedType).toBe('file');
   });
 });

--- a/frontend/src/features/dashboard/components/ui/multi-select-toolbar.tsx
+++ b/frontend/src/features/dashboard/components/ui/multi-select-toolbar.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMultiSelectStore } from '../../stores/use-multi-select-store';
+import { isFile, isFolder, isFolderMarker } from '@/shared/utils/drive-item';
 import {
   HiOutlineX,
   HiOutlineShare,
@@ -55,18 +56,21 @@ export function MultiSelectToolbar({
 
   // Helper to get parent folder path for files or the folder path itself for folders
   const getLocationPath = useCallback((item: FileItem | Folder): string => {
-    if ('Prefix' in item && item.Prefix) {
-      // It's a folder - keep the Prefix as-is with trailing slash for S3 compatibility
-      return item.Prefix;
-    } else if ('Key' in item && item.Key) {
-      // It's a file - navigate to the parent folder containing the file
-      const key = item.Key;
-      const pathParts = key.split('/').filter(Boolean);
-      pathParts.pop(); // Remove filename
+    if (isFolder(item)) {
+      // Keep the Prefix as-is with trailing slash for S3 compatibility
+      return item.Prefix ?? '';
+    }
+
+    // A file, or a folder written as an object. Either way the destination is
+    // the prefix holding it, so drop the last segment of the key.
+    if (isFile(item) || isFolderMarker(item)) {
+      const pathParts = (item.Key ?? '').split('/').filter(Boolean);
+      pathParts.pop();
       // Add trailing slash for S3 folder listing compatibility
       const parentPath = pathParts.join('/');
       return parentPath ? `${parentPath}/` : '';
     }
+
     return '';
   }, []);
 
@@ -87,9 +91,7 @@ export function MultiSelectToolbar({
   const count = getSelectionCount();
 
   // Determine what actions are available based on selection
-  const hasFiles = selectedItems.some(
-    (item) => 'Key' in item && item.Key && !item.Key.endsWith('/')
-  );
+  const hasFiles = selectedItems.some(isFile);
 
   const isFilesOnly = selectedType === 'file';
   const isSingleSelection = count === 1;

--- a/frontend/src/features/dashboard/hooks/use-multi-select-actions.ts
+++ b/frontend/src/features/dashboard/hooks/use-multi-select-actions.ts
@@ -7,6 +7,14 @@ import { useFilePreview } from '@/context/file-preview-context';
 import { getFileExtensionWithoutDot } from '@/config/file-extensions';
 import { useMultiSelectStore } from '../stores/use-multi-select-store';
 import { confirmAction } from '@/shared/components/ui/confirm-dialog';
+import { useNotification } from '@/context/notification-context';
+import {
+  folderFromMarker,
+  isFile,
+  isFolder,
+  isFolderLike,
+  isFolderMarker,
+} from '@/shared/utils/drive-item';
 
 interface UseMultiSelectActionsProps {
   openMultiShareDialog: (files: FileItem[]) => void;
@@ -17,14 +25,12 @@ export function useMultiSelectActions({ openMultiShareDialog }: UseMultiSelectAc
   const { deleteFile, deleteFolder, batchDeleteFiles } = useDeleteWithProgress();
   const { openPreview } = useFilePreview();
   const { clearSelection } = useMultiSelectStore();
+  const { error: showError } = useNotification();
 
   // Open multiple files in preview
   const handleOpenFiles = useCallback(
     (items: (FileItem | Folder)[]) => {
-      // Filter only files (not folders)
-      const files = items.filter(
-        (item) => 'Key' in item && item.Key && !item.Key.endsWith('/')
-      ) as FileItem[];
+      const files = items.filter(isFile);
 
       if (files.length === 0) return;
 
@@ -48,10 +54,7 @@ export function useMultiSelectActions({ openMultiShareDialog }: UseMultiSelectAc
   // Download multiple files one by one
   const handleDownloadFiles = useCallback(
     (items: (FileItem | Folder)[]) => {
-      // Filter only files (not folders)
-      const files = items.filter(
-        (item) => 'Key' in item && item.Key && !item.Key.endsWith('/')
-      ) as FileItem[];
+      const files = items.filter(isFile);
 
       if (files.length === 0) return;
 
@@ -67,10 +70,7 @@ export function useMultiSelectActions({ openMultiShareDialog }: UseMultiSelectAc
   // Share multiple files
   const handleShareFiles = useCallback(
     (items: (FileItem | Folder)[]) => {
-      // Filter only files (not folders)
-      const files = items.filter(
-        (item) => 'Key' in item && item.Key && !item.Key.endsWith('/')
-      ) as FileItem[];
+      const files = items.filter(isFile);
 
       if (files.length === 0) return;
 
@@ -86,11 +86,11 @@ export function useMultiSelectActions({ openMultiShareDialog }: UseMultiSelectAc
     async (items: (FileItem | Folder)[]) => {
       if (items.length === 0) return;
 
-      // Separate files and folders
-      const files = items.filter(
-        (item) => 'Key' in item && item.Key && !item.Key.endsWith('/')
-      ) as FileItem[];
-      const folders = items.filter((item) => 'Prefix' in item && item.Prefix) as Folder[];
+      // Separate files and folders. `isFolderLike` counts a folder marker - an
+      // object whose key ends in a slash - as a folder, so a selection holding
+      // one never takes the files-only batch path below.
+      const files = items.filter(isFile);
+      const folders = items.filter(isFolderLike);
 
       // Show confirmation dialog
       const itemNames = items.map((item) => `"${item.name}"`).join(', ');
@@ -111,31 +111,58 @@ export function useMultiSelectActions({ openMultiShareDialog }: UseMultiSelectAc
       // Clear selection immediately after confirmation
       clearSelection();
 
+      // What could not be deleted, so the caller hears about it. Every branch
+      // below used to swallow its failure, which meant a delete that removed
+      // nothing looked exactly like one that worked.
+      const failed: string[] = [];
+
       // If only files are selected, use batch delete for better performance
       if (files.length > 0 && folders.length === 0) {
         try {
           await batchDeleteFiles(files);
         } catch (error) {
           console.error('Failed to batch delete files:', error);
+          failed.push(...files.map((file) => file.name || 'an unnamed file'));
         }
       } else {
         // Delete items one by one (mixed files and folders, or only folders)
         for (const item of items) {
           try {
-            if ('Key' in item && item.Key) {
-              // It's a file
-              await deleteFile(item as FileItem);
-            } else if ('Prefix' in item && item.Prefix) {
-              // It's a folder
-              await deleteFolder(item as Folder);
+            if (isFolder(item)) {
+              await deleteFolder(item);
+            } else if (isFolderMarker(item)) {
+              // A folder written as an object rather than inferred from a
+              // delimiter. This branch used to be missing, so the marker went
+              // to deleteFile - which removed the marker and left everything
+              // beneath it orphaned, still stored and no longer listable.
+              await deleteFolder(folderFromMarker(item));
+            } else if (isFile(item)) {
+              await deleteFile(item);
+            } else {
+              // Neither branch matched. The loop used to end here silently,
+              // with the confirmation already accepted and the selection
+              // already cleared - so the interface reported a deletion that
+              // never happened.
+              throw new Error('Item carries neither a file key nor a folder prefix');
             }
           } catch (error) {
             console.error(`Failed to delete ${item.name}:`, error);
+            failed.push(item.name || 'an unnamed item');
           }
         }
       }
+
+      if (failed.length > 0) {
+        showError(
+          failed.length === 1
+            ? `Could not delete "${failed[0]}".`
+            : `Could not delete ${failed.length} of ${items.length} items: ${failed
+                .map((name) => `"${name}"`)
+                .join(', ')}.`
+        );
+      }
     },
-    [deleteFile, deleteFolder, batchDeleteFiles, clearSelection]
+    [deleteFile, deleteFolder, batchDeleteFiles, clearSelection, showError]
   );
 
   return {

--- a/frontend/src/features/dashboard/stores/use-multi-select-store.test.ts
+++ b/frontend/src/features/dashboard/stores/use-multi-select-store.test.ts
@@ -5,8 +5,15 @@
  * with the modifier keys, so the cases below are grouped by modifier rather
  * than by action name.
  *
- * Identity is by S3 key: files carry `Key`, folders carry `Prefix`. Two
- * different objects describing the same key are the same selection.
+ * Identity comes from `itemKey`, which reads `id` first and falls back to
+ * `Key`, then `Prefix`. Two different objects describing the same item are the
+ * same selection. The fixtures below carry no `id`, so they exercise the key
+ * and prefix fallbacks; the id path is pinned separately.
+ *
+ * The kind of a selection is derived from the items. Callers used to pass a
+ * literal `'file'` or `'folder'` alongside the item, and only the plain-click
+ * path read it - so the same folder reported one thing when clicked and another
+ * when ctrl-clicked. The argument is gone; the cases below pin what replaced it.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -19,10 +26,26 @@ const store = () => useMultiSelectStore.getState();
 const file = (key: string) => ({ Key: key, name: key }) as FileItem;
 const folder = (prefix: string) => ({ Prefix: prefix, name: prefix }) as Folder;
 
+/**
+ * A folder written as an object rather than inferred from a delimiter.
+ *
+ * S3 has no directories. A folder either comes back as a CommonPrefix, which
+ * carries a `Prefix`, or as a zero-byte object whose key ends in a slash. The
+ * second kind is shaped exactly like a file, and the trailing slash is the only
+ * thing separating them.
+ */
+const marker = (key: string) => ({ Key: key, name: key }) as FileItem;
+
 /** Five files, so range selections have room to move in both directions. */
 const files = [file('a.txt'), file('b.txt'), file('c.txt'), file('d.txt'), file('e.txt')];
 
-/** Mirrors the store's own getItemKey: files carry Key, folders carry Prefix. */
+/**
+ * The S3 key of each selected item, which is what these cases read for.
+ *
+ * Deliberately not a copy of `itemKey`: that prefers `id`, and asserting
+ * against a mirror of the implementation would pass however the implementation
+ * drifted. These fixtures carry no `id`, so the two agree here anyway.
+ */
 const keysOf = () =>
   store().selectedItems.map((item) => {
     const record = item as unknown as { Key?: string; Prefix?: string };
@@ -31,7 +54,7 @@ const keysOf = () =>
 
 describe('plain click', () => {
   it('selects exactly one item', () => {
-    store().selectItem(files[1]!, 'file', 1, false, false, files);
+    store().selectItem(files[1]!, 1, false, false, files);
 
     expect(keysOf()).toEqual(['b.txt']);
     expect(store().selectedType).toBe('file');
@@ -39,10 +62,10 @@ describe('plain click', () => {
   });
 
   it('replaces an existing selection', () => {
-    store().selectItem(files[0]!, 'file', 0, true, false, files);
-    store().selectItem(files[1]!, 'file', 1, true, false, files);
+    store().selectItem(files[0]!, 0, true, false, files);
+    store().selectItem(files[1]!, 1, true, false, files);
 
-    store().selectItem(files[3]!, 'file', 3, false, false, files);
+    store().selectItem(files[3]!, 3, false, false, files);
 
     expect(keysOf()).toEqual(['d.txt']);
   });
@@ -50,34 +73,34 @@ describe('plain click', () => {
 
 describe('ctrl+click', () => {
   it('adds to the selection', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
-    store().selectItem(files[2]!, 'file', 2, true, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
+    store().selectItem(files[2]!, 2, true, false, files);
 
     expect(keysOf()).toEqual(['a.txt', 'c.txt']);
   });
 
   it('removes an item that is already selected', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
-    store().selectItem(files[1]!, 'file', 1, true, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
+    store().selectItem(files[1]!, 1, true, false, files);
 
-    store().selectItem(files[0]!, 'file', 0, true, false, files);
+    store().selectItem(files[0]!, 0, true, false, files);
 
     expect(keysOf()).toEqual(['b.txt']);
   });
 
   it('matches by key, not by object identity', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
 
     // A re-render hands the UI a fresh object for the same S3 key.
-    store().selectItem(file('a.txt'), 'file', 0, true, false, files);
+    store().selectItem(file('a.txt'), 0, true, false, files);
 
     expect(keysOf()).toEqual([]);
   });
 
   it('drops the type once the last item is deselected', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
 
-    store().selectItem(files[0]!, 'file', 0, true, false, files);
+    store().selectItem(files[0]!, 0, true, false, files);
 
     // A lingering type would keep blocking folder selection.
     expect(store().selectedItems).toEqual([]);
@@ -85,16 +108,16 @@ describe('ctrl+click', () => {
   });
 
   it('keeps the type while anything is still selected', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
-    store().selectItem(files[1]!, 'file', 1, true, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
+    store().selectItem(files[1]!, 1, true, false, files);
 
-    store().selectItem(files[0]!, 'file', 0, true, false, files);
+    store().selectItem(files[0]!, 0, true, false, files);
 
     expect(store().selectedType).toBe('file');
   });
 
   it('starts a selection from nothing', () => {
-    store().selectItem(files[2]!, 'file', 2, true, false, files);
+    store().selectItem(files[2]!, 2, true, false, files);
 
     expect(keysOf()).toEqual(['c.txt']);
     expect(store().selectedType).toBe('file');
@@ -103,62 +126,62 @@ describe('ctrl+click', () => {
 
 describe('shift+click range', () => {
   it('selects downwards from the anchor', () => {
-    store().selectItem(files[1]!, 'file', 1, false, false, files);
+    store().selectItem(files[1]!, 1, false, false, files);
 
-    store().selectItem(files[3]!, 'file', 3, false, true, files);
+    store().selectItem(files[3]!, 3, false, true, files);
 
     expect(keysOf()).toEqual(['b.txt', 'c.txt', 'd.txt']);
   });
 
   it('selects upwards from the anchor', () => {
-    store().selectItem(files[3]!, 'file', 3, false, false, files);
+    store().selectItem(files[3]!, 3, false, false, files);
 
-    store().selectItem(files[1]!, 'file', 1, false, true, files);
+    store().selectItem(files[1]!, 1, false, true, files);
 
     // Range is min..max, so direction does not matter.
     expect(keysOf()).toEqual(['b.txt', 'c.txt', 'd.txt']);
   });
 
   it('selects a single item when the range collapses', () => {
-    store().selectItem(files[2]!, 'file', 2, false, false, files);
+    store().selectItem(files[2]!, 2, false, false, files);
 
-    store().selectItem(files[2]!, 'file', 2, false, true, files);
+    store().selectItem(files[2]!, 2, false, true, files);
 
     expect(keysOf()).toEqual(['c.txt']);
   });
 
   it('covers the whole list at the boundaries', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
 
-    store().selectItem(files[4]!, 'file', 4, false, true, files);
+    store().selectItem(files[4]!, 4, false, true, files);
 
     expect(keysOf()).toEqual(['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt']);
   });
 
   it('keeps the anchor fixed so the range can be resized', () => {
-    store().selectItem(files[1]!, 'file', 1, false, false, files);
-    store().selectItem(files[4]!, 'file', 4, false, true, files);
+    store().selectItem(files[1]!, 1, false, false, files);
+    store().selectItem(files[4]!, 4, false, true, files);
 
     // Shrinking the range must measure from the original anchor, not from the
     // end of the previous range.
-    store().selectItem(files[2]!, 'file', 2, false, true, files);
+    store().selectItem(files[2]!, 2, false, true, files);
 
     expect(store().lastSelectedIndex).toBe(1);
     expect(keysOf()).toEqual(['b.txt', 'c.txt']);
   });
 
   it('replaces the previous selection rather than adding to it', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
-    store().selectItem(files[4]!, 'file', 4, true, false, files); // ctrl-add, anchor moves to 4
+    store().selectItem(files[0]!, 0, false, false, files);
+    store().selectItem(files[4]!, 4, true, false, files); // ctrl-add, anchor moves to 4
 
-    store().selectItem(files[3]!, 'file', 3, false, true, files);
+    store().selectItem(files[3]!, 3, false, true, files);
 
     expect(keysOf()).toEqual(['d.txt', 'e.txt']);
   });
 
   it('falls back to a single selection with no anchor', () => {
     // Shift-clicking as the very first interaction has nothing to range from.
-    store().selectItem(files[2]!, 'file', 2, false, true, files);
+    store().selectItem(files[2]!, 2, false, true, files);
 
     expect(keysOf()).toEqual(['c.txt']);
     expect(store().lastSelectedIndex).toBe(2);
@@ -169,10 +192,10 @@ describe('mixing files and folders', () => {
   const folders = [folder('one/'), folder('two/')];
 
   it('replaces the selection on a plain click, whatever was held before', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
-    store().selectItem(files[1]!, 'file', 1, true, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
+    store().selectItem(files[1]!, 1, true, false, files);
 
-    store().selectItem(folders[0]!, 'folder', 0, false, false, folders);
+    store().selectItem(folders[0]!, 0, false, false, folders);
 
     // A click with no modifier still means "just this one" - mixing is what
     // ctrl and shift are for.
@@ -185,18 +208,18 @@ describe('mixing files and folders', () => {
   const combined = [folders[0]!, folders[1]!, files[0]!, files[1]!];
 
   it('adds a folder to a file selection when ctrl is held', () => {
-    store().selectItem(files[0]!, 'file', 2, false, false, combined);
+    store().selectItem(files[0]!, 2, false, false, combined);
 
-    store().selectItem(folders[0]!, 'folder', 0, true, false, combined);
+    store().selectItem(folders[0]!, 0, true, false, combined);
 
     expect(keysOf().sort()).toEqual(['one/', 'a.txt'].sort());
     expect(store().selectedType).toBe('mixed');
   });
 
   it('carries a shift range across the folder-file boundary', () => {
-    store().selectItem(folders[1]!, 'folder', 1, false, false, combined);
+    store().selectItem(folders[1]!, 1, false, false, combined);
 
-    store().selectItem(files[0]!, 'file', 2, false, true, combined);
+    store().selectItem(files[0]!, 2, false, true, combined);
 
     // Everything between the anchor and the target, whichever kind it is.
     expect(keysOf()).toEqual(['two/', 'a.txt']);
@@ -206,25 +229,25 @@ describe('mixing files and folders', () => {
   // Callers ask "is this files only" to decide whether open, download and share
   // apply. Mixed has to answer no without pretending to be one or the other.
   it('reports a single kind as that kind, not as mixed', () => {
-    store().selectItem(folders[0]!, 'folder', 0, false, false, combined);
-    store().selectItem(folders[1]!, 'folder', 1, true, false, combined);
+    store().selectItem(folders[0]!, 0, false, false, combined);
+    store().selectItem(folders[1]!, 1, true, false, combined);
 
     expect(store().selectedType).toBe('folder');
   });
 
   it('falls back to the remaining kind when the odd one out is removed', () => {
-    store().selectItem(folders[0]!, 'folder', 0, false, false, combined);
-    store().selectItem(files[0]!, 'file', 2, true, false, combined);
+    store().selectItem(folders[0]!, 0, false, false, combined);
+    store().selectItem(files[0]!, 2, true, false, combined);
     expect(store().selectedType).toBe('mixed');
 
     // Ctrl-clicking the folder again drops it, leaving only files behind.
-    store().selectItem(folders[0]!, 'folder', 0, true, false, combined);
+    store().selectItem(folders[0]!, 0, true, false, combined);
 
     expect(store().selectedType).toBe('file');
   });
 
   it('identifies folders by prefix', () => {
-    store().selectItem(folders[0]!, 'folder', 0, false, false, folders);
+    store().selectItem(folders[0]!, 0, false, false, folders);
 
     expect(store().isSelected(folder('one/'))).toBe(true);
     expect(store().isSelected(folder('two/'))).toBe(false);
@@ -233,30 +256,31 @@ describe('mixing files and folders', () => {
 
 describe('queries and clearing', () => {
   it('reports whether an item is selected', () => {
-    store().selectItem(files[1]!, 'file', 1, false, false, files);
+    store().selectItem(files[1]!, 1, false, false, files);
 
     expect(store().isSelected(files[1]!)).toBe(true);
     expect(store().isSelected(files[0]!)).toBe(false);
   });
 
   it('treats an item with neither key nor prefix as unselected', () => {
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
 
-    // getItemKey returns '' for these, which must not match a real key.
+    // These used to key to the empty string, which matched nothing real but
+    // matched each other - see the identity cases below.
     expect(store().isSelected({ name: 'orphan' } as unknown as FileItem)).toBe(false);
   });
 
   it('counts the selection', () => {
     expect(store().getSelectionCount()).toBe(0);
 
-    store().selectItem(files[0]!, 'file', 0, false, false, files);
-    store().selectItem(files[1]!, 'file', 1, true, false, files);
+    store().selectItem(files[0]!, 0, false, false, files);
+    store().selectItem(files[1]!, 1, true, false, files);
 
     expect(store().getSelectionCount()).toBe(2);
   });
 
   it('resets everything, including the anchor', () => {
-    store().selectItem(files[2]!, 'file', 2, false, false, files);
+    store().selectItem(files[2]!, 2, false, false, files);
 
     store().clearSelection();
 
@@ -265,5 +289,112 @@ describe('queries and clearing', () => {
     // Leaving the anchor behind would let the next shift-click build a range
     // from a row the user last touched minutes ago.
     expect(store().lastSelectedIndex).toBeNull();
+  });
+});
+
+/**
+ * The kind of a selection is read off the items, and nowhere else.
+ *
+ * There is no longer an argument that could contradict them, which is what
+ * these cases are really holding down: the item is the only input.
+ */
+describe('deriving the kind', () => {
+  it('reads a folder off its prefix on a plain click', () => {
+    store().selectItem(folder('one/'), 0, false, false, [folder('one/')]);
+
+    // The plain-click path was the one that used to store the caller's literal,
+    // so it is where the answer used to be able to differ from the item.
+    expect(store().selectedType).toBe('folder');
+  });
+
+  it('gives the same answer however the item was selected', () => {
+    const one = folder('one/');
+
+    store().selectItem(one, 0, false, false, [one]);
+    const byClick = store().selectedType;
+
+    store().clearSelection();
+    store().selectItem(one, 0, true, false, [one]);
+    const byCtrlClick = store().selectedType;
+
+    expect(byClick).toBe('folder');
+    expect(byCtrlClick).toBe('folder');
+  });
+
+  it('counts a folder stored as an object as a folder', () => {
+    const photos = marker('photos/');
+
+    store().selectItem(photos, 0, false, false, [photos]);
+
+    // Selecting one must grey out open, download and share the same way a
+    // CommonPrefix folder does. Reading only `Prefix` reported it as a file.
+    expect(store().selectedType).toBe('folder');
+  });
+
+  it('still calls an ordinary file a file', () => {
+    store().selectItem(files[0]!, 0, false, false, files);
+
+    expect(store().selectedType).toBe('file');
+  });
+
+  it('reports a marker held alongside a file as mixed', () => {
+    const photos = marker('photos/');
+    const combined = [photos, files[0]!];
+
+    store().selectItem(photos, 0, false, false, combined);
+    store().selectItem(files[0]!, 1, true, false, combined);
+
+    expect(store().selectedType).toBe('mixed');
+  });
+
+  it('reports a marker held alongside a prefix folder as folders', () => {
+    const photos = marker('photos/');
+    const combined = [photos, folder('one/')];
+
+    store().selectItem(photos, 0, false, false, combined);
+    store().selectItem(combined[1]!, 1, true, false, combined);
+
+    // Two spellings of the same idea are not a mixed selection.
+    expect(store().selectedType).toBe('folder');
+  });
+});
+
+describe('identity', () => {
+  it('uses the id when there is no key or prefix to fall back to', () => {
+    // enrichFolder and enrichFile both generate an id when the S3 field is
+    // absent, which is what makes it the only safe first choice. Reading the
+    // key first meant these three were indistinguishable.
+    const one = { id: 'file-generated-1', name: 'one' } as FileItem;
+    const rebuilt = { id: 'file-generated-1', name: 'one' } as FileItem;
+    const other = { id: 'file-generated-2', name: 'two' } as FileItem;
+
+    store().selectItem(one, 0, false, false, [one, other]);
+
+    // A re-render hands over a fresh object for the same item.
+    expect(store().isSelected(rebuilt)).toBe(true);
+    expect(store().isSelected(other)).toBe(false);
+  });
+
+  it('keeps two items with no identifier apart', () => {
+    const one = { name: 'orphan one' } as FileItem;
+    const two = { name: 'orphan two' } as FileItem;
+
+    store().selectItem(one, 0, false, false, [one, two]);
+
+    // Both used to key to the empty string, so they were one item: selecting
+    // either showed both selected, and ctrl-clicking one removed both.
+    expect(store().isSelected(one)).toBe(true);
+    expect(store().isSelected(two)).toBe(false);
+  });
+
+  it('answers the same way every time it is asked about one item', () => {
+    const orphan = { name: 'orphan' } as FileItem;
+
+    store().selectItem(orphan, 0, false, false, [orphan]);
+
+    // The fallback identifier has to be stable, or selection would forget an
+    // item between one render and the next.
+    expect(store().isSelected(orphan)).toBe(true);
+    expect(store().isSelected(orphan)).toBe(true);
   });
 });

--- a/frontend/src/features/dashboard/stores/use-multi-select-store.ts
+++ b/frontend/src/features/dashboard/stores/use-multi-select-store.ts
@@ -18,6 +18,7 @@
 import { create } from 'zustand';
 import { FileItem } from '../types/file';
 import { Folder } from '../types/folder';
+import { isFolderLike, itemKey as getItemKey } from '@/shared/utils/drive-item';
 
 type SelectableItem = FileItem | Folder;
 type ItemType = 'file' | 'folder';
@@ -48,9 +49,17 @@ interface MultiSelectState {
   anchorKey: string | null;
 
   // Actions
+  /**
+   * Takes no item type.
+   *
+   * Callers used to pass a literal `'file'` or `'folder'` alongside the item.
+   * It was a fifth answer to a question the item itself can be asked, and only
+   * the plain-click path ever read it - so the same folder reported one thing
+   * when clicked and another when ctrl-clicked, because those paths had always
+   * derived it. Every path derives now, and there is nothing left to disagree.
+   */
   selectItem: (
     item: SelectableItem,
-    type: ItemType,
     index: number,
     ctrlKey: boolean,
     shiftKey: boolean,
@@ -61,34 +70,26 @@ interface MultiSelectState {
   getSelectionCount: () => number;
 }
 
-const isFolder = (item: SelectableItem): boolean => 'Prefix' in item && Boolean(item.Prefix);
-
 /**
  * Read back off the items rather than tracked separately.
  *
  * A stored type and a stored list are two records of one fact, and the moment a
  * range spans both kinds they disagree. Deriving it means the answer cannot
  * drift from what is actually held.
+ *
+ * `isFolderLike` rather than a local test: a folder written as an object whose
+ * key ends in a slash is still a folder to the person selecting it, and the
+ * toolbar has to grey the same actions for it.
  */
 const typeOf = (items: SelectableItem[]): SelectionType | null => {
   if (items.length === 0) return null;
 
-  const folders = items.filter(isFolder).length;
+  const folders = items.filter(isFolderLike).length;
 
   if (folders === 0) return 'file';
   if (folders === items.length) return 'folder';
 
   return 'mixed';
-};
-
-const getItemKey = (item: SelectableItem): string => {
-  if ('Key' in item && item.Key) {
-    return item.Key;
-  }
-  if ('Prefix' in item && item.Prefix) {
-    return item.Prefix;
-  }
-  return '';
 };
 
 export const useMultiSelectStore = create<MultiSelectState>((set, get) => ({
@@ -97,7 +98,7 @@ export const useMultiSelectStore = create<MultiSelectState>((set, get) => ({
   lastSelectedIndex: null,
   anchorKey: null,
 
-  selectItem: (item, type, index, ctrlKey, shiftKey, allItems) => {
+  selectItem: (item, index, ctrlKey, shiftKey, allItems) => {
     const state = get();
 
     // Shift+Click: Select range from last clicked item to current item.
@@ -157,10 +158,12 @@ export const useMultiSelectStore = create<MultiSelectState>((set, get) => ({
       return;
     }
 
-    // Regular click: Single selection
+    // Regular click: Single selection.
+    //
+    // Derived from the item, like every other path here.
     set({
       selectedItems: [item],
-      selectedType: type,
+      selectedType: typeOf([item]),
       lastSelectedIndex: index,
       anchorKey: getItemKey(item),
     });

--- a/frontend/src/features/dashboard/types/file.ts
+++ b/frontend/src/features/dashboard/types/file.ts
@@ -6,6 +6,19 @@ export type DataUnits = 'B' | 'KB' | 'MB' | 'GB' | 'TB';
 
 export interface FileItem extends _Object {
   id: string;
+  /**
+   * Which shape this was built as, stated rather than inferred.
+   *
+   * Note what this does NOT say: a zero-byte object whose key ends in a slash
+   * is a folder to the person looking at it, and it is built by the same
+   * factory as any other object, so it carries `kind: 'file'` too. The tag
+   * records the shape; `isFile` and `isFolderLike` in `shared/utils/drive-item`
+   * answer what it means, and they treat that case as a folder.
+   *
+   * Optional only so that anything constructed before this existed, or already
+   * sitting in a cache, still type-checks.
+   */
+  kind?: 'file';
   name: string;
   extension: string;
   size: {

--- a/frontend/src/features/dashboard/types/folder.ts
+++ b/frontend/src/features/dashboard/types/folder.ts
@@ -8,6 +8,18 @@ export interface FolderLocation {
 
 export interface Folder extends CommonPrefix {
   id: string;
+  /**
+   * Which shape this was built as, stated rather than inferred.
+   *
+   * `Prefix` is optional on CommonPrefix, so a folder that arrives without one
+   * used to be indistinguishable from a file - there was nothing left to test.
+   * Set by every factory that produces a Folder.
+   *
+   * Optional only so that anything constructed before this existed, or already
+   * sitting in a cache, still type-checks. The guards in `shared/utils/drive-item`
+   * read it first and fall back to the structural test when it is absent.
+   */
+  kind?: 'folder';
   name: string;
   location: FolderLocation;
   icon?: 'folder';

--- a/frontend/src/features/file-management/file-helpers.ts
+++ b/frontend/src/features/file-management/file-helpers.ts
@@ -17,6 +17,7 @@ export const createFileItem = (
 ): FileItem => {
   return {
     id,
+    kind: 'file',
     name,
     extension,
     size: options?.size || {

--- a/frontend/src/features/file-management/folder-helpers.ts
+++ b/frontend/src/features/file-management/folder-helpers.ts
@@ -31,6 +31,7 @@ export const createFolder = (
 ): Folder => {
   return {
     id,
+    kind: 'folder',
     name,
     location: createFolderLocation(locationType, options?.customLocationLabel),
     icon: options?.icon || 'folder',

--- a/frontend/src/features/upload/hooks/use-delete-operations.ts
+++ b/frontend/src/features/upload/hooks/use-delete-operations.ts
@@ -10,6 +10,7 @@ import { markerLast } from '../utils/delete-key-order';
 import type { FileItem } from '@/features/dashboard/types/file';
 import type { Folder } from '@/features/dashboard/types/folder';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
+import { isFile } from '@/shared/utils/drive-item';
 
 interface FolderContents {
   allKeys: string[];
@@ -428,7 +429,7 @@ export function useDeleteOperations() {
       const itemId = `delete-batch-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
       // Determine batch operation details
-      const fileCount = items.filter((item) => 'Key' in item).length;
+      const fileCount = items.filter(isFile).length;
       const folderCount = items.length - fileCount;
       const operationLabel =
         folderCount > 0 && fileCount > 0
@@ -464,8 +465,7 @@ export function useDeleteOperations() {
             throw abortError();
           }
 
-          if ('Key' in item) {
-            // It's a file
+          if (isFile(item)) {
             allKeysToDelete.push(item.Key || item.name);
           }
         }

--- a/frontend/src/shared/utils/drive-item.test.ts
+++ b/frontend/src/shared/utils/drive-item.test.ts
@@ -1,0 +1,263 @@
+/**
+ * The one place that decides whether an item is a file or a folder.
+ *
+ * Four different predicates used to answer this across twenty sites, and they
+ * disagreed at the edges. One of the places they disagreed was delete, where a
+ * folder marker was handed to the file path and took only itself with it.
+ *
+ * Two rules run through everything below.
+ *
+ * The first is that the `kind` tag a factory stamps on is read before the
+ * shape, but the tag is optional - anything built before it existed, or
+ * restored from a cache written before it, still has to be answered for. So
+ * every case is stated twice where it matters: once tagged, once not.
+ *
+ * The second is that the tag records the SHAPE an item was built as, not what
+ * it means. A zero-byte object whose key ends in a slash is built by the file
+ * factory like everything else in a listing, so it carries `kind: 'file'` while
+ * being a folder to anyone looking at it. That is the case most of this file
+ * exists to hold down.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  driveItemKind,
+  folderFromMarker,
+  isFile,
+  isFolder,
+  isFolderLike,
+  isFolderMarker,
+  itemKey,
+} from './drive-item';
+import type { FileItem } from '@/features/dashboard/types/file';
+
+/** Untagged, the way anything built before the tag existed still looks. */
+const untaggedFile = { Key: 'reports/budget.xlsx', name: 'budget.xlsx' };
+const untaggedFolder = { Prefix: 'reports/', name: 'Reports' };
+const untaggedMarker = { Key: 'archive/photos/', name: 'Photos' };
+
+/** Tagged, the way every factory builds them now. */
+const taggedFile = { kind: 'file', Key: 'reports/budget.xlsx', name: 'budget.xlsx' };
+const taggedFolder = { kind: 'folder', Prefix: 'reports/', name: 'Reports' };
+
+/**
+ * The trap. Built by the file factory, so tagged `file` - and a folder.
+ *
+ * Trusting the tag here is what sent it to deleteFile, which removed the marker
+ * object and left everything stored beneath it orphaned: still billed, and no
+ * longer reachable by a listing with no prefix to find it under.
+ */
+const taggedMarker = { kind: 'file', Key: 'archive/photos/', name: 'Photos' };
+
+describe('reading the tag', () => {
+  it('calls a tagged folder a folder', () => {
+    expect(isFolder(taggedFolder)).toBe(true);
+    expect(isFile(taggedFolder)).toBe(false);
+    expect(driveItemKind(taggedFolder)).toBe('folder');
+  });
+
+  it('calls a tagged file a file', () => {
+    expect(isFile(taggedFile)).toBe(true);
+    expect(isFolder(taggedFile)).toBe(false);
+    expect(driveItemKind(taggedFile)).toBe('file');
+  });
+
+  it('believes the tag over the shape', () => {
+    // Contrived, but it pins the precedence: nothing structural gets to
+    // overrule a factory that already said what it built.
+    const oddity = { kind: 'folder', Key: 'reports/budget.xlsx', name: 'Reports' };
+
+    expect(isFolder(oddity)).toBe(true);
+    expect(isFile(oddity)).toBe(false);
+  });
+
+  it('answers for a folder that arrived without a prefix', () => {
+    // The case that had no answer at all before the tag. `Prefix` is optional
+    // on CommonPrefix, so a folder without one left nothing to test and fell
+    // through to being treated as a file.
+    const noPrefix = { kind: 'folder', name: 'Reports' };
+
+    expect(isFolder(noPrefix)).toBe(true);
+    expect(driveItemKind(noPrefix)).toBe('folder');
+  });
+
+  it('ignores a tag it does not recognise', () => {
+    // A cache written by a future version, or a hand-built object. Anything
+    // that is not one of the two literals is treated as absent rather than
+    // trusted, so the structural fallback still answers.
+    const bogus = { kind: 'directory', Key: 'reports/budget.xlsx', name: 'budget.xlsx' };
+
+    expect(isFile(bogus)).toBe(true);
+    expect(isFolder(bogus)).toBe(false);
+  });
+
+  it('falls back to the shape when the tag is absent', () => {
+    expect(isFile(untaggedFile)).toBe(true);
+    expect(isFolder(untaggedFolder)).toBe(true);
+    expect(driveItemKind(untaggedFile)).toBe('file');
+    expect(driveItemKind(untaggedFolder)).toBe('folder');
+  });
+});
+
+describe('a folder stored as an object', () => {
+  it('is a folder even though the tag says file', () => {
+    expect(isFolderMarker(taggedMarker)).toBe(true);
+    expect(isFolderLike(taggedMarker)).toBe(true);
+    expect(driveItemKind(taggedMarker)).toBe('folder');
+  });
+
+  it('is never a file, whatever the tag says', () => {
+    // The single assertion this module exists for. Everything gated on isFile
+    // - open, download, share, and the file branch of delete - is something
+    // that makes no sense for a folder.
+    expect(isFile(taggedMarker)).toBe(false);
+    expect(isFile(untaggedMarker)).toBe(false);
+  });
+
+  it('is recognised without a tag too', () => {
+    expect(isFolderMarker(untaggedMarker)).toBe(true);
+    expect(driveItemKind(untaggedMarker)).toBe('folder');
+  });
+
+  it('is not a prefix folder, which is a different shape', () => {
+    // isFolder stays narrow so that `item is Folder` is not a lie: a marker
+    // carries a Key, not a Prefix, and Folder.location is a different shape
+    // from FileItem.location.
+    expect(isFolder(taggedMarker)).toBe(false);
+    expect(isFolder(untaggedMarker)).toBe(false);
+  });
+
+  it('does not catch a file that merely lives under a folder', () => {
+    // Only a trailing slash makes a marker. A key with slashes in the middle
+    // is an ordinary file in a subdirectory.
+    expect(isFolderMarker({ kind: 'file', Key: 'a/b/c.txt', name: 'c.txt' })).toBe(false);
+    expect(isFile({ kind: 'file', Key: 'a/b/c.txt', name: 'c.txt' })).toBe(true);
+  });
+});
+
+describe('the three answers never overlap', () => {
+  it.each([
+    ['untagged file', untaggedFile],
+    ['untagged prefix folder', untaggedFolder],
+    ['untagged marker', untaggedMarker],
+    ['tagged file', taggedFile],
+    ['tagged prefix folder', taggedFolder],
+    ['tagged marker', taggedMarker],
+    ['tagged folder with no prefix', { kind: 'folder', name: 'Reports' }],
+    ['an item with nothing to go on', { name: 'orphan' }],
+  ])('%s matches at most one guard', (_label, item) => {
+    const matches = [isFolder(item), isFolderMarker(item), isFile(item)].filter(Boolean).length;
+
+    // Two guards agreeing is how the old predicates produced different answers
+    // in different files for the same item.
+    expect(matches).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('items with nothing to go on', () => {
+  it('is neither a file nor a folder', () => {
+    const orphan = { name: 'orphan' };
+
+    expect(isFolder(orphan)).toBe(false);
+    expect(isFile(orphan)).toBe(false);
+    expect(isFolderMarker(orphan)).toBe(false);
+    expect(driveItemKind(orphan)).toBe('unknown');
+  });
+
+  it('reports unknown rather than guessing, even when tagged', () => {
+    // A tag with no key behind it is not enough to act on: every file action
+    // needs the key. Better to say so than to pick a branch.
+    expect(driveItemKind({ kind: 'file', name: 'no key' })).toBe('unknown');
+  });
+
+  it('survives values that are not items at all', () => {
+    for (const value of [null, undefined, 42, 'reports/', []]) {
+      expect(isFolder(value)).toBe(false);
+      expect(isFile(value)).toBe(false);
+      expect(isFolderMarker(value)).toBe(false);
+    }
+  });
+
+  it('treats an empty key or prefix as absent', () => {
+    expect(isFile({ kind: 'file', Key: '', name: 'x' })).toBe(false);
+    expect(isFolder({ Prefix: '', name: 'x' })).toBe(false);
+  });
+});
+
+describe('turning a marker into a folder', () => {
+  const marker = {
+    id: 'archive/photos/',
+    kind: 'file',
+    Key: 'archive/photos/',
+    name: 'Photos',
+  } as unknown as FileItem;
+
+  it('produces something isFolder accepts', () => {
+    // Without this the folder delete path refuses the very thing the function
+    // exists to hand it, because the spread carries the marker's own
+    // `kind: 'file'` across.
+    expect(isFolder(folderFromMarker(marker))).toBe(true);
+  });
+
+  it('overrides the tag it inherited', () => {
+    expect(folderFromMarker(marker).kind).toBe('folder');
+  });
+
+  it('carries the key across as the prefix', () => {
+    // deleteFolderWithProgress reads `Prefix || name` and normalises a trailing
+    // slash onto it, so this is what makes the delete cover the contents.
+    expect(folderFromMarker(marker).Prefix).toBe('archive/photos/');
+  });
+
+  it('keeps the name and the identity', () => {
+    const folder = folderFromMarker(marker);
+
+    expect(folder.name).toBe('Photos');
+    expect(itemKey(folder)).toBe(itemKey(marker));
+  });
+
+  it('falls back to the name when there is no key', () => {
+    const nameless = { name: 'Photos' } as FileItem;
+
+    expect(folderFromMarker(nameless).Prefix).toBe('Photos');
+  });
+});
+
+describe('identity', () => {
+  it('reads the id first, the one field always populated', () => {
+    // enrichFolder and enrichFile both generate an id when the S3 field is
+    // absent, which is what makes it the only safe first choice.
+    expect(itemKey({ id: 'generated-1', Key: 'a.txt' })).toBe('generated-1');
+    expect(itemKey({ id: 'generated-2', Prefix: 'docs/' })).toBe('generated-2');
+  });
+
+  it('falls back to the key, then the prefix', () => {
+    expect(itemKey(untaggedFile)).toBe('reports/budget.xlsx');
+    expect(itemKey(untaggedFolder)).toBe('reports/');
+  });
+
+  it('never returns an empty string', () => {
+    for (const value of [{ name: 'orphan' }, {}, null, undefined, 7]) {
+      expect(itemKey(value)).not.toBe('');
+    }
+  });
+
+  it('gives one item the same answer every time', () => {
+    // Selection compares by this, so an item that answered differently between
+    // renders would drop out of the selection it was just added to.
+    const orphan = { name: 'orphan' };
+
+    expect(itemKey(orphan)).toBe(itemKey(orphan));
+  });
+
+  it('keeps two items with no identifier apart', () => {
+    // Both used to key to the empty string, so they were one item: selecting
+    // either showed both selected, and deselecting one removed both.
+    expect(itemKey({ name: 'one' })).not.toBe(itemKey({ name: 'two' }));
+  });
+
+  it('ignores an id that is not a usable string', () => {
+    expect(itemKey({ id: '', Key: 'a.txt' })).toBe('a.txt');
+    expect(itemKey({ id: 42, Key: 'a.txt' })).toBe('a.txt');
+  });
+});

--- a/frontend/src/shared/utils/drive-item.ts
+++ b/frontend/src/shared/utils/drive-item.ts
@@ -1,0 +1,199 @@
+/**
+ * The one answer to "is this a file or a folder?", and the one answer to
+ * "which item is this?".
+ *
+ * The types used to carry nothing saying what they were. `Folder extends
+ * CommonPrefix` and `FileItem extends _Object`, and in both the identifying
+ * field - `Prefix`, `Key` - is optional. So every site that needed to tell them
+ * apart invented its own test, and they were not invented the same way: four
+ * different predicates across twenty sites, disagreeing at exactly the edges
+ * that matter. One of the places they disagreed was delete, where a folder
+ * marker was sent to the file path and took only itself with it.
+ *
+ * Both types now carry a `kind` tag, set by whichever factory built them, and
+ * these read it first. It is optional, so anything built before it existed or
+ * restored from a cache written before it still has to be handled - which is
+ * why every structural test below is still here, as the fallback.
+ *
+ * One thing the tag deliberately does not settle. It records the SHAPE an item
+ * was built as, and a zero-byte object whose key ends in a slash is built by
+ * the file factory like everything else in a listing - so it carries
+ * `kind: 'file'` while being a folder to anyone looking at it. `isFolderMarker`
+ * is checked before the tag everywhere it matters, and that ordering is what
+ * keeps such an object off the file delete path.
+ *
+ * This module is the single place that decides. Everything else asks it.
+ */
+
+import type { FileItem } from '@/features/dashboard/types/file';
+import type { Folder } from '@/features/dashboard/types/folder';
+
+/** What an item turned out to be, including the case where we cannot tell. */
+export type DriveItemKind = 'folder' | 'file' | 'unknown';
+
+type MaybeFolder = { Prefix?: unknown };
+type MaybeFile = { Key?: unknown };
+type MaybeTagged = { kind?: unknown };
+
+/**
+ * The tag a factory stamped on, if there is one and it is one we know.
+ *
+ * Absent means the item predates the tag or came out of a cache written before
+ * it, so the structural tests below still have to answer. Anything else in the
+ * field is treated as absent rather than trusted.
+ */
+function readKind(item: unknown): 'folder' | 'file' | null {
+  if (typeof item !== 'object' || item === null) return null;
+  const kind = (item as MaybeTagged).kind;
+  return kind === 'folder' || kind === 'file' ? kind : null;
+}
+
+function readPrefix(item: unknown): string | null {
+  if (typeof item !== 'object' || item === null) return null;
+  const prefix = (item as MaybeFolder).Prefix;
+  return typeof prefix === 'string' && prefix.length > 0 ? prefix : null;
+}
+
+function readKey(item: unknown): string | null {
+  if (typeof item !== 'object' || item === null) return null;
+  const key = (item as MaybeFile).Key;
+  return typeof key === 'string' && key.length > 0 ? key : null;
+}
+
+/**
+ * A folder proper - one listed as a CommonPrefix, carrying a `Prefix`.
+ *
+ * Narrow on purpose. A folder marker is shaped like a file and claiming
+ * otherwise would be a lie the compiler then trusts, so it gets its own test
+ * below rather than being folded in here.
+ */
+export function isFolder(item: unknown): item is Folder {
+  const kind = readKind(item);
+  if (kind !== null) return kind === 'folder';
+
+  // Untagged, so fall back to the shape. This is the branch that could not
+  // answer for a folder arriving without a `Prefix` - the tag exists to stop
+  // that being unanswerable.
+  return readPrefix(item) !== null;
+}
+
+/**
+ * An object stored under a key that ends in a slash: a folder represented as an
+ * object rather than as a prefix.
+ *
+ * S3 has no directories. A folder is either inferred from a delimiter - which
+ * is what gives a `Prefix` - or written explicitly as a zero-byte object whose
+ * key ends in `/`. Both are folders to the person looking at them, and deleting
+ * one has to take its contents with it. Reading the trailing slash is the only
+ * way to tell the second kind from an ordinary file.
+ */
+export function isFolderMarker(item: unknown): item is FileItem {
+  if (isFolder(item)) return false;
+
+  // Deliberately not tag-aware beyond that. The same factory builds every
+  // object in a listing, marker or not, so a marker carries `kind: 'file'` like
+  // everything else. Consulting the tag here would hand it back to the file
+  // path, which is what deleted the marker and orphaned everything under it.
+  const key = readKey(item);
+  return key !== null && key.endsWith('/');
+}
+
+/** Either kind of folder. The test most callers actually want. */
+export function isFolderLike(item: unknown): boolean {
+  return isFolder(item) || isFolderMarker(item);
+}
+
+/**
+ * A real file - something with contents a person can open, download or share.
+ *
+ * Excludes folder markers, which is what separates this from a bare `'Key' in
+ * item` check. Every action gated on this is one that makes no sense for a
+ * folder.
+ */
+export function isFile(item: unknown): item is FileItem {
+  // Checked before the tag, for the reason given on isFolderMarker.
+  if (isFolderMarker(item)) return false;
+
+  const kind = readKind(item);
+  if (kind !== null) return kind === 'file' && readKey(item) !== null;
+
+  return readKey(item) !== null;
+}
+
+/** What this item is, for callers that need to branch on all three cases. */
+export function driveItemKind(item: unknown): DriveItemKind {
+  if (isFolderLike(item)) return 'folder';
+  if (isFile(item)) return 'file';
+  return 'unknown';
+}
+
+/**
+ * A folder marker as a `Folder`, so the folder delete path can take it.
+ *
+ * That path reads `Prefix || name` and normalises a trailing slash onto it, so
+ * handing it the marker's own key deletes the prefix and everything beneath it
+ * rather than just the marker object.
+ */
+export function folderFromMarker(marker: FileItem): Folder {
+  const key = readKey(marker) ?? marker.name;
+
+  return {
+    ...marker,
+    // After the spread, which carries the marker's own `kind: 'file'` across.
+    // Leaving that in place would make isFolder reject the very thing this
+    // function exists to produce, and the folder delete path would refuse it.
+    kind: 'folder',
+    Prefix: key,
+    name: marker.name,
+    icon: 'folder',
+    location: { type: 'my-drive', label: 'My Drive' },
+  } as Folder;
+}
+
+/**
+ * Identity, guaranteed non-empty and never shared between two different items.
+ *
+ * `id` comes first because it is the only field that is always populated:
+ * `enrichFolder` and `enrichFile` both fall back to a generated one precisely
+ * because the S3 field can be absent. The previous version of this went
+ * `Key`, then `Prefix`, then the empty string - so any two items missing both
+ * collapsed into one item, and selecting either showed both as selected.
+ */
+export function itemKey(item: unknown): string {
+  if (typeof item !== 'object' || item === null) return syntheticKey(item);
+
+  const id = (item as { id?: unknown }).id;
+  if (typeof id === 'string' && id.length > 0) return id;
+
+  const key = readKey(item);
+  if (key !== null) return key;
+
+  const prefix = readPrefix(item);
+  if (prefix !== null) return prefix;
+
+  return syntheticKey(item);
+}
+
+/**
+ * A last resort for an item carrying no usable identifier at all.
+ *
+ * Keyed off the object itself, so the same item answers the same way every
+ * time it is asked - which selection depends on - while two distinct items
+ * still never collide. A counter rather than a random value keeps it readable
+ * when one shows up in a log.
+ */
+const syntheticKeys = new WeakMap<object, string>();
+let syntheticCount = 0;
+
+function syntheticKey(item: unknown): string {
+  if (typeof item !== 'object' || item === null) {
+    return `drive-item:unidentifiable:${++syntheticCount}`;
+  }
+
+  const existing = syntheticKeys.get(item);
+  if (existing !== undefined) return existing;
+
+  const created = `drive-item:unidentifiable:${++syntheticCount}`;
+  syntheticKeys.set(item, created);
+  return created;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
         'src/features/**/utils/folder-structure-processor.ts',
         'src/features/**/utils/drag-events.ts',
         'src/features/**/hooks/use-folder-drop-target.ts',
+        // The single answer to whether an item is a file or a folder. Every
+        // delete routes through it, so it is worth holding to a number.
+        'src/shared/utils/drive-item.ts',
       ],
       exclude: ['**/*.test.{ts,tsx}'],
       // No thresholds yet - Phase 2 is only half written. Add them at the end,


### PR DESCRIPTION
Stacked on #193 - **base that branch, not main.** This builds directly on the selection rewrite there (`typeOf`, `anchorKey`, mixed selection), so it does not stand alone. Merge #193 first and this retargets to main.

This is Code Review Finding 5 from #193.

## Summary

S3 has no real folders. A "folder" is one of two things:

- a **prefix** — comes back with a `Prefix` field, e.g. `photos/`
- a **marker** — a real empty object whose key ends in a slash, e.g. `Key: 'photos/'`

The second kind looks *exactly* like a file. Same shape, same fields. The only difference is the slash at the end.

Because nothing said what it was, the code had **six different ways** of asking "file or folder?", spread across 20 places. They did not all agree. Delete was one of the places they disagreed — and it failed quietly.

## Critical fixes

### 1. Deleting a folder left everything inside it behind

The delete code picked the file list one way, then deleted a different way:

```js
// picking the batch — skips markers ✅
const files = items.filter((i) => i.Key && !i.Key.endsWith('/'));

// actually deleting — does NOT skip markers ❌
if (item.Key) await deleteFile(item);
```

**What that meant:** you select the folder `photos/` and hit Delete. It removes the marker object only. The 200 photos inside stay in the bucket. You still pay for them, but nothing lists them any more — they are invisible, not deleted.

**Now:** `photos/` is recognised as a folder and goes down the folder path, taking its contents with it.

### 2. Some deletes did nothing, and said nothing

The old loop was:

```js
if (isFile)         deleteFile()
else if (isFolder)  deleteFolder()
// ...and nothing else
```

An item matching neither branch just fell through. No error, no log. The confirm box had already been accepted and the selection had already been cleared — so **the app looked like it deleted something it never touched.**

Now there is an `else` that raises an error, and anything that fails is reported:
`Could not delete "report.pdf".`

## Architectural changes

### One module decides — `shared/utils/drive-item.ts`

Everything asks it instead of guessing:

| Function | Answers |
|---|---|
| `isFolder(item)` | a real prefix folder |
| `isFolderMarker(item)` | a folder saved as an object (key ends in `/`) |
| `isFile(item)` | an actual file you can open, download or share |
| `itemKey(item)` | which item is this |

### Items now say what they are

Before, we guessed from whichever field happened to exist. Now every factory stamps the item:

```js
{ kind: 'folder', Prefix: 'photos/' }
{ kind: 'file',   Key: 'notes.txt' }
```

The tag is optional (`kind?`), so anything already sitting in a cache still works — if it is missing we fall back to the old structural check (`Prefix` vs `Key`).

**One catch worth knowing.** A folder marker is built by the *file* factory, so it gets stamped `kind: 'file'` even though it is a folder. So `isFolderMarker` is always checked **before** the tag is trusted. Trusting the tag first would put the marker straight back on the file delete path — the exact bug above.

### Stable IDs for selection

`itemKey` used to return `''` for an item with no key. Two such items then looked like the same item:

- select one → both highlight
- unselect one → both disappear

Now it tries `id`, then `Key`, then `Prefix`, and if all are missing it hands out a unique ID from a `WeakMap`. The same object always gets the same ID, and two different objects never share one.

## Cleanup

- **96 call sites** no longer pass a type argument to `selectItem`. Components used to hand over `'file'` or `'folder'` by hand, which could disagree with the item itself. The item is read directly now.
- **20 hand-rolled type checks** removed, along with the `as FileItem` / `as Folder` casts each of them needed. Those casts were the tell: every one was a spot where the compiler had been told to stop checking.

## Testing

- **1385 tests pass**, typecheck clean, 0 lint errors, clean build.
- New `drive-item.test.ts` covers all **11 tag/marker combinations**, including the awkward one: `{ kind: 'file', Key: 'photos/' }` must come out as a **folder**, never a file.
- Existing selection tests updated: the type is now derived from the item rather than passed in, so cases that used to assert the passed-in value now assert the derived one.

## What to test by hand

1. Delete a folder that has files in it. Check in the S3 console that the contents are gone, not just the folder.
2. Select a folder and a file together — Open, Download and Share should be greyed out; Delete stays available.
3. Delete something that fails (e.g. revoke permissions first). You should see an error, not a silent success.
