### PR TITLE
feat: update listings in place instead of re-reading them

### DIFF
--- a/.changeset/delete-card-says-what-it-did.md
+++ b/.changeset/delete-card-says-what-it-did.md
@@ -1,0 +1,49 @@
+---
+'frontend': patch
+---
+
+Make the delete card say what it deleted, and what it could not
+
+Three things about that card were wrong, and the last one hid real failures.
+
+The icon was hardcoded. Batch deletes set `type: 'folder'` to get _an_ icon, so
+deleting a single photo drew a folder — and a selection of eight files drew a
+folder too, sitting next to a label that correctly read "Deleting 8 files". The
+icon is now read from the selection: one item gets its own name and icon, eight
+JSON files get the JSON icon, and a selection with no one answer gets a stacked
+one rather than picking a side. A folder saved as a real object — a zero-byte
+key ending in a slash — counts as a folder here, because that is what it is to
+the person looking at it.
+
+The shared extension has to be carried on the card rather than read back off its
+name, because a batch card is named "8 items" and there is no extension in that.
+Deriving it from the name is what left the icon as a question mark, which reads
+as an error rather than as eight files.
+
+The card also names them now, behind an info icon beside the count: hovering it
+lists the files one per line. "8 items" is true and useless — it does not tell
+you whether the eight you selected are the eight you meant — but the names
+inline truncate to "main - Copy - Copy (2).json, mai…", which spends a whole
+line saying less than the count already did.
+
+That list needed two things from the tooltip it borrows. `multiline` on its own
+gives `white-space: normal`, which wraps but folds newlines into spaces, so a
+list arrives as one run-on paragraph; there is a `pre-line` variant for it now.
+And the tooltip measured itself with a class list that left out the caller's own
+`className`, so it sized one element and rendered another — harmless while
+nothing passed one, and wrong the moment anything did.
+
+A finished delete was painted the same red as a cancelled or failed one, so a
+green tick sat beside red text and a genuine failure was indistinguishable from
+a success at a glance. It is muted now, like a finished upload.
+
+And a failed delete showed no reason at all. `failDeleteOperation` sets the
+status to `'failed'`, but the row only rendered a reason for `'error'` — a
+status deletes never use. So the summary naming the objects that could not be
+deleted was built, written to the store, and dropped at the last step. That
+summary now reaches the card, and it names up to three failed objects with the
+codes S3 gave, rather than only the first one.
+
+None of this costs an extra request. S3 returns per-object failures inline in
+the same `DeleteObjects` response that does the deleting; the information was
+already in hand.

--- a/.changeset/localized-cache-updates.md
+++ b/.changeset/localized-cache-updates.md
@@ -1,0 +1,25 @@
+---
+'frontend': patch
+---
+
+Update the listing in place after a file operation, instead of re-reading it
+
+Every operation used to finish by calling `refreshCurrentData`, which re-lists a
+whole prefix twice - once for the directory and once for the recent items, each
+up to a thousand objects. It always re-read the prefix the user was standing in,
+whatever prefix the operation had actually touched, so dropping files into a
+folder from outside it re-listed the wrong folder and left the right one stale.
+Deleting several files paid for that round trip once per file, in series.
+
+The drive store now edits the rows it already knows changed. `removeFiles`,
+`addFile`, `addFolder`, `renameFile` and `renameFolder` rewrite the affected
+listing - and the recent list behind it, offsets included - and each returns the
+inverse of what it did, so an operation whose request then fails puts back what
+it took and nothing else. Uploads carry the key, size and destination they
+landed at, so a finished one adds its own row rather than asking where the user
+happens to be.
+
+A re-read still happens where the outcome is genuinely unknown - a partly failed
+batch delete, a folder rename that left copies behind - but silently: it does
+not announce itself as loading, and a failure no longer replaces rows that are
+still on screen with an error notice.

--- a/.changeset/readable-delete-confirmation.md
+++ b/.changeset/readable-delete-confirmation.md
@@ -1,0 +1,21 @@
+---
+'frontend': patch
+---
+
+Make the multi-select delete confirmation readable, and warn about folders
+
+Deleting a selection asked for confirmation with every name comma-joined and
+quoted into one paragraph, and with no cap at all — so eight files arrived as a
+run-on line to be parsed rather than scanned, and four hundred arrived as a
+four-hundred-name wall. The body also opened by repeating the count the title
+had just given.
+
+The names are now listed one per line, capped at eight with the rest counted,
+and folders keep a trailing slash — in a plain list that is the only thing that
+says a name is a folder.
+
+More importantly, it now says what a folder costs. The single-folder dialog has
+always warned "and everything inside it"; this one said "5 items will be deleted
+forever" and stopped, which gives no hint that one of those five might hold ten
+thousand more. A selection containing a folder now carries that sentence, and a
+selection of exactly one folder gets the same wording the overflow menu uses.

--- a/.changeset/rename-provider-hook-order.md
+++ b/.changeset/rename-provider-hook-order.md
@@ -1,0 +1,21 @@
+---
+'frontend': patch
+---
+
+Declare the rename provider's hooks unconditionally
+
+`RenameProvider` returned early — once while authenticating, once when signed
+out — above every hook it declares. That makes the number of hooks depend on
+session state, which is the one thing rules-of-hooks exists to prevent: signing
+out flips `isAuthenticated` on an already-mounted provider, so the next render
+runs one hook where the previous ran twenty. React raises "Rendered fewer hooks
+than expected" and the dashboard goes down with it.
+
+The hooks now come first and the two returns last. `renameService` is memoised
+on `apiS3` rather than rebuilt on every render, which also settles a stale
+closure: as a bare call it was absent from every dependency array, so the rename
+callbacks captured whichever instance the first render happened to build and
+would have kept talking to the previous bucket after a switch.
+
+Eighteen lint warnings had been reporting this, and `--max-warnings=0` in
+lint-staged meant the file could not be committed at all.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -882,6 +882,19 @@ body {
   max-width: 200px;
 }
 
+/*
+ * A tooltip that lists things, one per line.
+ *
+ * `multiline` alone is not enough: it gives white-space: normal, which wraps
+ * but folds newlines into spaces, so a list of filenames arrives as one
+ * run-on paragraph.
+ */
+.custom-aria-label.aria-label-list {
+  white-space: pre-line;
+  text-align: left;
+  max-width: 320px;
+}
+
 /* No triangle - clean tooltip design */
 
 @media (max-width: 640px) {
@@ -894,6 +907,10 @@ body {
 
   .custom-aria-label.multiline {
     max-width: 150px;
+  }
+
+  .custom-aria-label.aria-label-list {
+    max-width: 220px;
   }
 }
 

--- a/frontend/src/context/data-context-mutators.test.ts
+++ b/frontend/src/context/data-context-mutators.test.ts
@@ -337,43 +337,6 @@ describe('creating a folder', () => {
   });
 });
 
-describe('invalidating a prefix', () => {
-  it('drops one the user is not looking at', () => {
-    useDriveStore.setState({
-      currentPrefix: '/',
-      cache: {
-        '/': { files: [file('a.txt')], folders: [], isTruncated: false },
-        'docs/': { files: [file('docs/b.txt')], folders: [], isTruncated: false },
-      },
-      directory: { 'docs/': { status: 'ready' } },
-    });
-
-    store().invalidatePrefix('docs/');
-
-    expect(store().cache['docs/']).toBeUndefined();
-    expect(store().directory['docs/']).toBeUndefined();
-    // The folder on screen is untouched.
-    expect(keysAt('/')).toEqual(['a.txt']);
-  });
-
-  it('re-reads the one on screen instead of dropping it', () => {
-    const fetchDirectoryStructure = vi.fn(() => new Promise(() => {}));
-    useDriveStore.setState({
-      currentPrefix: '/',
-      cache: { '/': { files: [file('a.txt')], folders: [], isTruncated: false } },
-      directory: { '/': { status: 'ready' } },
-    });
-    store().setApiS3({ fetchDirectoryStructure, getPrefix: () => '' } as never);
-
-    store().invalidatePrefix('/');
-
-    // Dropping it would leave the view with nothing to render and send it back
-    // to its skeleton, which is the blanking this whole change exists to avoid.
-    expect(keysAt('/')).toEqual(['a.txt']);
-    expect(fetchDirectoryStructure).toHaveBeenCalled();
-  });
-});
-
 describe('statuses left behind by a retired request', () => {
   it('frees a "Show more" that was mid-flight', () => {
     useDriveStore.setState({

--- a/frontend/src/context/data-context-mutators.test.ts
+++ b/frontend/src/context/data-context-mutators.test.ts
@@ -1,0 +1,528 @@
+/**
+ * Localized edits to the drive cache.
+ *
+ * Every file operation used to end in refreshCurrentData, which re-lists the
+ * prefix the user is standing in - twice, once for the listing and once for the
+ * recent items - whatever prefix the operation actually touched. These mutators
+ * replace that with an edit to the rows themselves.
+ *
+ * What is pinned here is mostly the ways that edit can go wrong: matching a
+ * file by prefix instead of by whole key, inserting into a page nobody has
+ * fetched, moving a window without moving the offset that marks its edge, and
+ * undoing a change by restoring a snapshot that also undoes everyone else's.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useDriveStore } from './data-context';
+import type { FileItem } from '@/features/dashboard/types/file';
+import type { Folder } from '@/features/dashboard/types/folder';
+
+function folder(prefix: string): Folder {
+  const name = prefix.replace(/\/$/, '').split('/').pop() ?? '';
+  return {
+    Prefix: prefix,
+    id: prefix,
+    name,
+    icon: 'folder',
+    location: { type: 'my-drive', label: 'My Drive' },
+  };
+}
+
+function file(key: string, minutesAgo = 0): FileItem {
+  return {
+    Key: key,
+    id: key,
+    name: key.split('/').pop() ?? '',
+    extension: 'txt',
+    size: { value: 1, unit: 'B' },
+    lastModified: new Date(Date.UTC(2026, 0, 1, 12, 0) - minutesAgo * 60_000),
+  };
+}
+
+const store = () => useDriveStore.getState();
+const keysAt = (prefix: string) => store().cache[prefix]?.files.map((item) => item.Key);
+const foldersAt = (prefix: string) => store().cache[prefix]?.folders.map((item) => item.Prefix);
+
+beforeEach(() => {
+  useDriveStore.setState({
+    apiS3: null,
+    cache: {},
+    recentCache: {},
+    directory: {},
+    recent: {},
+    loadMoreStatus: {},
+    rootPrefix: '/',
+    currentPrefix: '/',
+  });
+});
+
+describe('removing files by whole key', () => {
+  beforeEach(() => {
+    useDriveStore.setState({
+      cache: {
+        '/': {
+          files: [file('report.pdf'), file('report.pdf.bak'), file('notes.txt')],
+          folders: [],
+          isTruncated: false,
+        },
+      },
+    });
+  });
+
+  it('takes out only the file named', () => {
+    store().removeFiles(['report.pdf']);
+
+    expect(keysAt('/')).toEqual(['report.pdf.bak', 'notes.txt']);
+  });
+
+  it('leaves a listing alone when nothing matches', () => {
+    const before = store().cache['/'];
+    store().removeFiles(['absent.txt']);
+
+    // Same object, not merely an equal one: a change aimed elsewhere must not
+    // re-render the folder on screen.
+    expect(store().cache['/']).toBe(before);
+  });
+
+  it('routes each key to the listing that holds it', () => {
+    useDriveStore.setState({
+      cache: {
+        '/': { files: [file('a.txt')], folders: [], isTruncated: false },
+        'docs/': { files: [file('docs/b.txt')], folders: [], isTruncated: false },
+      },
+    });
+
+    store().removeFiles(['a.txt', 'docs/b.txt']);
+
+    expect(keysAt('/')).toEqual([]);
+    expect(keysAt('docs/')).toEqual([]);
+  });
+});
+
+describe('inserting into a truncated listing', () => {
+  beforeEach(() => {
+    useDriveStore.setState({
+      cache: {
+        'x/': {
+          files: [file('x/a.txt'), file('x/m.txt')],
+          folders: [],
+          isTruncated: true,
+          nextToken: 'token',
+        },
+      },
+    });
+  });
+
+  it('skips a key belonging to a page nobody has fetched', () => {
+    store().addFile('x/', { key: 'x/z.txt', size: 10 });
+
+    // 'z' sorts past the last key read, so the real object is in a page still
+    // to come. Placing it here would make appendUnique drop that object when
+    // the page arrives, stranding this guess in its place.
+    expect(keysAt('x/')).toEqual(['x/a.txt', 'x/m.txt']);
+  });
+
+  it('still places a key that falls inside what was fetched', () => {
+    store().addFile('x/', { key: 'x/b.txt', size: 10 });
+
+    expect(keysAt('x/')).toEqual(['x/a.txt', 'x/b.txt', 'x/m.txt']);
+  });
+
+  it('places a key past the end once the listing is complete', () => {
+    useDriveStore.setState({
+      cache: { 'x/': { files: [file('x/a.txt')], folders: [], isTruncated: false } },
+    });
+
+    store().addFile('x/', { key: 'x/z.txt', size: 10 });
+
+    expect(keysAt('x/')).toEqual(['x/a.txt', 'x/z.txt']);
+  });
+
+  it('leaves the server cursor alone when removing', () => {
+    store().removeFiles(['x/a.txt']);
+
+    // nextToken marks where the server stopped reading, not what we are
+    // holding, so filtering locally must not disturb it.
+    expect(store().cache['x/']?.nextToken).toBe('token');
+    expect(store().cache['x/']?.isTruncated).toBe(true);
+  });
+});
+
+describe('the recent list and its pagination window', () => {
+  beforeEach(() => {
+    useDriveStore.setState({
+      recentCache: {
+        '/': {
+          files: [file('c.txt', 1), file('b.txt', 2), file('a.txt', 3)],
+          folders: [],
+          _allFiles: [file('c.txt', 1), file('b.txt', 2), file('a.txt', 3), file('old.txt', 99)],
+          _allFolders: [],
+          fileOffset: 3,
+          folderOffset: 0,
+          hasMoreFiles: true,
+          hasMoreFolders: false,
+        },
+      },
+    });
+  });
+
+  it('adds a new file to the window and the source behind it', () => {
+    store().addFile('/', { key: 'fresh.txt', size: 5 });
+
+    const recent = store().recentCache['/']!;
+
+    expect(recent.files[0]?.Key).toBe('fresh.txt');
+    expect(recent._allFiles?.[0]?.Key).toBe('fresh.txt');
+    expect(recent._allFiles).toHaveLength(5);
+    // The window grew, so the mark of how far it reaches grows with it.
+    // Left at 3, "View more" would hand back c.txt a second time.
+    expect(recent.fileOffset).toBe(4);
+    expect(recent.hasMoreFiles).toBe(true);
+  });
+
+  it('keeps a file older than the window out of it', () => {
+    store().addFile('/', { key: 'ancient.txt', size: 5, lastModified: new Date(0) });
+
+    const recent = store().recentCache['/']!;
+
+    expect(recent.files.map((item) => item.Key)).toEqual(['c.txt', 'b.txt', 'a.txt']);
+    expect(recent._allFiles?.map((item) => item.Key)).toContain('ancient.txt');
+    expect(recent.fileOffset).toBe(3);
+  });
+
+  it('moves the offset down with the window on a removal', () => {
+    store().removeFiles(['b.txt']);
+
+    const recent = store().recentCache['/']!;
+
+    expect(recent.files.map((item) => item.Key)).toEqual(['c.txt', 'a.txt']);
+    expect(recent._allFiles).toHaveLength(3);
+    expect(recent.fileOffset).toBe(2);
+    expect(recent.hasMoreFiles).toBe(true);
+  });
+});
+
+describe('undoing a change without undoing anyone else', () => {
+  beforeEach(() => {
+    useDriveStore.setState({
+      cache: {
+        '/': { files: [file('a.txt'), file('b.txt')], folders: [], isTruncated: false },
+      },
+    });
+  });
+
+  it('takes back only what it added', () => {
+    const undo = store().addFile('/', { key: 'new.txt', size: 1 });
+    expect(keysAt('/')).toContain('new.txt');
+
+    undo();
+
+    expect(keysAt('/')).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('leaves a concurrent delete in place when an upload is rolled back', () => {
+    // The interleaving that a snapshot-restoring undo gets wrong: ten files
+    // uploading, two existing files deleted while they are in flight, then one
+    // upload fails. Putting back the array as it was before the upload would
+    // resurrect both deleted files.
+    const undoUpload = store().addFile('/', { key: 'new.txt', size: 1 });
+    store().removeFiles(['a.txt', 'b.txt']);
+
+    undoUpload();
+
+    expect(keysAt('/')).toEqual([]);
+  });
+
+  it('puts back only the rows a delete removed', () => {
+    const undoDelete = store().removeFiles(['a.txt']);
+    store().addFile('/', { key: 'new.txt', size: 1 });
+
+    undoDelete();
+
+    expect(keysAt('/')).toEqual(['a.txt', 'b.txt', 'new.txt']);
+  });
+
+  it('does not duplicate a row when an undo runs twice', () => {
+    const undo = store().removeFiles(['a.txt']);
+
+    undo();
+    undo();
+
+    expect(keysAt('/')).toEqual(['a.txt', 'b.txt']);
+  });
+});
+
+describe('renaming', () => {
+  it('moves a file to its new place in the order', () => {
+    useDriveStore.setState({
+      cache: {
+        '/': {
+          files: [file('a.txt'), file('m.txt'), file('z.txt')],
+          folders: [],
+          isTruncated: false,
+        },
+      },
+    });
+
+    store().renameFile('a.txt', 'q.txt');
+
+    expect(keysAt('/')).toEqual(['m.txt', 'q.txt', 'z.txt']);
+  });
+
+  it('carries the size and timestamp across', () => {
+    const original = file('a.txt', 30);
+    useDriveStore.setState({
+      cache: { '/': { files: [original], folders: [], isTruncated: false } },
+    });
+
+    store().renameFile('a.txt', 'renamed.md');
+
+    const [renamed] = store().cache['/']?.files ?? [];
+    expect(renamed?.name).toBe('renamed.md');
+    expect(renamed?.extension).toBe('md');
+    expect(renamed?.lastModified).toEqual(original.lastModified);
+  });
+
+  it('restores the original name on undo', () => {
+    useDriveStore.setState({
+      cache: { '/': { files: [file('a.txt')], folders: [], isTruncated: false } },
+    });
+
+    const undo = store().renameFile('a.txt', 'b.txt');
+    undo();
+
+    expect(keysAt('/')).toEqual(['a.txt']);
+  });
+
+  it('forgets what was cached under a renamed folder', () => {
+    useDriveStore.setState({
+      cache: {
+        '/': { files: [], folders: [folder('docs/')], isTruncated: false },
+        'docs/': { files: [file('docs/inner.txt')], folders: [], isTruncated: false },
+      },
+    });
+
+    store().renameFolder('docs/', 'papers');
+
+    expect(foldersAt('/')).toEqual(['papers/']);
+    // Those objects live under a different prefix now, so the listing that
+    // described them cannot be served again.
+    expect(store().cache['docs/']).toBeUndefined();
+  });
+});
+
+describe('creating a folder', () => {
+  it('places the row in order and takes it back on undo', () => {
+    useDriveStore.setState({
+      cache: {
+        '/': { files: [], folders: [folder('a/'), folder('z/')], isTruncated: false },
+      },
+    });
+
+    const undo = store().addFolder('/', 'm');
+    expect(foldersAt('/')).toEqual(['a/', 'm/', 'z/']);
+
+    undo();
+    expect(foldersAt('/')).toEqual(['a/', 'z/']);
+  });
+
+  it('nests under the prefix it was created in', () => {
+    useDriveStore.setState({
+      cache: { 'docs/': { files: [], folders: [], isTruncated: false } },
+    });
+
+    store().addFolder('docs/', 'drafts');
+
+    expect(foldersAt('docs/')).toEqual(['docs/drafts/']);
+  });
+});
+
+describe('invalidating a prefix', () => {
+  it('drops one the user is not looking at', () => {
+    useDriveStore.setState({
+      currentPrefix: '/',
+      cache: {
+        '/': { files: [file('a.txt')], folders: [], isTruncated: false },
+        'docs/': { files: [file('docs/b.txt')], folders: [], isTruncated: false },
+      },
+      directory: { 'docs/': { status: 'ready' } },
+    });
+
+    store().invalidatePrefix('docs/');
+
+    expect(store().cache['docs/']).toBeUndefined();
+    expect(store().directory['docs/']).toBeUndefined();
+    // The folder on screen is untouched.
+    expect(keysAt('/')).toEqual(['a.txt']);
+  });
+
+  it('re-reads the one on screen instead of dropping it', () => {
+    const fetchDirectoryStructure = vi.fn(() => new Promise(() => {}));
+    useDriveStore.setState({
+      currentPrefix: '/',
+      cache: { '/': { files: [file('a.txt')], folders: [], isTruncated: false } },
+      directory: { '/': { status: 'ready' } },
+    });
+    store().setApiS3({ fetchDirectoryStructure, getPrefix: () => '' } as never);
+
+    store().invalidatePrefix('/');
+
+    // Dropping it would leave the view with nothing to render and send it back
+    // to its skeleton, which is the blanking this whole change exists to avoid.
+    expect(keysAt('/')).toEqual(['a.txt']);
+    expect(fetchDirectoryStructure).toHaveBeenCalled();
+  });
+});
+
+describe('statuses left behind by a retired request', () => {
+  it('frees a "Show more" that was mid-flight', () => {
+    useDriveStore.setState({
+      cache: { '/': { files: [file('a.txt')], folders: [], isTruncated: true } },
+      directory: { '/': { status: 'loading' } },
+      loadMoreStatus: { '/': 'loading' },
+    });
+
+    store().removeFiles(['a.txt']);
+
+    // The retired request never writes the 'ready' it would have written, so
+    // without this repair the button refuses to run again for good.
+    expect(store().loadMoreStatus['/']).toBeUndefined();
+    expect(store().directory['/']).toEqual({ status: 'ready' });
+  });
+});
+
+describe('a silent re-read', () => {
+  it('leaves rows on screen when it fails', async () => {
+    const fetchDirectoryStructure = vi.fn().mockRejectedValue(new Error('network'));
+    useDriveStore.setState({
+      currentPrefix: '/',
+      rootPrefix: '/',
+      cache: { '/': { files: [file('a.txt')], folders: [], isTruncated: false } },
+      directory: { '/': { status: 'ready' } },
+    });
+    store().setApiS3({ fetchDirectoryStructure, getPrefix: () => '' } as never);
+
+    await store().fetchData({ silent: true });
+
+    // toAsyncState reads 'error' before it reads the data, so writing one here
+    // would replace a listing the user is reading with a full-page failure
+    // notice - over rows that are still perfectly good.
+    expect(store().directory['/']).toEqual({ status: 'ready' });
+    expect(keysAt('/')).toEqual(['a.txt']);
+  });
+
+  it('still reports a failure when there is nothing to show', async () => {
+    const fetchDirectoryStructure = vi.fn().mockRejectedValue(new Error('network'));
+    useDriveStore.setState({ currentPrefix: '/', rootPrefix: '/', cache: {}, directory: {} });
+    store().setApiS3({ fetchDirectoryStructure, getPrefix: () => '' } as never);
+
+    await store().fetchData({ silent: true });
+
+    expect(store().directory['/']?.status).toBe('error');
+  });
+});
+
+describe('an undo takes back only what its own call did', () => {
+  it('leaves a file that was already listed alone', () => {
+    useDriveStore.setState({
+      cache: { '/': { files: [file('a.txt')], folders: [], isTruncated: false } },
+    });
+
+    // An upload that replaced an existing object finds the row already there,
+    // so this call added nothing - and an undo that removed it would take out
+    // a row this call is not responsible for.
+    const undo = store().addFile('/', { key: 'a.txt', size: 5 });
+    undo();
+
+    expect(keysAt('/')).toEqual(['a.txt']);
+  });
+
+  it('leaves a folder that was already listed alone', () => {
+    useDriveStore.setState({
+      cache: { '/': { files: [], folders: [folder('docs/')], isTruncated: false } },
+    });
+
+    // The "replace" answer to the create-folder duplicate prompt.
+    const undo = store().addFolder('/', 'docs');
+    undo();
+
+    expect(foldersAt('/')).toEqual(['docs/']);
+  });
+});
+
+describe('an undo restores what a truncated listing had', () => {
+  it('puts back a row that was the last one loaded', () => {
+    useDriveStore.setState({
+      cache: {
+        'x/': {
+          files: [file('x/a.txt'), file('x/z.txt')],
+          folders: [],
+          isTruncated: true,
+          nextToken: 'token',
+        },
+      },
+    });
+
+    const undo = store().removeFiles(['x/z.txt']);
+    expect(keysAt('x/')).toEqual(['x/a.txt']);
+
+    undo();
+
+    // Removing z left a as the last key, so the truncation guard would have
+    // refused to put z back. That guard is about objects the listing has never
+    // held, not ones it held a moment ago - and refusing here is a rollback
+    // quietly losing a file that was never deleted.
+    expect(keysAt('x/')).toEqual(['x/a.txt', 'x/z.txt']);
+  });
+
+  it('puts back a renamed row that sorted last', () => {
+    useDriveStore.setState({
+      cache: {
+        'x/': {
+          files: [file('x/a.txt'), file('x/z.txt')],
+          folders: [],
+          isTruncated: true,
+          nextToken: 'token',
+        },
+      },
+    });
+
+    const undo = store().renameFile('x/z.txt', 'x/b.txt');
+    expect(keysAt('x/')).toEqual(['x/a.txt', 'x/b.txt']);
+
+    undo();
+
+    expect(keysAt('x/')).toEqual(['x/a.txt', 'x/z.txt']);
+  });
+});
+
+describe('renaming onto a name that is already taken', () => {
+  beforeEach(() => {
+    useDriveStore.setState({
+      cache: {
+        '/': { files: [file('a.txt'), file('b.txt')], folders: [], isTruncated: false },
+      },
+    });
+  });
+
+  it('leaves the file that was already there alone when undone', () => {
+    // The "replace" answer to the rename duplicate prompt: b.txt is listed
+    // already, so this call takes a.txt out and adds nothing.
+    const undo = store().renameFile('a.txt', 'b.txt');
+
+    undo();
+
+    // An undo that removed b.txt would delete a row this call never added, and
+    // b.txt is still a perfectly real file.
+    expect(keysAt('/')).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('still puts the renamed row back when the name was free', () => {
+    const undo = store().renameFile('a.txt', 'c.txt');
+    expect(keysAt('/')).toEqual(['b.txt', 'c.txt']);
+
+    undo();
+
+    expect(keysAt('/')).toEqual(['a.txt', 'b.txt']);
+  });
+});

--- a/frontend/src/context/data-context.tsx
+++ b/frontend/src/context/data-context.tsx
@@ -92,17 +92,6 @@ type Store = {
   renameFolder: (prefix: string, newName: string) => Revert;
 
   /**
-   * Marks a prefix stale without disturbing what is on screen.
-   *
-   * For the folder an operation landed in when the user is standing somewhere
-   * else: dropping its cache costs nothing, and it re-lists when they walk into
-   * it. The prefix being viewed is the one case that cannot be dropped - with
-   * no cache entry the view has nothing to render and falls back to its
-   * skeleton - so that one is re-read in place instead.
-   */
-  invalidatePrefix: (prefix: string) => void;
-
-  /**
    * `silent` re-reads a prefix without announcing it: no 'loading' on the way
    * in, and no 'error' on the way out over rows that are still on screen. For
    * refreshing something the user is already looking at.
@@ -479,6 +468,13 @@ function withFile(data: PrefixData, file: FileItem, restoring = false): PrefixDa
  * the last loaded key backwards, so renaming the last row of a truncated folder
  * looks to it like an object from an unfetched page and it refuses to place it.
  * A rename would then read as a deletion.
+ *
+ * The cost of bypassing it: in a truncated folder, a name that really does sort
+ * into an unfetched page is shown here anyway, and when that page arrives
+ * `appendUnique` finds the key already present and keeps this row instead. The
+ * row carries the object's real size and timestamp, so what is left is a sort
+ * position that is wrong until the next full read - which is a far smaller
+ * problem than the file appearing to have been deleted.
  */
 function replacingFile(data: PrefixData, fromKey: string, to: FileItem): PrefixData {
   return withFile(withoutKeys(data, new Set([fromKey])), to, true);
@@ -1092,41 +1088,6 @@ export const useDriveStore = create<Store>((set, get) => ({
         );
       }
     };
-  },
-
-  invalidatePrefix: (prefix) => {
-    const key = toCacheKey(prefix);
-    const { currentPrefix } = get();
-
-    // The prefix on screen cannot simply be dropped: with no cache entry the
-    // view has nothing to render and falls back to its skeleton, which is the
-    // blanking this whole change exists to avoid. Re-read it in place instead,
-    // so the rows stay up until the new ones arrive.
-    if (currentPrefix !== null && key === toCacheKey(currentPrefix)) {
-      void get().fetchData({ silent: true });
-      void get().fetchRecentItems({ silent: true, itemsPerType: 10 });
-      return;
-    }
-
-    discardOpenRequests(key);
-
-    set((state) => {
-      const cache = { ...state.cache };
-      const recentCache = { ...state.recentCache };
-      const directory = { ...state.directory };
-      const recent = { ...state.recent };
-      const loadMoreStatus = { ...state.loadMoreStatus };
-
-      delete cache[key];
-      delete recentCache[key];
-      delete directory[key];
-      delete recent[key];
-      delete loadMoreStatus[key];
-
-      return { cache, recentCache, directory, recent, loadMoreStatus };
-    });
-
-    useSearchStore.getState().invalidatePrefix(key);
   },
 
   fetchData: async (opts = { sync: false }) => {

--- a/frontend/src/context/data-context.tsx
+++ b/frontend/src/context/data-context.tsx
@@ -73,12 +73,50 @@ type Store = {
   clearAllData: () => void;
   removeDeletedFolder: (prefix: string) => void;
 
-  fetchData: (opts?: { sync?: boolean }) => Promise<void>;
-  fetchRecentItems: (opts?: { sync?: boolean; itemsPerType?: number }) => Promise<void>;
+  /**
+   * Localized edits, for when an operation has already told us what changed.
+   *
+   * Each one rewrites the affected listing in place and returns the inverse of
+   * what it did, so a caller whose request then fails can put things back.
+   *
+   * The revert is an inverse operation and not a restored snapshot on purpose.
+   * Restoring the array a row sat in would also restore every other row a
+   * concurrent operation had removed from it meanwhile - delete two files while
+   * an upload is in flight, let the upload fail, and both deleted files come
+   * back. Applying the inverse touches only what this call touched.
+   */
+  removeFiles: (keys: readonly string[]) => Revert;
+  addFile: (prefix: string, file: OptimisticFile) => Revert;
+  addFolder: (prefix: string, name: string) => Revert;
+  renameFile: (oldKey: string, newKey: string) => Revert;
+  renameFolder: (prefix: string, newName: string) => Revert;
+
+  /**
+   * Marks a prefix stale without disturbing what is on screen.
+   *
+   * For the folder an operation landed in when the user is standing somewhere
+   * else: dropping its cache costs nothing, and it re-lists when they walk into
+   * it. The prefix being viewed is the one case that cannot be dropped - with
+   * no cache entry the view has nothing to render and falls back to its
+   * skeleton - so that one is re-read in place instead.
+   */
+  invalidatePrefix: (prefix: string) => void;
+
+  /**
+   * `silent` re-reads a prefix without announcing it: no 'loading' on the way
+   * in, and no 'error' on the way out over rows that are still on screen. For
+   * refreshing something the user is already looking at.
+   */
+  fetchData: (opts?: { sync?: boolean; silent?: boolean }) => Promise<void>;
+  fetchRecentItems: (opts?: {
+    sync?: boolean;
+    silent?: boolean;
+    itemsPerType?: number;
+  }) => Promise<void>;
   loadMoreRecentFiles: () => Promise<void>;
   loadMoreRecentFolders: () => Promise<void>;
   loadMoreData: () => Promise<void>;
-  refreshCurrentData: () => Promise<void>;
+  refreshCurrentData: (opts?: { silent?: boolean }) => Promise<void>;
   refreshAll: () => Promise<void>;
 };
 
@@ -294,6 +332,406 @@ function recentWithoutPrefix(data: RecentDataWithCache, prefix: string): RecentD
   };
 }
 
+/** Undoes one optimistic change by applying its inverse. */
+export type Revert = () => void;
+
+/** Nothing changed, so there is nothing to undo. */
+const NO_REVERT: Revert = () => {};
+
+/** The zustand setter, narrowed to the functional form these helpers require. */
+type SetState = (updater: (state: Store) => Partial<Store>) => void;
+
+type GetState = () => Store;
+
+/** What an optimistic insert knows about a file before S3 has confirmed it. */
+export type OptimisticFile = {
+  key: string;
+  size?: number;
+  lastModified?: Date;
+};
+
+function fileKey(file: FileItem): string {
+  return file.Key ?? file.id;
+}
+
+function folderKey(folder: Folder): string {
+  return folder.Prefix ?? folder.id;
+}
+
+function fileTime(file: FileItem): number {
+  return file.lastModified ? file.lastModified.getTime() : 0;
+}
+
+function ensureTrailingSlash(prefix: string): string {
+  return prefix.endsWith('/') ? prefix : `${prefix}/`;
+}
+
+/**
+ * A listing with the named objects taken out, matched by whole key.
+ *
+ * Deliberately not `withoutPrefix`. That matches with startsWith, which is what
+ * a folder needs and what a file must never get: removing "report.pdf" by
+ * prefix takes "report.pdf.bak" with it.
+ */
+function withoutKeys(data: PrefixData, keys: ReadonlySet<string>): PrefixData {
+  const files = data.files.filter((file) => !keys.has(fileKey(file)));
+
+  // Returning the same object when nothing matched is what stops a change
+  // aimed at one folder from re-rendering every other one.
+  if (files.length === data.files.length) return data;
+
+  // nextToken and isTruncated describe where the server's cursor stopped, not
+  // what we are holding, so filtering locally leaves both alone.
+  return { ...data, files };
+}
+
+function recentWithoutKeys(
+  data: RecentDataWithCache,
+  keys: ReadonlySet<string>
+): RecentDataWithCache {
+  const files = data.files.filter((file) => !keys.has(fileKey(file)));
+  const allFiles = data._allFiles?.filter((file) => !keys.has(fileKey(file)));
+
+  if (files.length === data.files.length && allFiles?.length === data._allFiles?.length) {
+    return data;
+  }
+
+  return {
+    ...data,
+    files,
+    _allFiles: allFiles,
+    // The rule recentWithoutPrefix follows: the offset marks how far the
+    // visible window reaches, so it moves with the window. Left behind, "View
+    // more" skips an item for every one removed ahead of it.
+    fileOffset: files.length,
+    hasMoreFiles: allFiles ? allFiles.length > files.length : data.hasMoreFiles,
+  };
+}
+
+/** Index for `key` in a list held in S3's lexicographic order. */
+function sortedIndex<T>(items: readonly T[], key: string, keyOf: (item: T) => string): number {
+  let low = 0;
+  let high = items.length;
+
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    if (keyOf(items[mid]!) < key) low = mid + 1;
+    else high = mid;
+  }
+
+  return low;
+}
+
+/**
+ * Where a new object belongs in a listing, or null when it belongs to a page
+ * nobody has fetched.
+ *
+ * A truncated listing holds only the pages read so far. An object sorting past
+ * the last of them is not missing from the view - it is in a page the user has
+ * not asked for yet. Putting it in anyway strands it there for good: when that
+ * page does arrive, `appendUnique` finds the key already present and drops the
+ * real object, leaving the guess standing in its place.
+ */
+function insertionIndex<T>(
+  items: readonly T[],
+  key: string,
+  keyOf: (item: T) => string,
+  isTruncated: boolean | undefined
+): number | null {
+  const last = items[items.length - 1];
+  if (isTruncated && last && keyOf(last) < key) return null;
+
+  return sortedIndex(items, key, keyOf);
+}
+
+function insertAt<T>(items: readonly T[], item: T, index: number): T[] {
+  return [...items.slice(0, index), item, ...items.slice(index)];
+}
+
+/**
+ * @param restoring true when putting back a row this session took out.
+ *
+ * The truncation guard is about objects we have never had in the listing. A row
+ * that was in it a moment ago belongs in it still - and once it has been
+ * removed, the key after it becomes the last one, so the guard would refuse to
+ * put back the very row it was asked to restore. That is a rollback silently
+ * losing the last file of a folder with more than a thousand objects in it.
+ */
+function withFile(data: PrefixData, file: FileItem, restoring = false): PrefixData {
+  const key = fileKey(file);
+
+  // Already listed: an upload that overwrote an existing object, or a revert
+  // running twice. Either way the row is there, and adding it would double it.
+  if (data.files.some((existing) => fileKey(existing) === key)) return data;
+
+  const at = insertionIndex(data.files, key, fileKey, restoring ? false : data.isTruncated);
+  if (at === null) return data;
+
+  return { ...data, files: insertAt(data.files, file, at) };
+}
+
+/**
+ * One row swapped for another.
+ *
+ * The truncation guard is deliberately bypassed. This is not a new object
+ * arriving from S3 - it is one the listing was already showing, under another
+ * name - and the guard cannot tell the difference: taking the old row out moves
+ * the last loaded key backwards, so renaming the last row of a truncated folder
+ * looks to it like an object from an unfetched page and it refuses to place it.
+ * A rename would then read as a deletion.
+ */
+function replacingFile(data: PrefixData, fromKey: string, to: FileItem): PrefixData {
+  return withFile(withoutKeys(data, new Set([fromKey])), to, true);
+}
+
+/** `restoring` as in withFile, for the same reason. */
+function withFolder(data: PrefixData, folder: Folder, restoring = false): PrefixData {
+  const key = folderKey(folder);
+  if (data.folders.some((existing) => folderKey(existing) === key)) return data;
+
+  const at = insertionIndex(data.folders, key, folderKey, restoring ? false : data.isTruncated);
+  if (at === null) return data;
+
+  return { ...data, folders: insertAt(data.folders, folder, at) };
+}
+
+/**
+ * A listing with one folder row taken out, matched by whole prefix.
+ *
+ * The row only - nothing cached *under* the folder. Dropping that is
+ * removeDeletedFolder's job, and it is not what an undo wants.
+ */
+function withoutFolder(data: PrefixData, prefix: string): PrefixData {
+  const folders = data.folders.filter((folder) => folderKey(folder) !== prefix);
+  if (folders.length === data.folders.length) return data;
+
+  return { ...data, folders };
+}
+
+/** Position for `file` in a list held newest-first. */
+function newestFirstIndex(files: readonly FileItem[], file: FileItem): number {
+  const time = fileTime(file);
+  const at = files.findIndex((existing) => fileTime(existing) < time);
+
+  return at === -1 ? files.length : at;
+}
+
+/**
+ * The recent list with one file added, to both the window on screen and the
+ * pagination source behind it.
+ *
+ * `files` is a window onto `_allFiles`; adding to one and not the other makes
+ * "View more" hand back a list that disagrees with what is showing. A file
+ * older than everything on screen goes only into the source, where "View more"
+ * reaches it in its proper place.
+ */
+function recentWithFile(data: RecentDataWithCache, file: FileItem): RecentDataWithCache {
+  const key = fileKey(file);
+  if (data.files.some((existing) => fileKey(existing) === key)) return data;
+  if (data._allFiles?.some((existing) => fileKey(existing) === key)) return data;
+
+  const allFiles = data._allFiles
+    ? insertAt(data._allFiles, file, newestFirstIndex(data._allFiles, file))
+    : undefined;
+
+  // With no pagination source there is no "behind the window" to fall into, so
+  // everything shows.
+  const oldestVisible = data.files[data.files.length - 1];
+  const belongsOnScreen =
+    !allFiles || oldestVisible === undefined || fileTime(file) >= fileTime(oldestVisible);
+
+  const files = belongsOnScreen
+    ? insertAt(data.files, file, newestFirstIndex(data.files, file))
+    : data.files;
+
+  return {
+    ...data,
+    files,
+    _allFiles: allFiles,
+    fileOffset: files.length,
+    hasMoreFiles: allFiles ? allFiles.length > files.length : data.hasMoreFiles,
+  };
+}
+
+/**
+ * The same for a folder, inserted in lexicographic order.
+ *
+ * Recent folders arrive from S3 in that order and stay in it: a CommonPrefix
+ * carries no LastModified, so the sort in fetchRecentItems has nothing to move
+ * them by and leaves them as they came.
+ */
+function recentWithFolder(data: RecentDataWithCache, folder: Folder): RecentDataWithCache {
+  const key = folderKey(folder);
+  if (data.folders.some((existing) => folderKey(existing) === key)) return data;
+  if (data._allFolders?.some((existing) => folderKey(existing) === key)) return data;
+
+  const allFolders = data._allFolders
+    ? insertAt(data._allFolders, folder, sortedIndex(data._allFolders, key, folderKey))
+    : undefined;
+
+  const at = sortedIndex(data.folders, key, folderKey);
+  const belongsOnScreen = !allFolders || at < data.folders.length || !data.hasMoreFolders;
+
+  const folders = belongsOnScreen ? insertAt(data.folders, folder, at) : data.folders;
+
+  return {
+    ...data,
+    folders,
+    _allFolders: allFolders,
+    folderOffset: folders.length,
+    hasMoreFolders: allFolders ? allFolders.length > folders.length : data.hasMoreFolders,
+  };
+}
+
+function recentWithoutFolder(data: RecentDataWithCache, prefix: string): RecentDataWithCache {
+  const folders = data.folders.filter((folder) => folderKey(folder) !== prefix);
+  const allFolders = data._allFolders?.filter((folder) => folderKey(folder) !== prefix);
+
+  if (folders.length === data.folders.length && allFolders?.length === data._allFolders?.length) {
+    return data;
+  }
+
+  return {
+    ...data,
+    folders,
+    _allFolders: allFolders,
+    folderOffset: folders.length,
+    hasMoreFolders: allFolders ? allFolders.length > folders.length : data.hasMoreFolders,
+  };
+}
+
+/** The five prefix-keyed maps, as the copies a functional update is building. */
+type StatusMaps = {
+  cache: Record<string, PrefixData>;
+  recentCache: Record<string, RecentDataWithCache>;
+  directory: Record<string, RequestState>;
+  recent: Record<string, RequestState>;
+  loadMoreStatus: Record<string, Status>;
+};
+
+/**
+ * Puts a key's statuses back to something a view can act on, after
+ * `discardOpenRequests` has retired whatever was running for it.
+ *
+ * A retired request returns without writing, and the status it set on the way
+ * in is part of what it never writes. Left alone that is permanent: a listing
+ * behind a skeleton that never resolves, and a "Show more" that refuses to run
+ * again because it still reads as loading. What is cached is what there is to
+ * show, so say so.
+ *
+ * Mutates the maps it is handed.
+ */
+function repairStrandedStatus(key: string, maps: StatusMaps): void {
+  if (maps.directory[key]?.status === 'loading') {
+    if (maps.cache[key]) maps.directory[key] = { status: 'ready' };
+    else delete maps.directory[key];
+  }
+
+  if (maps.recent[key]?.status === 'loading') {
+    if (maps.recentCache[key]) maps.recent[key] = { status: 'ready' };
+    else delete maps.recent[key];
+  }
+
+  if (maps.loadMoreStatus[key] === 'loading') delete maps.loadMoreStatus[key];
+}
+
+/**
+ * Applies one change to a prefix's two listings, as a single write.
+ *
+ * Both listings are read from `state` inside the update rather than from a
+ * snapshot taken beforehand, so two operations landing in the same tick compose
+ * instead of overwriting one another - the lesson loadMoreData records about
+ * appending to a stale copy, applied to every mutation rather than only that
+ * one.
+ *
+ * No status is written. The rows are already right, and writing 'loading' is
+ * what puts a folder behind a skeleton when it has nothing cached to show.
+ */
+function applyToPrefix(
+  set: SetState,
+  get: GetState,
+  key: string,
+  changeDirectory: (data: PrefixData) => PrefixData,
+  changeRecent: (data: RecentDataWithCache) => RecentDataWithCache
+): void {
+  const current = get();
+
+  // Every transform here returns its argument untouched when it matched
+  // nothing, which is the whole point of that convention: a delete in one
+  // folder must not hand the subscribers of every other folder a new store
+  // object. Writing unconditionally would do exactly that, since the write
+  // rebuilds all five maps whether or not anything in them moved.
+  //
+  // Reading state to decide whether to write is safe precisely here: this
+  // function is synchronous start to finish, so nothing can land between the
+  // read and the write the way it can across an await.
+  const directoryData = current.cache[key];
+  const recentData = current.recentCache[key];
+
+  const changesRows =
+    (directoryData !== undefined && changeDirectory(directoryData) !== directoryData) ||
+    (recentData !== undefined && changeRecent(recentData) !== recentData);
+
+  const strandedStatus =
+    current.directory[key]?.status === 'loading' ||
+    current.recent[key]?.status === 'loading' ||
+    current.loadMoreStatus[key] === 'loading';
+
+  // An open request is a reason to write even when no row moved, and it is not
+  // the same question as whether anything is cached. Delete a file from a
+  // folder being listed for the very first time and there is nothing cached to
+  // change - but that listing is still on its way, still describing the file as
+  // present, and retiring it is the only thing standing between the user and
+  // watching the row come back.
+  const hasOpenRequest =
+    inFlightFetches.has(key) || inFlightRecentFetches.has(key) || inFlightLoadMores.has(key);
+
+  if (!changesRows && !strandedStatus && !hasOpenRequest) return;
+
+  // A read issued before this change is about to describe the prefix as it was,
+  // and it would land on top of what we are writing. Retiring it here turns it
+  // into a no-op when it arrives.
+  discardOpenRequests(key);
+
+  set((state) => {
+    const cache = { ...state.cache };
+    const recentCache = { ...state.recentCache };
+    const directory = { ...state.directory };
+    const recent = { ...state.recent };
+    const loadMoreStatus = { ...state.loadMoreStatus };
+
+    const directoryData = cache[key];
+    const recentData = recentCache[key];
+
+    if (directoryData) cache[key] = changeDirectory(directoryData);
+    if (recentData) recentCache[key] = changeRecent(recentData);
+
+    repairStrandedStatus(key, { cache, recentCache, directory, recent, loadMoreStatus });
+
+    return { cache, recentCache, directory, recent, loadMoreStatus };
+  });
+
+  // Cached search results for this prefix now list something that is gone, or
+  // miss something that is there. invalidatePrefix drops only those entries;
+  // clearCache would blank a search page the user is reading.
+  useSearchStore.getState().invalidatePrefix(key);
+}
+
+/** Groups object keys by the cache key of the listing that holds them. */
+function groupKeysByPrefix(keys: readonly string[]): Map<string, Set<string>> {
+  const groups = new Map<string, Set<string>>();
+
+  for (const key of keys) {
+    const cacheKey = toCacheKey(getParentPrefix(key));
+    const group = groups.get(cacheKey);
+
+    if (group) group.add(key);
+    else groups.set(cacheKey, new Set([key]));
+  }
+
+  return groups;
+}
+
 export const useDriveStore = create<Store>((set, get) => ({
   apiS3: null,
   cache: {},
@@ -424,18 +862,8 @@ export const useDriveStore = create<Store>((set, get) => ({
 
       // A request retired above never writes, which includes the status it set
       // on its way out. Anything the parent had in flight would sit on
-      // 'loading' for good: a listing stuck behind its skeleton, and a "Show
-      // more" that refuses to run again because it thinks one is still going.
-      // What is already cached is what there is to show, so say so.
-      if (directory[parentKey]?.status === 'loading') {
-        if (cache[parentKey]) directory[parentKey] = { status: 'ready' };
-        else delete directory[parentKey];
-      }
-      if (recent[parentKey]?.status === 'loading') {
-        if (recentCache[parentKey]) recent[parentKey] = { status: 'ready' };
-        else delete recent[parentKey];
-      }
-      if (loadMoreStatus[parentKey] === 'loading') delete loadMoreStatus[parentKey];
+      // 'loading' for good.
+      repairStrandedStatus(parentKey, { cache, recentCache, directory, recent, loadMoreStatus });
 
       return { cache, recentCache, directory, recent, loadMoreStatus };
     });
@@ -445,6 +873,260 @@ export const useDriveStore = create<Store>((set, get) => ({
     // started from a search result would blank the whole page the user is
     // reading. A cached query that still lists the folder goes stale on its own
     // TTL, which is the smaller problem of the two.
+  },
+
+  removeFiles: (keys) => {
+    if (keys.length === 0) return NO_REVERT;
+
+    const groups = groupKeysByPrefix(keys);
+
+    // The rows themselves, read before the removal, so the revert puts back
+    // exactly what this call took out and nothing else.
+    const removed: { prefix: string; file: FileItem }[] = [];
+    const { cache } = get();
+
+    for (const [prefix, group] of groups) {
+      for (const file of cache[prefix]?.files ?? []) {
+        if (group.has(fileKey(file))) removed.push({ prefix, file });
+      }
+    }
+
+    for (const [prefix, group] of groups) {
+      applyToPrefix(
+        set,
+        get,
+        prefix,
+        (data) => withoutKeys(data, group),
+        (data) => recentWithoutKeys(data, group)
+      );
+    }
+
+    // Nothing was showing, so nothing needs putting back. The listing will
+    // arrive already correct whenever it is read.
+    if (removed.length === 0) return NO_REVERT;
+
+    return () => {
+      for (const { prefix, file } of removed) {
+        applyToPrefix(
+          set,
+          get,
+          prefix,
+          (data) => withFile(data, file, true),
+          (data) => recentWithFile(data, file)
+        );
+      }
+    };
+  },
+
+  addFile: (prefix, file) => {
+    const key = toCacheKey(prefix);
+
+    // The same shape a listing would have given us, built from what the upload
+    // already knows. An absent timestamp means now: this object was written a
+    // moment ago, which is exactly where the recent list should show it.
+    const item = enrichFile({
+      Key: file.key,
+      Size: file.size,
+      LastModified: file.lastModified ?? new Date(),
+    });
+
+    // Was the row already there before this call? An upload that replaced an
+    // existing object finds it listed and withFile leaves it alone - so this
+    // call added nothing, and handing back an undo that removes it would take
+    // out a row this call is not responsible for.
+    const alreadyListed = (get().cache[key]?.files ?? []).some(
+      (existing) => fileKey(existing) === file.key
+    );
+
+    applyToPrefix(
+      set,
+      get,
+      key,
+      (data) => withFile(data, item),
+      (data) => recentWithFile(data, item)
+    );
+
+    if (alreadyListed) return NO_REVERT;
+
+    return () => {
+      const gone = new Set([file.key]);
+
+      applyToPrefix(
+        set,
+        get,
+        key,
+        (data) => withoutKeys(data, gone),
+        (data) => recentWithoutKeys(data, gone)
+      );
+    };
+  },
+
+  addFolder: (prefix, name) => {
+    const parentKey = toCacheKey(prefix);
+    const folderPrefix = `${prefix === '/' ? '' : prefix}${name}/`;
+    const folder = enrichFolder({ Prefix: folderPrefix });
+
+    // As in addFile: creating a folder over one that is already listed - the
+    // "replace" answer to the duplicate prompt - adds nothing, so there is
+    // nothing for an undo to take away. Removing the row anyway would delete a
+    // folder from the listing that is still perfectly real.
+    const alreadyListed = (get().cache[parentKey]?.folders ?? []).some(
+      (existing) => folderKey(existing) === folderPrefix
+    );
+
+    applyToPrefix(
+      set,
+      get,
+      parentKey,
+      (data) => withFolder(data, folder),
+      (data) => recentWithFolder(data, folder)
+    );
+
+    if (alreadyListed) return NO_REVERT;
+
+    return () => {
+      applyToPrefix(
+        set,
+        get,
+        parentKey,
+        (data) => withoutFolder(data, folderPrefix),
+        (data) => recentWithoutFolder(data, folderPrefix)
+      );
+    };
+  },
+
+  renameFile: (oldKey, newKey) => {
+    const prefix = toCacheKey(getParentPrefix(oldKey));
+    const existing = get().cache[prefix]?.files.find((file) => fileKey(file) === oldKey);
+
+    // Nothing cached to rename; the listing will arrive already correct.
+    if (!existing) return NO_REVERT;
+
+    // Size, timestamp and ETag survive a rename. The key is what changes, and
+    // the name, extension and id are read back off it by enrichFile.
+    //
+    // The two put back afterwards are the ones enrichFile infers from the raw
+    // S3 fields rather than from the row: a FileItem is only guaranteed to
+    // carry the enriched `size` and `lastModified`, so a row built anywhere but
+    // a listing comes back from enrichFile with no date at all - and a file
+    // with no date sorts to the bottom of the recent list instead of staying
+    // where the user just renamed it.
+    const renamed: FileItem = {
+      ...enrichFile({ ...existing, Key: newKey }),
+      size: existing.size,
+      lastModified: existing.lastModified,
+    };
+
+    // Is something already sitting at the new key? Answering "replace" to the
+    // duplicate prompt renames onto a row that is already listed, so withFile
+    // leaves it alone and this call adds nothing - it only takes the old row
+    // out. Undoing by removing the new key would then delete a file this call
+    // never touched and which is still perfectly real.
+    const targetOccupied = (get().cache[prefix]?.files ?? []).some(
+      (file) => fileKey(file) === newKey
+    );
+
+    // Out and back in rather than in place: the new name sorts somewhere else,
+    // and a row left at the old index is a listing out of order.
+    const swap = (from: FileItem, to: FileItem) => {
+      const fromKey = fileKey(from);
+      const gone = new Set([fromKey]);
+
+      applyToPrefix(
+        set,
+        get,
+        prefix,
+        (data) => replacingFile(data, fromKey, to),
+        (data) => recentWithFile(recentWithoutKeys(data, gone), to)
+      );
+    };
+
+    swap(existing, renamed);
+
+    if (targetOccupied) {
+      // Put back only the row this call removed. Whoever was at the new key
+      // was there first and stays.
+      return () => {
+        applyToPrefix(
+          set,
+          get,
+          prefix,
+          (data) => withFile(data, existing, true),
+          (data) => recentWithFile(data, existing)
+        );
+      };
+    }
+
+    return () => swap(renamed, existing);
+  },
+
+  renameFolder: (prefix, newName) => {
+    const normalized = ensureTrailingSlash(prefix);
+
+    // '/' is the root, which is not a folder anyone can rename.
+    if (normalized === '/' || normalized === '') return NO_REVERT;
+
+    const parent = getParentPrefix(normalized);
+    const parentKey = toCacheKey(parent);
+    const existing = get().cache[parentKey]?.folders.find(
+      (folder) => folderKey(folder) === normalized
+    );
+
+    // Every listing cached under the old prefix describes objects that have
+    // moved, so they go along with the row in the parent. What is dropped here
+    // is re-read on the next visit; the undo below only restores the row, which
+    // is the part anyone is looking at.
+    get().removeDeletedFolder(normalized);
+    const undoAdd = get().addFolder(parent, newName);
+
+    return () => {
+      undoAdd();
+
+      if (existing) {
+        applyToPrefix(
+          set,
+          get,
+          parentKey,
+          (data) => withFolder(data, existing, true),
+          (data) => recentWithFolder(data, existing)
+        );
+      }
+    };
+  },
+
+  invalidatePrefix: (prefix) => {
+    const key = toCacheKey(prefix);
+    const { currentPrefix } = get();
+
+    // The prefix on screen cannot simply be dropped: with no cache entry the
+    // view has nothing to render and falls back to its skeleton, which is the
+    // blanking this whole change exists to avoid. Re-read it in place instead,
+    // so the rows stay up until the new ones arrive.
+    if (currentPrefix !== null && key === toCacheKey(currentPrefix)) {
+      void get().fetchData({ silent: true });
+      void get().fetchRecentItems({ silent: true, itemsPerType: 10 });
+      return;
+    }
+
+    discardOpenRequests(key);
+
+    set((state) => {
+      const cache = { ...state.cache };
+      const recentCache = { ...state.recentCache };
+      const directory = { ...state.directory };
+      const recent = { ...state.recent };
+      const loadMoreStatus = { ...state.loadMoreStatus };
+
+      delete cache[key];
+      delete recentCache[key];
+      delete directory[key];
+      delete recent[key];
+      delete loadMoreStatus[key];
+
+      return { cache, recentCache, directory, recent, loadMoreStatus };
+    });
+
+    useSearchStore.getState().invalidatePrefix(key);
   },
 
   fetchData: async (opts = { sync: false }) => {
@@ -464,14 +1146,19 @@ export const useDriveStore = create<Store>((set, get) => ({
     // Avoid duplicate concurrent fetches unless forced by sync
     const currStatus = directory[keyPrefix]?.status;
 
-    if (currStatus === 'ready' && !opts.sync) return;
+    // A silent read is a forced one. Its whole purpose is to replace what is
+    // cached, so the checks that skip a fetch when data is present must let it
+    // through the same way a sync does.
+    const force = opts.sync === true || opts.silent === true;
+
+    if (currStatus === 'ready' && !force) return;
 
     const currentData = cache[keyPrefix];
 
     // Data already present and nobody asked for fresh; just reflect it.
     // Don't auto-refetch just because isTruncated is true - let the user decide
     // with the "Show More" button.
-    if (currentData && !opts.sync) {
+    if (currentData && !force) {
       if (currStatus !== 'ready') setDirectoryState(keyPrefix, 'ready');
       return;
     }
@@ -480,11 +1167,13 @@ export const useDriveStore = create<Store>((set, get) => ({
     // identical one. Navigating A -> B -> A did exactly that: A's first request
     // is still 'loading' rather than 'ready', so the status check above let it
     // through, and cache[A] was still empty, so the data check did too.
-    return runDeduped(inFlightFetches, keyPrefix, !opts.sync, async () => {
+    return runDeduped(inFlightFetches, keyPrefix, !force, async () => {
       const requestId = claimRequestId(latestRequestId, keyPrefix);
 
       try {
-        setDirectoryState(keyPrefix, 'loading');
+        // A silent read leaves the status alone. 'loading' only means anything
+        // with nothing to show, and this one runs over a listing already up.
+        if (!opts.silent) setDirectoryState(keyPrefix, 'loading');
 
         // Always read from the top. This branch only runs when there is no data
         // yet or a sync was forced, and either way the result replaces the cache
@@ -509,6 +1198,12 @@ export const useDriveStore = create<Store>((set, get) => ({
         // result, or a folder that loaded fine renders as failed.
         if (isSuperseded(latestRequestId, keyPrefix, requestId)) return;
 
+        // Neither may a silent read. toAsyncState checks 'error' before it
+        // checks for data, so writing it here would replace a listing the user
+        // is reading with a full-page failure notice - over rows that are still
+        // perfectly good. A background read that failed changes nothing.
+        if (opts.silent && get().cache[keyPrefix]) return;
+
         // One write, so there is no frame in which the row knows it failed
         // but not why.
         setDirectoryState(keyPrefix, 'error', classifyConnectionFailure(error));
@@ -516,7 +1211,7 @@ export const useDriveStore = create<Store>((set, get) => ({
     });
   },
 
-  refreshCurrentData: async () => {
+  refreshCurrentData: async (opts) => {
     const { fetchData, fetchRecentItems, currentPrefix, rootPrefix } = get();
 
     // Only refresh if we have valid prefixes set
@@ -526,8 +1221,8 @@ export const useDriveStore = create<Store>((set, get) => ({
 
       // Refresh both regular cache and recent cache in parallel
       await Promise.all([
-        fetchData({ sync: true }),
-        fetchRecentItems({ sync: true, itemsPerType: 10 }),
+        fetchData({ sync: true, silent: opts?.silent }),
+        fetchRecentItems({ sync: true, silent: opts?.silent, itemsPerType: 10 }),
       ]);
     }
   },
@@ -560,7 +1255,12 @@ export const useDriveStore = create<Store>((set, get) => ({
     const keyPrefix = formattedPrefix === '' ? '/' : formattedPrefix;
 
     const currStatus = recent[keyPrefix]?.status;
-    if (currStatus === 'ready' && !opts.sync) return;
+
+    // Same rule as fetchData: silent still means read, it just means read
+    // quietly.
+    const force = opts.sync === true || opts.silent === true;
+
+    if (currStatus === 'ready' && !force) return;
 
     // Ensure itemsPerType has a default value
     const itemsPerType = opts.itemsPerType ?? 10;
@@ -568,11 +1268,11 @@ export const useDriveStore = create<Store>((set, get) => ({
     // Same A -> B -> A race as fetchData: 'loading' is not 'ready', so
     // returning to a folder whose recent-items request is still open used to
     // fire a second identical one.
-    return runDeduped(inFlightRecentFetches, keyPrefix, !opts.sync, async () => {
+    return runDeduped(inFlightRecentFetches, keyPrefix, !force, async () => {
       const requestId = claimRequestId(latestRecentRequestId, keyPrefix);
 
       try {
-        setRecentState(keyPrefix, 'loading');
+        if (!opts.silent) setRecentState(keyPrefix, 'loading');
 
         // Fetch up to 1000 items from current directory
         const data = await apiS3.fetchDirectoryStructure(formattedPrefix, 1000);
@@ -611,7 +1311,12 @@ export const useDriveStore = create<Store>((set, get) => ({
 
         // Store all sorted data for pagination (keeping full sorted arrays in memory temporarily)
         const existingCache = recentCache[keyPrefix];
-        if (!existingCache || opts.sync) {
+
+        // `force`, not `opts.sync`: a silent read replaces the listing, so it
+        // has to replace the pagination source behind it too. Leaving the old
+        // _allFiles in place would let "View more" hand back rows this read
+        // just established are gone.
+        if (!existingCache || force) {
           // Store full sorted arrays for pagination access
           recentData._allFiles = sortedFiles;
           recentData._allFolders = sortedFolders;
@@ -621,6 +1326,10 @@ export const useDriveStore = create<Store>((set, get) => ({
         setRecentState(keyPrefix, 'ready');
       } catch (error) {
         if (isSuperseded(latestRecentRequestId, keyPrefix, requestId)) return;
+
+        // As in fetchData: a failed background read must not replace a good
+        // list with an error notice.
+        if (opts.silent && get().recentCache[keyPrefix]) return;
 
         setRecentState(keyPrefix, 'error', classifyConnectionFailure(error));
       }

--- a/frontend/src/context/rename-context.tsx
+++ b/frontend/src/context/rename-context.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react';
 import { FileItem } from '@/features/dashboard/types/file';
 import { Folder } from '@/features/dashboard/types/folder';
 import { createRenameService } from '@/features/dashboard/services/rename-service';
 import { useNotification } from '@/context/notification-context';
-import { useDriveStore } from '@/context/data-context';
+import { useDriveStore, type Revert } from '@/context/data-context';
 import { PreviewLoading } from '@/components/file-preview';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
 
@@ -49,15 +49,23 @@ const RenameContext = createContext<RenameContextType | undefined>(undefined);
 export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { apiS3, isLoading, isAuthenticated } = useAuthGuard();
 
-  if (isLoading) {
-    return <PreviewLoading message="Authenticating..." />;
-  }
-
-  if (!isAuthenticated || !apiS3) {
-    return null;
-  }
-
-  const renameService = createRenameService(apiS3);
+  /**
+   * Every hook below is declared unconditionally, and the two early returns
+   * this provider needs now sit at the bottom instead of here.
+   *
+   * They used to come first, which made the number of hooks depend on whether
+   * the session had loaded - the exact thing rules-of-hooks exists to prevent.
+   * Signing out flips `isAuthenticated` on an already-mounted provider, so the
+   * render after it would run one hook where the previous had run twenty:
+   * "Rendered fewer hooks than expected", and the dashboard goes down with it.
+   * Eighteen lint warnings were saying so.
+   *
+   * Memoised rather than rebuilt each render: as a bare call it was absent from
+   * every dependency array below, so those callbacks captured whichever
+   * instance the first render happened to make and would have kept talking to
+   * the previous bucket after a switch.
+   */
+  const renameService = useMemo(() => (apiS3 ? createRenameService(apiS3) : null), [apiS3]);
 
   const [activeRenames, setActiveRenames] = useState<Set<string>>(new Set());
   const [duplicateDialog, setDuplicateDialog] = useState<RenameDuplicateDialogState>({
@@ -78,19 +86,62 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   });
 
   const { success, error, warning } = useNotification();
-  const { refreshCurrentData } = useDriveStore();
+
+  // One selector per action rather than `useDriveStore()`, which subscribes
+  // this provider - and the whole tree under it - to every write the drive
+  // store makes. That was survivable while the only writes were refreshes;
+  // now that each operation writes rows of its own, it would be a re-render
+  // of everything per row.
+  const refreshCurrentData = useDriveStore((state) => state.refreshCurrentData);
+  const renameFileRow = useDriveStore((state) => state.renameFile);
+  const renameFolderRow = useDriveStore((state) => state.renameFolder);
 
   /**
    * Shared handling for a folder rename that succeeded but left old copies
-   * behind. This is a warning, not a failure - and it still refreshes, because
-   * the files really did move and the browser must reflect that.
+   * behind. This is a warning, not a failure - the files really did move, so
+   * the optimistic rename stands and only the leftovers need looking up.
    */
   const handlePartialCleanup = useCallback(
     (message: string) => {
       warning(message, 10000);
-      refreshCurrentData().catch(() => {});
+      // Silent: the renamed rows are on screen and correct. This is here for
+      // the copies that did not get cleaned up, not to redraw the page.
+      refreshCurrentData({ silent: true }).catch(() => {});
     },
     [warning, refreshCurrentData]
+  );
+
+  /**
+   * Renames the row before the request goes out, and hands back the undo.
+   *
+   * Optimistic on purpose. A rename is a copy followed by a delete, and a name
+   * that only changes once both have finished is a name that appears not to
+   * have changed at all for a second or two.
+   *
+   * Every failure path here runs the undo: the service calls `onError` before
+   * it rethrows, in both of its rename methods, so that is the one place the
+   * row needs putting back. A partial cleanup is deliberately not one of them -
+   * the files really are at the new name, and only the old copies are in doubt.
+   */
+  const applyRename = useCallback(
+    (item: FileItem | Folder, type: 'file' | 'folder', newName: string): Revert => {
+      if (type === 'folder') {
+        const prefix = (item as Folder).Prefix;
+        return prefix ? renameFolderRow(prefix, newName) : () => {};
+      }
+
+      const oldKey = (item as FileItem).Key;
+      if (!oldKey) return () => {};
+
+      // The key the service builds, built the same way: the last segment of
+      // the old key replaced and nothing else touched. Deriving it from
+      // currentPath instead would be a second opinion about where the file is.
+      const parts = oldKey.split('/');
+      parts[parts.length - 1] = newName;
+
+      return renameFileRow(oldKey, parts.join('/'));
+    },
+    [renameFileRow, renameFolderRow]
   );
 
   const showRenameDialog = useCallback(
@@ -131,6 +182,11 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
   const renameFile = useCallback(
     async (file: FileItem, newName: string, currentPath: string) => {
+      // No session, no service. The provider renders nothing in that state, so
+      // nothing can call this - but the callback is now built before the state
+      // is known, so it says what it does without one.
+      if (!renameService) return;
+
       const fileId = file.id || file.Key || file.name;
 
       if (newName === file.name) {
@@ -151,13 +207,15 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
               try {
                 setActiveRenames((prev) => new Set(prev).add(fileId));
 
+                const undoRename = applyRename(file, 'file', newName);
+
                 await renameService.renameFile(file, newName, currentPath, {
                   onComplete: () => {
                     success(`"${file.name}" renamed to "${newName}"`);
-                    refreshCurrentData().catch(() => {});
                   },
                   onError: (errorMessage) => {
                     reportedError = true;
+                    undoRename();
                     error(`Failed to rename "${file.name}": ${errorMessage}`);
                   },
                 });
@@ -187,13 +245,15 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
                   file.Key
                 );
 
+                const undoRename = applyRename(file, 'file', uniqueName);
+
                 await renameService.renameFile(file, uniqueName, currentPath, {
                   onComplete: () => {
                     success(`"${file.name}" renamed to "${uniqueName}"`);
-                    refreshCurrentData().catch(() => {});
                   },
                   onError: (errorMessage) => {
                     reportedError = true;
+                    undoRename();
                     error(`Failed to rename "${file.name}": ${errorMessage}`);
                   },
                 });
@@ -220,13 +280,15 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
       let reportedError = false;
       try {
+        const undoRename = applyRename(file, 'file', newName);
+
         await renameService.renameFile(file, newName, currentPath, {
           onComplete: () => {
             success(`"${file.name}" renamed to "${newName}"`);
-            refreshCurrentData().catch(() => {});
           },
           onError: (errorMessage) => {
             reportedError = true;
+            undoRename();
             error(`Failed to rename "${file.name}": ${errorMessage}`);
           },
         });
@@ -241,11 +303,13 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         });
       }
     },
-    [success, error, refreshCurrentData, hideDuplicateDialog]
+    [success, error, applyRename, hideDuplicateDialog, renameService]
   );
 
   const renameFolder = useCallback(
     async (folder: Folder, newName: string, currentPath: string) => {
+      if (!renameService) return;
+
       const folderId = folder.id || folder.Prefix || folder.name;
 
       if (newName === folder.name) {
@@ -266,14 +330,16 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
               try {
                 setActiveRenames((prev) => new Set(prev).add(folderId));
 
+                const undoRename = applyRename(folder, 'folder', newName);
+
                 await renameService.renameFolder(folder, newName, currentPath, {
                   onComplete: () => {
                     success(`"${folder.name}" renamed to "${newName}"`);
-                    refreshCurrentData().catch(() => {});
                   },
                   onPartialCleanup: handlePartialCleanup,
                   onError: (errorMessage) => {
                     reportedError = true;
+                    undoRename();
                     error(`Failed to rename "${folder.name}": ${errorMessage}`);
                   },
                 });
@@ -301,14 +367,16 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
                 const uniqueName = await renameService.findUniqueFolderName(newName, currentPath);
 
+                const undoRename = applyRename(folder, 'folder', uniqueName);
+
                 await renameService.renameFolder(folder, uniqueName, currentPath, {
                   onComplete: () => {
                     success(`"${folder.name}" renamed to "${uniqueName}"`);
-                    refreshCurrentData().catch(() => {});
                   },
                   onPartialCleanup: handlePartialCleanup,
                   onError: (errorMessage) => {
                     reportedError = true;
+                    undoRename();
                     error(`Failed to rename "${folder.name}": ${errorMessage}`);
                   },
                 });
@@ -335,14 +403,16 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
       let reportedError = false;
       try {
+        const undoRename = applyRename(folder, 'folder', newName);
+
         await renameService.renameFolder(folder, newName, currentPath, {
           onComplete: () => {
             success(`"${folder.name}" renamed to "${newName}"`);
-            refreshCurrentData().catch(() => {});
           },
           onPartialCleanup: handlePartialCleanup,
           onError: (errorMessage) => {
             reportedError = true;
+            undoRename();
             error(`Failed to rename "${folder.name}": ${errorMessage}`);
           },
         });
@@ -357,7 +427,7 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         });
       }
     },
-    [success, error, refreshCurrentData, hideDuplicateDialog]
+    [success, error, applyRename, handlePartialCleanup, hideDuplicateDialog, renameService]
   );
 
   const handleRenameConfirm = useCallback(
@@ -398,6 +468,16 @@ export const RenameProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     renameFolder,
     isRenaming,
   };
+
+  // Below every hook, so the count never changes between renders. See the
+  // note on renameService above for what putting these first used to cost.
+  if (isLoading) {
+    return <PreviewLoading message="Authenticating..." />;
+  }
+
+  if (!isAuthenticated || !apiS3) {
+    return null;
+  }
 
   return <RenameContext.Provider value={value}>{children}</RenameContext.Provider>;
 };

--- a/frontend/src/features/dashboard/hooks/use-folder-creation.test.tsx
+++ b/frontend/src/features/dashboard/hooks/use-folder-creation.test.tsx
@@ -16,15 +16,20 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useFolderCreation } from './use-folder-creation';
 
-const { fetchData, refreshCurrentData } = vi.hoisted(() => ({
-  fetchData: vi.fn(async () => {}),
-  refreshCurrentData: vi.fn(async () => {}),
-}));
+const { fetchData, refreshCurrentData, addFolder, undoAddFolder } = vi.hoisted(() => {
+  const undoAddFolder = vi.fn();
+  return {
+    fetchData: vi.fn(async () => {}),
+    refreshCurrentData: vi.fn(async () => {}),
+    addFolder: vi.fn(() => undoAddFolder),
+    undoAddFolder,
+  };
+});
 
 vi.mock('@opndrive/s3-api', () => ({ BYOS3ApiProvider: class {} }));
 
 vi.mock('@/context/data-context', () => {
-  const state = { fetchData, refreshCurrentData };
+  const state = { fetchData, refreshCurrentData, addFolder };
   // Applies the selector the way zustand does. Returning the whole state
   // regardless worked only while callers destructured it, and silently handed
   // back the entire store to anyone selecting a single value out of it.
@@ -171,5 +176,42 @@ describe('a name that cannot work is refused, not rewritten', () => {
     ).rejects.toThrow('Folder name cannot be empty.');
 
     expect(apiS3.createFolder).not.toHaveBeenCalled();
+  });
+});
+
+describe('the new folder appears without a re-list', () => {
+  it('adds the row to the listing it was created in', async () => {
+    const { result } = mount('projects/');
+
+    await act(async () => {
+      await result.current.handleFolderCreation('reports');
+    });
+
+    expect(addFolder).toHaveBeenCalledWith('projects/', 'reports');
+    // This used to cost three full listings of the prefix for one folder: one
+    // inside createFolder and a refreshCurrentData - itself two - after it.
+    expect(fetchData).not.toHaveBeenCalled();
+    expect(refreshCurrentData).not.toHaveBeenCalled();
+  });
+
+  it('adds it at the root when there is no current path', async () => {
+    const { result } = mount('');
+
+    await act(async () => {
+      await result.current.handleFolderCreation('reports');
+    });
+
+    expect(addFolder).toHaveBeenCalledWith('', 'reports');
+  });
+
+  it('takes the row back out when the write is refused', async () => {
+    apiS3.createFolder.mockRejectedValueOnce(new Error('AccessDenied'));
+    const { result } = mount('projects/');
+
+    await act(async () => {
+      await expect(result.current.handleFolderCreation('reports')).rejects.toThrow('AccessDenied');
+    });
+
+    expect(undoAddFolder).toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/dashboard/hooks/use-folder-creation.ts
+++ b/frontend/src/features/dashboard/hooks/use-folder-creation.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 import { generateUniqueFolderName } from '@/features/upload/utils/unique-filename';
 import { useDriveStore } from '@/context/data-context';
+import { getParentPrefix } from '@/features/folder-navigation/folder-navigation';
 import { generateS3Key } from '@/features/upload/utils/generate-s3-key';
 import { describeFolderNameError } from '@/features/upload/utils/folder-name';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
@@ -28,8 +29,7 @@ export function useFolderCreation({ currentPath, onFolderCreated }: UseFolderCre
     onKeepBoth: null,
   });
 
-  const fetchData = useDriveStore((state) => state.fetchData);
-  const refreshCurrentData = useDriveStore((state) => state.refreshCurrentData);
+  const addFolder = useDriveStore((state) => state.addFolder);
 
   const { apiS3 } = useAuthGuard();
 
@@ -71,14 +71,26 @@ export function useFolderCreation({ currentPath, onFolderCreated }: UseFolderCre
       const name = folderName.trim();
       const folderKey = generateS3Key(`${name}/`, currentPath);
 
-      await apiS3.createFolder(folderKey);
+      // The row goes in before the request. One call decides whether this
+      // folder exists, so a failure means it provably does not and the row
+      // comes straight back out.
+      //
+      // The prefix is read back off the key that will actually be written
+      // rather than from currentPath, so there is only ever one opinion about
+      // where this folder lives - generateS3Key strips a leading slash and
+      // currentPath may carry one.
+      const undoRow = addFolder(getParentPrefix(folderKey), name);
 
-      // Refresh the current directory to show the new folder
-      await fetchData({ sync: true });
+      try {
+        await apiS3.createFolder(folderKey);
+      } catch (error) {
+        undoRow();
+        throw error;
+      }
 
       onFolderCreated?.(name);
     },
-    [currentPath, fetchData, onFolderCreated, apiS3]
+    [currentPath, addFolder, onFolderCreated, apiS3]
   );
 
   // Handle folder creation with duplicate checking
@@ -107,12 +119,9 @@ export function useFolderCreation({ currentPath, onFolderCreated }: UseFolderCre
                   onReplace: null,
                   onKeepBoth: null,
                 });
-                // Refresh data to show the newly created folder
-                try {
-                  await refreshCurrentData();
-                } catch {
-                  // Don't fail folder creation if refresh fails
-                }
+                // createFolder has already put the row in the listing. The
+                // re-read that used to follow it here was the third full
+                // listing of this prefix for one folder.
                 resolve();
               } catch (error) {
                 resolve();
@@ -129,12 +138,6 @@ export function useFolderCreation({ currentPath, onFolderCreated }: UseFolderCre
                   onReplace: null,
                   onKeepBoth: null,
                 });
-                // Refresh data to show the newly created folder
-                try {
-                  await refreshCurrentData();
-                } catch {
-                  // Don't fail folder creation if refresh fails
-                }
                 resolve();
               } catch (error) {
                 resolve();
@@ -146,16 +149,9 @@ export function useFolderCreation({ currentPath, onFolderCreated }: UseFolderCre
       } else {
         // No duplicate, create folder directly
         await createFolder(folderName);
-
-        // Refresh data to show the newly created folder
-        try {
-          await refreshCurrentData();
-        } catch {
-          // Don't fail folder creation if refresh fails
-        }
       }
     },
-    [checkFolderExists, createFolder, currentPath, refreshCurrentData, apiS3]
+    [checkFolderExists, createFolder, currentPath, apiS3]
   );
 
   return {

--- a/frontend/src/features/dashboard/hooks/use-multi-select-actions.test.tsx
+++ b/frontend/src/features/dashboard/hooks/use-multi-select-actions.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * What the multi-select delete asks before it does anything.
+ *
+ * This is the last thing standing between a selection and permanent deletion,
+ * and it had two problems. It listed every name comma-joined and quoted, with
+ * no cap - so eight files arrived as one run-on line to be parsed rather than
+ * scanned, and four hundred arrived as a four-hundred-name paragraph.
+ *
+ * And it never mentioned folders. The single-folder dialog has always said "and
+ * everything inside it"; this one said "5 items will be deleted forever", which
+ * gives no hint that one of those five might hold ten thousand more.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMultiSelectActions } from './use-multi-select-actions';
+import { confirmAction } from '@/shared/components/ui/confirm-dialog';
+import type { FileItem } from '../types/file';
+import type { Folder } from '../types/folder';
+
+vi.mock('@/shared/components/ui/confirm-dialog', () => ({
+  // Declined, so nothing past the question runs. These tests are about the
+  // question.
+  confirmAction: vi.fn(async () => false),
+}));
+
+vi.mock('./use-download', () => ({
+  useDownloadActions: () => ({ downloadMultipleFiles: vi.fn() }),
+}));
+
+vi.mock('./use-delete-with-progress', () => ({
+  useDeleteWithProgress: () => ({
+    deleteFile: vi.fn(),
+    deleteFolder: vi.fn(),
+    batchDeleteFiles: vi.fn(),
+  }),
+}));
+
+vi.mock('@/context/file-preview-context', () => ({
+  useFilePreview: () => ({ openPreview: vi.fn() }),
+}));
+
+vi.mock('@/context/notification-context', () => ({
+  // The hook reports what it could not delete through this. Nothing here
+  // reaches that far - every test declines the question - but the provider is
+  // read at render time, so it has to exist.
+  useNotification: () => ({ error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() }),
+}));
+
+function file(name: string): FileItem {
+  return {
+    Key: `docs/${name}`,
+    id: `docs/${name}`,
+    name,
+    extension: name.split('.').pop() ?? '',
+    size: { value: 1, unit: 'B' },
+  };
+}
+
+function folder(name: string): Folder {
+  return {
+    Prefix: `${name}/`,
+    id: `${name}/`,
+    name,
+    icon: 'folder',
+    location: { type: 'my-drive', label: 'My Drive' },
+  };
+}
+
+function actions() {
+  return renderHook(() => useMultiSelectActions({ openMultiShareDialog: vi.fn() })).result.current;
+}
+
+async function askAbout(items: (FileItem | Folder)[]) {
+  const { handleDeleteItems } = actions();
+  await act(async () => {
+    await handleDeleteItems(items);
+  });
+
+  return vi.mocked(confirmAction).mock.calls[0]![0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('the list of what will go', () => {
+  it('puts one name on each line, unquoted', async () => {
+    const asked = await askAbout([file('a.json'), file('b.json'), file('c.json')]);
+
+    expect(asked.description).toContain('a.json\nb.json\nc.json');
+    expect(asked.description).not.toContain('"a.json"');
+  });
+
+  it('stops at eight and counts the rest', async () => {
+    const asked = await askAbout(Array.from({ length: 20 }, (_, i) => file(`f${i}.json`)));
+
+    // There was no cap at all: twenty names, or four hundred, all went in.
+    expect(asked.description).toContain('and 12 more');
+    expect(asked.description).not.toContain('f8.json');
+  });
+
+  it('does not repeat the count the title already gives', async () => {
+    const asked = await askAbout([file('a.json'), file('b.json')]);
+
+    expect(asked.title).toBe('Delete 2 items forever?');
+    expect(asked.description).not.toContain('2 items will be deleted');
+  });
+
+  it('marks a folder so a plain list can still tell you it is one', async () => {
+    const asked = await askAbout([folder('photos'), file('a.json')]);
+
+    expect(asked.description).toContain('photos/');
+    expect(asked.description).toContain('a.json');
+  });
+});
+
+describe('the warning a folder earns', () => {
+  it('says a folder takes its contents with it', async () => {
+    const asked = await askAbout([folder('photos'), file('a.json'), file('b.json')]);
+
+    expect(asked.description).toContain('everything inside it');
+  });
+
+  it('says nothing about folders when none are selected', async () => {
+    const asked = await askAbout([file('a.json'), file('b.json')]);
+
+    expect(asked.description).not.toContain('everything inside it');
+    expect(asked.description).toContain('This action cannot be undone.');
+  });
+
+  it('matches the single-folder dialog when one folder is selected', async () => {
+    const asked = await askAbout([folder('photos')]);
+
+    // The same sentence the folder overflow menu has always used. Selecting a
+    // folder and selecting it through the menu should not warn differently.
+    expect(asked.title).toBe('Delete forever?');
+    expect(asked.description).toBe(
+      '"photos" and everything inside it will be deleted forever. This action cannot be undone.'
+    );
+  });
+
+  it('keeps a single file to its own sentence', async () => {
+    const asked = await askAbout([file('report.json')]);
+
+    expect(asked.description).toBe(
+      '"report.json" will be deleted forever. This action cannot be undone.'
+    );
+  });
+});

--- a/frontend/src/features/dashboard/hooks/use-multi-select-actions.ts
+++ b/frontend/src/features/dashboard/hooks/use-multi-select-actions.ts
@@ -16,6 +16,41 @@ import {
   isFolderMarker,
 } from '@/shared/utils/drive-item';
 
+/**
+ * How many names the confirmation lists before the rest become a count.
+ *
+ * Eight fits a dialog without scrolling it. There was no cap at all before, so
+ * selecting four hundred files built a four-hundred-name paragraph and asked
+ * the user to read it.
+ */
+const MAX_LISTED_NAMES = 8;
+
+/**
+ * What is about to be deleted, one name per line.
+ *
+ * Comma-joined and quoted, the way this used to read, eight names arrive as a
+ * single run-on line that has to be parsed rather than scanned - which is the
+ * one thing a destructive confirmation must not ask of anyone.
+ *
+ * Folders keep a trailing slash. In a plain list it is the only thing that says
+ * a name is a folder, and a folder is the one entry here that takes more than
+ * itself with it.
+ */
+function listNames(items: (FileItem | Folder)[], folders: readonly (FileItem | Folder)[]): string {
+  // Not Folder[]: a folder marker is a FileItem that happens to be a folder,
+  // which is exactly why isFolderLike is not a type predicate. Identity is all
+  // this needs anyway - the set only answers "was this one of them?".
+  const isFolder = new Set<FileItem | Folder>(folders);
+
+  const named = items
+    .slice(0, MAX_LISTED_NAMES)
+    .map((item) => (isFolder.has(item) ? `${item.name}/` : item.name));
+
+  const remaining = items.length - named.length;
+
+  return remaining > 0 ? `${named.join('\n')}\nand ${remaining} more` : named.join('\n');
+}
+
 interface UseMultiSelectActionsProps {
   openMultiShareDialog: (files: FileItem[]) => void;
 }
@@ -93,11 +128,25 @@ export function useMultiSelectActions({ openMultiShareDialog }: UseMultiSelectAc
       const folders = items.filter(isFolderLike);
 
       // Show confirmation dialog
-      const itemNames = items.map((item) => `"${item.name}"`).join(', ');
-      const confirmMessage =
-        items.length === 1
-          ? `${itemNames} will be deleted forever. This action cannot be undone.`
-          : `${items.length} items will be deleted forever. This action cannot be undone.\n\nItems: ${itemNames}`;
+      const single = items.length === 1 ? items[0]! : undefined;
+
+      // Deleting a folder takes everything underneath it. The single-folder
+      // dialog has always said so; this one never did, so a selection with a
+      // folder in it asked for confirmation without mentioning the part that
+      // cannot be taken back - and the count alone gives no hint that one of
+      // those five items might hold ten thousand more.
+      const consequence =
+        folders.length > 0
+          ? 'Deleting a folder also deletes everything inside it. This action cannot be undone.'
+          : 'This action cannot be undone.';
+
+      const confirmMessage = single
+        ? folders.length > 0
+          ? `"${single.name}" and everything inside it will be deleted forever. This action cannot be undone.`
+          : `"${single.name}" will be deleted forever. This action cannot be undone.`
+        : // The count is already in the title; repeating it here spent the
+          // first line of the body saying nothing new.
+          `${consequence}\n\n${listNames(items, folders)}`;
 
       const confirmDelete = await confirmAction({
         title: items.length === 1 ? 'Delete forever?' : `Delete ${items.length} items forever?`,

--- a/frontend/src/features/upload/components/operation-row.test.tsx
+++ b/frontend/src/features/upload/components/operation-row.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * OperationRow.
+ *
+ * Here for the same reason QueueNotices is: the thing that went wrong was not
+ * that the data was missing, but that it was computed and never displayed.
+ *
+ * A partly-failed delete builds a summary naming the objects that survived,
+ * writes it to the store, and sets the operation's status to 'failed'. The row
+ * only ever rendered a reason for status 'error' - which uploads and downloads
+ * use and deletes never do - so every one of those summaries was thrown away at
+ * the last step. Nothing in the store layer could catch that.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { OperationRow, type OperationRowProps } from './operation-row';
+
+function props(overrides: Partial<OperationRowProps> = {}): OperationRowProps {
+  return {
+    id: 'op-1',
+    name: 'report.pdf',
+    type: 'file',
+    operationType: 'delete',
+    status: 'deleting',
+    progress: 0,
+    isHovered: false,
+    supportsPauseResume: false,
+    onHoverChange: vi.fn(),
+    onCancel: vi.fn(),
+    onRemove: vi.fn(),
+    onPause: vi.fn(),
+    onResume: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('a delete that failed says why', () => {
+  it('shows the reason a delete reports', () => {
+    const summary =
+      '2 of 8 object(s) could not be deleted. photos/locked.jpg - AccessDenied; photos/held.jpg - ObjectLockRetention';
+
+    render(<OperationRow {...props({ status: 'failed', error: summary })} />);
+
+    // The status a delete actually reports is 'failed'. Matching on 'error'
+    // alone rendered nothing at all here.
+    expect(screen.getByText(summary)).toBeTruthy();
+  });
+
+  it('says something even when no reason came back', () => {
+    render(<OperationRow {...props({ status: 'failed' })} />);
+
+    expect(screen.getByText('Failed')).toBeTruthy();
+  });
+
+  it('still shows an upload error, which uses the other status', () => {
+    render(
+      <OperationRow
+        {...props({ operationType: 'upload', status: 'error', error: 'Network unreachable' })}
+      />
+    );
+
+    expect(screen.getByText('Network unreachable')).toBeTruthy();
+  });
+});
+
+describe('a delete that worked does not look like one that did not', () => {
+  it('paints a finished delete the same as any other finished operation', () => {
+    const { unmount } = render(
+      <OperationRow {...props({ operationType: 'upload', status: 'completed' })} />
+    );
+    const finishedUpload = screen.getByText('Upload complete').getAttribute('style');
+    unmount();
+
+    render(<OperationRow {...props({ operationType: 'delete', status: 'completed' })} />);
+    const finishedDelete = screen.getByText('Delete complete').getAttribute('style');
+
+    // A finished delete used to be painted the same red as a cancelled or
+    // failed one, so a green tick sat next to red text - and a real failure
+    // was indistinguishable from a success at a glance.
+    expect(finishedDelete).toBe(finishedUpload);
+  });
+
+  it('keeps a cancelled delete visually distinct from a finished one', () => {
+    const { unmount } = render(<OperationRow {...props({ status: 'completed' })} />);
+    const finished = screen.getByText('Delete complete').getAttribute('style');
+    unmount();
+
+    render(<OperationRow {...props({ status: 'cancelled' })} />);
+    const cancelled = screen.getByText('Delete cancelled').getAttribute('style');
+
+    expect(cancelled).not.toBe(finished);
+  });
+});
+
+describe('a counted card shows what it counted', () => {
+  const detail = 'a.json\nb.json\nc.json';
+
+  it('offers the names behind an icon rather than on the card', () => {
+    render(<OperationRow {...props({ name: '3 items', detail })} />);
+
+    // Inline, eight names truncate to "main - Copy - Copy (2).json, mai..." -
+    // a whole line spent saying less than the count above it already did.
+    expect(screen.getByText('3 items')).toBeTruthy();
+    expect(screen.queryByText(detail)).toBeNull();
+    expect(screen.getByLabelText('Show all items')).toBeTruthy();
+  });
+
+  it('lists them when the icon is hovered', () => {
+    vi.useFakeTimers();
+
+    try {
+      render(<OperationRow {...props({ name: '3 items', detail })} />);
+      const trigger = screen.getByLabelText('Show all items').parentElement!;
+
+      fireEvent.mouseEnter(trigger);
+      act(() => {
+        // The tooltip waits before appearing, so resting on a control is a
+        // deliberate act rather than something that happens in passing.
+        vi.advanceTimersByTime(700);
+      });
+
+      expect(screen.getByRole('tooltip').textContent).toBe(detail);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('renders the list with the breaks kept, not folded into a paragraph', () => {
+    vi.useFakeTimers();
+
+    try {
+      render(<OperationRow {...props({ name: '3 items', detail })} />);
+      fireEvent.mouseEnter(screen.getByLabelText('Show all items').parentElement!);
+      act(() => {
+        vi.advanceTimersByTime(700);
+      });
+
+      // `multiline` alone gives white-space: normal, which wraps but folds
+      // newlines into spaces - a list of filenames as one run-on paragraph.
+      expect(screen.getByRole('tooltip').className).toContain('aria-label-list');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows no icon when there is nothing behind it', () => {
+    render(<OperationRow {...props({ name: 'report.pdf' })} />);
+
+    expect(screen.queryByLabelText('Show all items')).toBeNull();
+  });
+});

--- a/frontend/src/features/upload/components/operation-row.tsx
+++ b/frontend/src/features/upload/components/operation-row.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { HiOutlineXMark } from 'react-icons/hi2';
+import { Files, Info } from 'lucide-react';
 import { FileIcon } from '@/shared/components/icons/file-icons';
 import { FolderIcon } from '@/shared/components/icons/folder-icons';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
@@ -27,7 +28,16 @@ export type OperationType = 'upload' | 'delete' | 'download';
 export interface OperationRowProps {
   id: string;
   name: string;
-  type: 'file' | 'folder';
+  /** 'mixed' is a selection that is neither - see DeleteProgress['type']. */
+  type: 'file' | 'folder' | 'mixed';
+  /**
+   * Names of what a counted card is actually operating on, one per line.
+   *
+   * Shown behind an info icon rather than on the card: eight of them inline
+   * truncate to "main - Copy - Copy (2).json, mai...", which spends a whole
+   * line saying less than the count above it already did.
+   */
+  detail?: string;
   operationType: OperationType;
   status: string;
   progress: number;
@@ -52,6 +62,7 @@ const OperationRowInner: React.FC<OperationRowProps> = ({
   id,
   name,
   type,
+  detail,
   operationType,
   status,
   progress,
@@ -94,6 +105,10 @@ const OperationRowInner: React.FC<OperationRowProps> = ({
       <div className="flex-shrink-0">
         {type === 'folder' ? (
           <FolderIcon />
+        ) : type === 'mixed' ? (
+          // Files and folders together. Drawing either one alone would claim
+          // something about the selection that is not true.
+          <Files className="w-6 h-6" style={{ color: 'var(--muted-foreground)' }} />
         ) : (
           <FileIcon extension={extension} filename={name} className="w-6 h-6" />
         )}
@@ -101,25 +116,35 @@ const OperationRowInner: React.FC<OperationRowProps> = ({
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <p
-          className="text-xs font-medium truncate"
-          title={name}
-          style={{ color: 'var(--foreground)' }}
-        >
-          {name}
-        </p>
-        {status === 'completed' && (
+        <div className="flex min-w-0 items-center gap-1.5">
           <p
-            className="text-xs"
-            style={{
-              color:
-                operationType === 'upload'
-                  ? 'var(--muted-foreground)'
-                  : operationType === 'download'
-                    ? 'var(--muted-foreground)'
-                    : '#ef4444',
-            }}
+            className="text-xs font-medium truncate"
+            title={name}
+            style={{ color: 'var(--foreground)' }}
           >
+            {name}
+          </p>
+          {detail ? (
+            <AriaLabel
+              label={detail}
+              multiline
+              className="aria-label-list"
+              position="top"
+              focusableWrapper
+            >
+              <Info
+                className="h-3.5 w-3.5 shrink-0"
+                style={{ color: 'var(--muted-foreground)' }}
+                aria-label="Show all items"
+              />
+            </AriaLabel>
+          ) : null}
+        </div>
+        {status === 'completed' && (
+          // Muted, like the other two. A finished delete used to be painted the
+          // same red as a cancelled or failed one, so a green tick sat next to
+          // red text - and a real failure looked identical to a success.
+          <p className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
             {operationType === 'upload'
               ? 'Upload complete'
               : operationType === 'delete'
@@ -161,7 +186,11 @@ const OperationRowInner: React.FC<OperationRowProps> = ({
             Paused
           </p>
         )}
-        {status === 'error' && (
+        {(status === 'failed' || status === 'error') && (
+          // 'failed' is the status a delete actually reports; only uploads and
+          // downloads use 'error'. Matching on 'error' alone meant a failed or
+          // partly-failed delete rendered no reason at all - the summary naming
+          // the objects that survived was written to the store and never shown.
           <p className="text-xs" style={{ color: '#ef4444' }}>
             {error || 'Failed'}
           </p>

--- a/frontend/src/features/upload/components/operations-modal.tsx
+++ b/frontend/src/features/upload/components/operations-modal.tsx
@@ -16,7 +16,8 @@ import { useUploadSettingsStore } from '@/features/upload/stores/use-upload-sett
 interface OperationItem {
   id: string;
   name: string;
-  type: 'file' | 'folder';
+  type: 'file' | 'folder' | 'mixed';
+  detail?: string;
   operationType: OperationType;
   status: string;
   progress: number;
@@ -291,7 +292,14 @@ export const OperationsModal: React.FC = () => {
         completedFiles: deleteOp.completedFiles,
         isCalculatingSize: deleteOp.isCalculatingSize,
         error: deleteOp.error,
-        extension: deleteOp.type === 'file' ? getFileExtension(deleteOp.name) : undefined,
+        detail: deleteOp.detail,
+        // The stored extension first. A batch card is named "8 items", which
+        // has nothing to read an extension out of, but the hook already worked
+        // out that all eight of them are .json.
+        extension:
+          deleteOp.type === 'file'
+            ? ((deleteOp.extension as FileExtension | undefined) ?? getFileExtension(deleteOp.name))
+            : undefined,
       })),
       // Download operations
       ...downloads.map((download) => ({
@@ -710,6 +718,7 @@ export const OperationsModal: React.FC = () => {
                   id={operation.id}
                   name={operation.name}
                   type={operation.type}
+                  detail={operation.detail}
                   operationType={operation.operationType}
                   status={operation.status}
                   progress={operation.progress}

--- a/frontend/src/features/upload/hooks/use-delete-operations-session.test.tsx
+++ b/frontend/src/features/upload/hooks/use-delete-operations-session.test.tsx
@@ -31,6 +31,8 @@ const { refreshCurrentData, notifyError, removeDeletedFolder } = vi.hoisted(() =
   notifyError: vi.fn(),
   removeDeletedFolder: vi.fn(),
 }));
+/** Returns its undo, the way the real mutator does. */
+const removeFiles = vi.fn(() => vi.fn());
 
 vi.mock('@opndrive/s3-api', () => ({
   UploadManager: class {},
@@ -48,6 +50,7 @@ const drive = {
   rootPrefix: '/' as string | null,
   refreshCurrentData,
   removeDeletedFolder,
+  removeFiles,
 };
 
 vi.mock('@/context/data-context', () => ({

--- a/frontend/src/features/upload/hooks/use-delete-operations.test.tsx
+++ b/frontend/src/features/upload/hooks/use-delete-operations.test.tsx
@@ -18,7 +18,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useDeleteOperations } from './use-delete-operations';
 import { useDeleteRecoveryStore } from '../stores/use-delete-recovery-store';
+import { useUploadStore } from '../stores/use-upload-store';
 import type { Folder } from '@/features/dashboard/types/folder';
+import type { FileItem } from '@/features/dashboard/types/file';
 
 const listFromPrefix = vi.fn();
 const deleteBatch = vi.fn();
@@ -26,6 +28,8 @@ const deleteFile = vi.fn();
 const refreshCurrentData = vi.fn();
 const removeDeletedFolder = vi.fn();
 const routerReplace = vi.fn();
+/** Returns its undo, the way the real mutator does. */
+const removeFiles = vi.fn(() => vi.fn());
 const notifyError = vi.fn();
 
 /** Where the user is standing, which is what decides whether a delete moves them. */
@@ -34,6 +38,7 @@ const drive = {
   rootPrefix: '/' as string | null,
   refreshCurrentData,
   removeDeletedFolder,
+  removeFiles,
 };
 
 const route = { pathname: '/dashboard/browse' };
@@ -191,14 +196,18 @@ describe('after the folder is gone', () => {
     expect(removeDeletedFolder).toHaveBeenCalledWith('docs/');
   });
 
-  it('refreshes in place when the user was somewhere else', async () => {
+  it('corrects the listing in place when the user was somewhere else', async () => {
     const { result } = renderHook(() => useDeleteOperations());
     await act(async () => {
       await result.current.deleteFolderWithProgress(folder());
     });
 
     expect(routerReplace).not.toHaveBeenCalled();
-    expect(refreshCurrentData).toHaveBeenCalled();
+    // removeDeletedFolder has already taken the row out of the parent listing,
+    // so re-reading the prefix would spend two full listings confirming what
+    // the store was just told.
+    expect(removeDeletedFolder).toHaveBeenCalledWith('docs/');
+    expect(refreshCurrentData).not.toHaveBeenCalled();
   });
 
   it('steps out to the parent when the user was inside it', async () => {
@@ -263,7 +272,7 @@ describe('after the folder is gone', () => {
     });
 
     expect(routerReplace).not.toHaveBeenCalled();
-    expect(refreshCurrentData).toHaveBeenCalled();
+    expect(refreshCurrentData).not.toHaveBeenCalled();
   });
 
   it('does not throw the user out of their search results', async () => {
@@ -376,5 +385,343 @@ describe('recovery record', () => {
     });
 
     expect(bucketDuringRun).toBe('test-bucket');
+  });
+});
+
+describe('deleting one file', () => {
+  function doc(): FileItem {
+    return {
+      id: 'docs/a.txt',
+      Key: 'docs/a.txt',
+      name: 'a.txt',
+      extension: 'txt',
+      size: { value: 1, unit: 'B' },
+    };
+  }
+
+  it('takes the row out instead of re-listing the folder', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.deleteFileWithProgress(doc());
+    });
+
+    expect(removeFiles).toHaveBeenCalledWith(['docs/a.txt']);
+    // Two full listings of a thousand objects, to learn one row had gone.
+    expect(refreshCurrentData).not.toHaveBeenCalled();
+  });
+
+  it('removes the row before the request goes out', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.deleteFileWithProgress(doc());
+    });
+
+    // Optimistic: the row goes the moment the user asks, not a round trip later.
+    expect(removeFiles.mock.invocationCallOrder[0]!).toBeLessThan(
+      deleteFile.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it('puts the row back when the delete is refused', async () => {
+    const undo = vi.fn();
+    removeFiles.mockReturnValueOnce(undo);
+    deleteFile.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await expect(result.current.deleteFileWithProgress(doc())).rejects.toThrow('AccessDenied');
+    });
+
+    // One call, one object: it did not happen, so the row is owed back.
+    expect(undo).toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalled();
+  });
+});
+
+/**
+ * What the card claims to be deleting.
+ *
+ * Batch deletes used to hardcode `type: 'folder'` to get *an* icon, with the
+ * comment "Use folder icon for batch operations". So deleting a single photo
+ * drew a folder, and a selection of eight files drew a folder next to a label
+ * that correctly read "Deleting 8 files".
+ */
+describe('what the delete card says it is deleting', () => {
+  const card = () => Object.values(useUploadStore.getState().deletes)[0]!;
+
+  function item(key: string, name?: string): FileItem {
+    return {
+      Key: key,
+      id: key,
+      name: name ?? key.split('/').filter(Boolean).pop() ?? key,
+      extension: 'txt',
+      size: { value: 1, unit: 'B' },
+    };
+  }
+
+  it('names the one thing being deleted rather than counting it', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete([item('docs/report.pdf')]);
+    });
+
+    // "1 item" next to a folder icon told the user nothing about the photo
+    // they had just deleted.
+    expect(card().name).toBe('report.pdf');
+    expect(card().type).toBe('file');
+  });
+
+  it('does not call a selection of files a folder', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete([item('docs/a.txt'), item('docs/b.txt')]);
+    });
+
+    expect(card().type).toBe('file');
+    expect(card().name).toBe('2 items');
+    expect(card().operationLabel).toBe('Deleting 2 files');
+  });
+
+  it('treats a folder marker as a folder, however file-shaped it is', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete([item('photos/', 'photos')]);
+    });
+
+    // A zero-byte object whose key ends in a slash is a folder to anyone
+    // looking at it. The trailing slash is the only thing that says so.
+    expect(card().type).toBe('folder');
+  });
+
+  it('says mixed when the selection is both', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete([item('docs/a.txt'), item('photos/', 'photos')]);
+    });
+
+    expect(card().type).toBe('mixed');
+    expect(card().operationLabel).toBe('Deleting 1 file and 1 folder');
+  });
+});
+
+describe('a partial failure names the objects that survived', () => {
+  const card = () => Object.values(useUploadStore.getState().deletes)[0]!;
+
+  function item(key: string): FileItem {
+    return {
+      Key: key,
+      id: key,
+      name: key.split('/').pop() ?? key,
+      extension: 'txt',
+      size: { value: 1, unit: 'B' },
+    };
+  }
+
+  it('lists the failures rather than only the first', async () => {
+    deleteBatch.mockResolvedValue({
+      requested: 3,
+      deleted: 0,
+      errors: [
+        { key: 'docs/a.txt', code: 'AccessDenied' },
+        { key: 'docs/b.txt', code: 'ObjectLockRetention' },
+        { key: 'docs/c.txt', code: 'AccessDenied' },
+      ],
+    });
+
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await expect(
+        result.current.batchDelete([item('docs/a.txt'), item('docs/b.txt'), item('docs/c.txt')])
+      ).rejects.toThrow();
+    });
+
+    // Every one of these came back inside the DeleteObjects response that did
+    // the deleting, so naming them costs nothing. Asking afterwards whether
+    // each object was still there would be one HEAD per object.
+    const summary = card().error ?? '';
+    expect(summary).toContain('docs/a.txt');
+    expect(summary).toContain('docs/b.txt');
+    expect(summary).toContain('docs/c.txt');
+    expect(summary).toContain('AccessDenied');
+    expect(summary).toContain('ObjectLockRetention');
+  });
+
+  it('counts the rest once the list would get too long', async () => {
+    const keys = Array.from({ length: 6 }, (_, i) => `docs/f${i}.txt`);
+    deleteBatch.mockResolvedValue({
+      requested: 6,
+      deleted: 0,
+      errors: keys.map((key) => ({ key, code: 'AccessDenied' })),
+    });
+
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await expect(result.current.batchDelete(keys.map(item))).rejects.toThrow();
+    });
+
+    // Three named, three counted. This string goes on a card, and a failed
+    // batch can run to hundreds.
+    expect(card().error).toContain('and 3 more');
+  });
+});
+
+describe('a batch of one kind of file keeps that kind of icon', () => {
+  const card = () => Object.values(useUploadStore.getState().deletes)[0]!;
+
+  function item(key: string): FileItem {
+    const name = key.split('/').filter(Boolean).pop() ?? key;
+    return {
+      Key: key,
+      id: key,
+      name,
+      extension: name.split('.').pop() ?? '',
+      size: { value: 1, unit: 'B' },
+    };
+  }
+
+  it('carries the shared extension so eight json files draw a json icon', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete(
+        Array.from({ length: 8 }, (_, i) => item(`docs/f${i}.json`))
+      );
+    });
+
+    // The card is named "8 items", which has no extension to read back off it.
+    // Without the shared one carried here, FileIcon falls through to its
+    // unknown-type question mark - which reads as an error, not as eight files.
+    expect(card().type).toBe('file');
+    expect(card().extension).toBe('json');
+  });
+
+  it('does not pick one kind when the selection is several', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete([item('docs/a.json'), item('docs/b.pdf')]);
+    });
+
+    // No single icon here is true of both, so neither gets claimed.
+    expect(card().type).toBe('mixed');
+    expect(card().extension).toBeUndefined();
+  });
+});
+
+describe('the card names what it is deleting', () => {
+  const card = () => Object.values(useUploadStore.getState().deletes)[0]!;
+
+  function item(key: string): FileItem {
+    const name = key.split('/').filter(Boolean).pop() ?? key;
+    return {
+      Key: key,
+      id: key,
+      name,
+      extension: name.split('.').pop() ?? '',
+      size: { value: 1, unit: 'B' },
+    };
+  }
+
+  it('lists the names behind the count', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete([
+        item('docs/report.json'),
+        item('docs/data.json'),
+        item('docs/config.json'),
+      ]);
+    });
+
+    // "3 items" is true and useless: it does not say whether the three you
+    // picked are the three you meant.
+    expect(card().detail).toBe('report.json\ndata.json\nconfig.json');
+  });
+
+  it('lists every name while the tooltip can hold them', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete(
+        Array.from({ length: 8 }, (_, i) => item(`docs/f${i}.json`))
+      );
+    });
+
+    expect(card().detail?.split('\n')).toHaveLength(8);
+  });
+
+  it('counts the rest once there are more than it can hold', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete(
+        Array.from({ length: 20 }, (_, i) => item(`docs/f${i}.json`))
+      );
+    });
+
+    // Nothing can scroll the tooltip - it is pointer-transparent by design -
+    // so a selection of twenty has to stop somewhere rather than run off the
+    // top of the screen.
+    const lines = card().detail?.split('\n') ?? [];
+    expect(lines).toHaveLength(13);
+    expect(lines[12]).toBe('and 8 more');
+  });
+
+  it('says nothing extra when there is only one thing', async () => {
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await result.current.batchDelete([item('docs/only.json')]);
+    });
+
+    // The name IS the file. Repeating it underneath would be noise.
+    expect(card().name).toBe('only.json');
+    expect(card().detail).toBeUndefined();
+  });
+});
+
+describe('how far a failed batch got decides what happens to the rows', () => {
+  function item(key: string): FileItem {
+    return {
+      Key: key,
+      id: key,
+      name: key.split('/').pop() ?? key,
+      extension: 'txt',
+      size: { value: 1, unit: 'B' },
+    };
+  }
+
+  it('puts the rows back when the first batch never went through', async () => {
+    const undo = vi.fn();
+    removeFiles.mockReturnValueOnce(undo);
+    deleteBatch.mockRejectedValueOnce(new Error('network'));
+
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await expect(result.current.batchDelete([item('docs/a.txt')])).rejects.toThrow('network');
+    });
+
+    // Nothing reached the bucket, so every row is owed back. Flagging dispatch
+    // before the request instead read this as a partial success and resynced -
+    // and the resync is deliberately silent, so offline it changed nothing and
+    // the rows stayed gone having never been deleted at all.
+    expect(undo).toHaveBeenCalled();
+    expect(refreshCurrentData).not.toHaveBeenCalled();
+  });
+
+  it('asks the bucket once a batch has actually gone through', async () => {
+    const undo = vi.fn();
+    removeFiles.mockReturnValueOnce(undo);
+    // Over the 1000-key chunk size, so there are two batches: the first lands,
+    // the second does not.
+    deleteBatch
+      .mockResolvedValueOnce({ requested: 1000, deleted: 1000, errors: [] })
+      .mockRejectedValueOnce(new Error('network'));
+
+    const keys = Array.from({ length: 1001 }, (_, i) => item(`docs/f${i}.txt`));
+
+    const { result } = renderHook(() => useDeleteOperations());
+    await act(async () => {
+      await expect(result.current.batchDelete(keys)).rejects.toThrow('network');
+    });
+
+    // A thousand of them really are gone. Putting every row back would be as
+    // wrong as leaving them all out, so the bucket is asked instead.
+    expect(undo).not.toHaveBeenCalled();
+    expect(refreshCurrentData).toHaveBeenCalledWith({ silent: true });
   });
 });

--- a/frontend/src/features/upload/hooks/use-delete-operations.ts
+++ b/frontend/src/features/upload/hooks/use-delete-operations.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import { useDriveStore } from '@/context/data-context';
+import { useDriveStore, type Revert } from '@/context/data-context';
 import { SESSION_ENDED, useUploadStore } from '../stores/use-upload-store';
 import { useDeleteRecoveryStore } from '../stores/use-delete-recovery-store';
 import { useNotification } from '@/context/notification-context';
@@ -10,7 +10,7 @@ import { markerLast } from '../utils/delete-key-order';
 import type { FileItem } from '@/features/dashboard/types/file';
 import type { Folder } from '@/features/dashboard/types/folder';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
-import { isFile } from '@/shared/utils/drive-item';
+import { isFile, isFolderLike } from '@/shared/utils/drive-item';
 
 interface FolderContents {
   allKeys: string[];
@@ -126,22 +126,108 @@ class PartialDeleteError extends Error {
   }
 }
 
+/**
+ * How many failed objects to name before falling back to a count.
+ *
+ * This string is rendered on a card, and a failed batch can run to hundreds.
+ */
+const MAX_NAMED_FAILURES = 3;
+
+/**
+ * What went wrong, in the words S3 used.
+ *
+ * Every one of these failures arrives inside the same DeleteObjects response
+ * that did the deleting - S3 returns per-object errors inline - so naming them
+ * costs nothing. The alternative, asking afterwards whether each object is
+ * still there, would be one HEAD request per object.
+ */
 function describeFailures(failures: DeleteBatchError[], total: number): string {
   const headline = `${failures.length} of ${total} object(s) could not be deleted.`;
-  const first = failures[0];
-  if (!first) return headline;
+  if (failures.length === 0) return headline;
 
-  const parts = [first.key || '(unknown key)'];
-  if (first.versionId) parts.push(`version ${first.versionId}`);
-  if (first.code) parts.push(first.code);
-  if (first.message) parts.push(first.message);
+  const named = failures.slice(0, MAX_NAMED_FAILURES).map((failure) => {
+    const parts = [failure.key || '(unknown key)'];
+    if (failure.versionId) parts.push(`version ${failure.versionId}`);
+    if (failure.code) parts.push(failure.code);
+    // Only when there is one, otherwise three S3 messages make an unreadable
+    // wall of text out of a line that has to fit on a card.
+    if (failures.length === 1 && failure.message) parts.push(failure.message);
+    return parts.join(' - ');
+  });
 
-  return `${headline} First failure: ${parts.join(' - ')}`;
+  const remaining = failures.length - named.length;
+  const more = remaining > 0 ? `; and ${remaining} more` : '';
+
+  return `${headline} ${named.join('; ')}${more}`;
+}
+
+/**
+ * How many names the tooltip lists before the rest become a count.
+ *
+ * The tooltip is not scrollable - it is pointer-transparent by design, so
+ * nothing can reach a scrollbar inside it. A cap is what keeps a selection of
+ * four hundred from running off the screen.
+ */
+const MAX_NAMED_ITEMS = 12;
+
+/** The name to show for an item, falling back to the last segment of its key. */
+function displayName(item: FileItem | Folder): string {
+  if (item.name) return item.name;
+
+  // A folder marker's name comes out empty: enrichFile splits its key on '/'
+  // and a key ending in one leaves nothing after the final separator.
+  const key = 'Prefix' in item ? item.Prefix : 'Key' in item ? item.Key : undefined;
+  return typeof key === 'string' ? (key.split('/').filter(Boolean).pop() ?? key) : '';
+}
+
+function extensionOf(name: string): string | undefined {
+  const dot = name.lastIndexOf('.');
+  // `<= 0` rather than `=== -1`, so a dotfile is not read as being all suffix.
+  return dot <= 0 ? undefined : name.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * The extension every name shares, when they share one.
+ *
+ * Eight .json files have an obvious icon and should get it. Eight files of
+ * different kinds have no single icon that would not be a lie about seven of
+ * them, so they get the stacked one instead.
+ */
+function sharedExtension(names: string[]): string | undefined {
+  const first = extensionOf(names[0] ?? '');
+  if (!first) return undefined;
+
+  return names.every((name) => extensionOf(name) === first) ? first : undefined;
+}
+
+/**
+ * What is in the selection, one name per line.
+ *
+ * These are the items the caller already handed us, so this costs nothing.
+ * "8 items" is true and useless - it does not tell you whether the eight you
+ * selected are the eight you meant.
+ *
+ * Newline-separated rather than an array because the operations panel memoises
+ * each row on shallow-equal props: an array rebuilt every render would defeat
+ * that for every row at once, which is the regression OperationRow's own doc
+ * comment exists to warn about. The tooltip renders the breaks.
+ */
+function describeItems(names: string[]): string | undefined {
+  if (names.length <= 1) return undefined;
+
+  const usable = names.filter(Boolean);
+  if (usable.length === 0) return undefined;
+
+  const listed = usable.slice(0, MAX_NAMED_ITEMS);
+  const remaining = usable.length - listed.length;
+
+  return remaining > 0 ? `${listed.join('\n')}\nand ${remaining} more` : listed.join('\n');
 }
 
 export function useDeleteOperations() {
   const { apiS3 } = useAuthGuard();
   const refreshCurrentData = useDriveStore((state) => state.refreshCurrentData);
+  const removeFiles = useDriveStore((state) => state.removeFiles);
   const { error: errorFunction } = useNotification();
   const {
     startDeleteOperation,
@@ -204,8 +290,23 @@ export function useDeleteOperations() {
         // Show intermediate progress
         updateDeleteProgress(itemId, 20);
 
-        // Perform the actual delete
-        await apiS3.deleteFile(file.Key || file.name);
+        // The row goes now rather than when S3 answers. Everything below is
+        // careful about who may put it back: only a failure of the one call
+        // this function makes leaves the object provably still there.
+        const undoRemoval = removeFiles([file.Key || file.name]);
+
+        try {
+          // Perform the actual delete
+          await apiS3.deleteFile(file.Key || file.name);
+        } catch (error) {
+          // One call, one object: it either happened or it did not, so the row
+          // belongs back exactly as it was. Note this is deliberately not the
+          // outer catch, which also sees aborts raised *after* the delete
+          // succeeded - putting the row back there would resurrect a file that
+          // really is gone.
+          undoRemoval();
+          throw error;
+        }
 
         updateDeleteProgress(itemId, 90);
 
@@ -220,8 +321,6 @@ export function useDeleteOperations() {
 
         updateDeleteProgress(itemId, 100);
         completeDeleteOperation(itemId);
-
-        await refreshCurrentData();
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
           return;
@@ -234,7 +333,7 @@ export function useDeleteOperations() {
     },
     [
       apiS3,
-      refreshCurrentData,
+      removeFiles,
       errorFunction,
       startDeleteOperation,
       updateDeleteProgress,
@@ -348,8 +447,10 @@ export function useDeleteOperations() {
             const summary = describeFailures(failures, allKeys.length);
             failDeleteOperation(itemId, summary);
             errorFunction(`Partially deleted "${folder.name}": ${summary}`);
-            // Refresh so the browser reflects what actually survived.
-            await refreshCurrentData();
+            // Some objects went and some did not, and only the bucket knows
+            // which. Silently, because those rows are on screen and asking is
+            // no reason to blank them.
+            await refreshCurrentData({ silent: true });
             throw new PartialDeleteError(summary, failures);
           }
         } else {
@@ -371,10 +472,10 @@ export function useDeleteOperations() {
         completeDeleteOperation(itemId);
 
         // Every listing that mentioned this folder is now wrong, not just the
-        // one on screen. When the folder we were pointing at is one of them,
-        // the cleanup has moved us out and there is nothing left to refetch.
-        const prefixGone = cleanUpDeletedFolder(normalizedKey);
-        if (!prefixGone) await refreshCurrentData();
+        // one on screen. cleanUpDeletedFolder drops all of them and prunes the
+        // row out of the parent, so there is nothing left to re-read: the
+        // listing the user is looking at is already correct.
+        cleanUpDeletedFolder(normalizedKey);
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
           return;
@@ -438,15 +539,56 @@ export function useDeleteOperations() {
             ? `Deleting ${folderCount} folder${folderCount !== 1 ? 's' : ''}`
             : `Deleting ${fileCount} file${fileCount !== 1 ? 's' : ''}`;
 
+      // Deleting one thing is not a batch to the person doing it, so the card
+      // says which thing. Only a real multi-selection falls back to a count.
+      const single = items.length === 1 ? items[0] : undefined;
+      const names = items.map(displayName);
+
+      // Only meaningful when the whole selection is files: a folder has no
+      // extension to agree with.
+      const uniform = folderCount === 0 ? sharedExtension(names) : undefined;
+
       const signal = startDeleteOperation(itemId, {
         id: itemId,
-        name: `${items.length} item${items.length !== 1 ? 's' : ''}`,
-        type: 'folder', // Use folder icon for batch operations
+        name: single ? displayName(single) : `${items.length} items`,
+        // 'file' only where there is an extension to draw it from. A batch card
+        // is named "8 items", which has no extension to read back off it, so
+        // claiming 'file' without one lands on FileIcon's unknown-type
+        // question mark - which reads as an error rather than as eight files.
+        type: single
+          ? isFolderLike(single)
+            ? 'folder'
+            : 'file'
+          : fileCount === 0
+            ? 'folder'
+            : uniform
+              ? 'file'
+              : 'mixed',
         size: 0,
         status: 'deleting',
         progress: 0,
         operationLabel,
+        extension: single
+          ? isFolderLike(single)
+            ? undefined
+            : (single as FileItem).extension
+          : uniform,
+        detail: describeItems(names),
       });
+
+      // Declared out here so the catch can reach them. `anyDispatched` is what
+      // decides whether undoing is still honest: see undoOrResync.
+      let undoRemoval: Revert = () => {};
+      let anyDispatched = false;
+
+      const undoOrResync = () => {
+        // A revert only tells the truth while nothing has actually been
+        // deleted. Once the first batch has gone out, some of these keys are
+        // gone and some are not, and putting every row back would be as wrong
+        // as leaving them all out - so the bucket gets asked instead.
+        if (anyDispatched) void refreshCurrentData({ silent: true });
+        else undoRemoval();
+      };
 
       try {
         // Show calculating state
@@ -486,9 +628,11 @@ export function useDeleteOperations() {
         if (uniqueKeys.length === 0) {
           updateDeleteProgress(itemId, 100);
           completeDeleteOperation(itemId);
-          await refreshCurrentData();
+          // Nothing was deleted, so nothing in the listing has changed.
           return;
         }
+
+        undoRemoval = removeFiles(uniqueKeys);
 
         // Batch delete in chunks of 1000 (S3 limit)
         const batchSize = 1000;
@@ -510,6 +654,13 @@ export function useDeleteOperations() {
           );
           if (!result.reliable) warnLegacyProviderOnce();
 
+          // Set after the call, not before it. Set beforehand, a failure on the
+          // very first batch - offline, a 5xx, expired credentials - read as
+          // "some of this was deleted", so undoOrResync resynced instead of
+          // reverting. The resync is deliberately silent, so when it failed too
+          // it changed nothing: the rows stayed gone, having never been deleted.
+          anyDispatched = true;
+
           processed += batch.length;
           deletedCount += result.deleted;
           failures.push(...result.errors);
@@ -527,7 +678,7 @@ export function useDeleteOperations() {
           const summary = describeFailures(failures, uniqueKeys.length);
           failDeleteOperation(itemId, summary);
           errorFunction(`Partially deleted selection: ${summary}`);
-          await refreshCurrentData();
+          await refreshCurrentData({ silent: true });
           throw new PartialDeleteError(summary, failures);
         }
 
@@ -540,15 +691,17 @@ export function useDeleteOperations() {
 
         updateDeleteProgress(itemId, 100);
         completeDeleteOperation(itemId);
-
-        await refreshCurrentData();
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
+          // A cancel can land between batches, so this is the same question as
+          // a failure: how far did we get before stopping?
+          undoOrResync();
           return;
         }
         if (error instanceof PartialDeleteError) {
           throw error;
         }
+        undoOrResync();
         const errorMessage = error instanceof Error ? error.message : 'Batch delete failed';
         failDeleteOperation(itemId, errorMessage);
         errorFunction(`Failed to delete items: ${errorMessage}`);
@@ -558,6 +711,7 @@ export function useDeleteOperations() {
     // batchDelete works from keys it already has, so it never lists a prefix
     [
       apiS3,
+      removeFiles,
       refreshCurrentData,
       errorFunction,
       startDeleteOperation,
@@ -584,16 +738,43 @@ export function useDeleteOperations() {
       const uniqueKeys = Array.from(new Set(keys));
 
       const itemId = `delete-keys-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+      // Only raw keys here, so the trailing slash is the only thing that says
+      // folder. Same rule as isFolderLike, applied to a string.
+      const markerCount = uniqueKeys.filter((key) => key.endsWith('/')).length;
+      const onlyKey = uniqueKeys.length === 1 ? uniqueKeys[0]! : undefined;
+      const names = uniqueKeys.map((key) => key.split('/').filter(Boolean).pop() ?? key);
+      const uniform = markerCount === 0 ? sharedExtension(names) : undefined;
+
       const signal = startDeleteOperation(itemId, {
         id: itemId,
-        name: `${uniqueKeys.length} item${uniqueKeys.length !== 1 ? 's' : ''}`,
-        type: 'folder',
+        name: onlyKey ? (names[0] ?? onlyKey) : `${uniqueKeys.length} items`,
+        // Same rule as batchDelete: 'file' only where an icon can be drawn.
+        type:
+          markerCount === uniqueKeys.length
+            ? 'folder'
+            : markerCount > 0
+              ? 'mixed'
+              : onlyKey || uniform
+                ? 'file'
+                : 'mixed',
         size: 0,
         status: 'deleting',
         progress: 0,
         totalFiles: uniqueKeys.length,
         operationLabel: `Deleting ${uniqueKeys.length} item${uniqueKeys.length !== 1 ? 's' : ''}`,
+        extension: onlyKey ? extensionOf(names[0] ?? '') : uniform,
+        detail: describeItems(names),
       });
+
+      // Same scaffolding as batchDelete, for the same reason.
+      let undoRemoval: Revert = () => {};
+      let anyDispatched = false;
+
+      const undoOrResync = () => {
+        if (anyDispatched) void refreshCurrentData({ silent: true });
+        else undoRemoval();
+      };
 
       try {
         updateDeleteProgress(itemId, 0, 0, uniqueKeys.length);
@@ -601,6 +782,8 @@ export function useDeleteOperations() {
         if (signal.aborted) {
           throw abortError();
         }
+
+        undoRemoval = removeFiles(uniqueKeys);
 
         // Batch delete in chunks of 1000 (S3 limit)
         const batchSize = 1000;
@@ -622,6 +805,13 @@ export function useDeleteOperations() {
           );
           if (!result.reliable) warnLegacyProviderOnce();
 
+          // Set after the call, not before it. Set beforehand, a failure on the
+          // very first batch - offline, a 5xx, expired credentials - read as
+          // "some of this was deleted", so undoOrResync resynced instead of
+          // reverting. The resync is deliberately silent, so when it failed too
+          // it changed nothing: the rows stayed gone, having never been deleted.
+          anyDispatched = true;
+
           processed += batch.length;
           deletedCount += result.deleted;
           failures.push(...result.errors);
@@ -638,19 +828,20 @@ export function useDeleteOperations() {
           const summary = describeFailures(failures, uniqueKeys.length);
           failDeleteOperation(itemId, summary);
           errorFunction(`Partially deleted items: ${summary}`);
-          await refreshCurrentData();
+          await refreshCurrentData({ silent: true });
           throw new PartialDeleteError(summary, failures);
         }
 
         completeDeleteOperation(itemId);
-        await refreshCurrentData();
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
+          undoOrResync();
           return;
         }
         if (error instanceof PartialDeleteError) {
           throw error;
         }
+        undoOrResync();
         const errorMessage = error instanceof Error ? error.message : 'Batch delete failed';
         failDeleteOperation(itemId, errorMessage);
         errorFunction(`Failed to delete items: ${errorMessage}`);
@@ -659,6 +850,7 @@ export function useDeleteOperations() {
     },
     [
       apiS3,
+      removeFiles,
       refreshCurrentData,
       errorFunction,
       startDeleteOperation,

--- a/frontend/src/features/upload/hooks/use-delete-operations.ts
+++ b/frontend/src/features/upload/hooks/use-delete-operations.ts
@@ -583,9 +583,12 @@ export function useDeleteOperations() {
 
       const undoOrResync = () => {
         // A revert only tells the truth while nothing has actually been
-        // deleted. Once the first batch has gone out, some of these keys are
-        // gone and some are not, and putting every row back would be as wrong
-        // as leaving them all out - so the bucket gets asked instead.
+        // deleted. Once a batch has come back successfully, some of these keys
+        // are gone and some are not, and putting every row back would be as
+        // wrong as leaving them all out - so the bucket gets asked instead.
+        //
+        // "come back", not "gone out": the flag is set after the await, which
+        // is what makes a first-batch failure revert rather than resync.
         if (anyDispatched) void refreshCurrentData({ silent: true });
         else undoRemoval();
       };

--- a/frontend/src/features/upload/hooks/use-upload-dispatch.test.ts
+++ b/frontend/src/features/upload/hooks/use-upload-dispatch.test.ts
@@ -456,3 +456,99 @@ describe('planning without an api', () => {
     expect(manager.added.map((a) => a.key)).toEqual(['photos/a.jpg']);
   });
 });
+
+/**
+ * What a card carries about where it is going.
+ *
+ * A finished upload adds its own row to the listing it landed in rather than
+ * re-reading whatever prefix the user happens to be standing in. These three
+ * fields are the only thing that makes that possible, and getting the prefix
+ * wrong puts the row in the wrong folder - or in no folder at all.
+ */
+describe('destination on the card', () => {
+  it('points a loose file at the prefix holding it', async () => {
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ individualFiles: [makeFile('notes.txt')] }), 'docs', apiS3);
+
+    expect(uploads()['upload-0']).toMatchObject({
+      key: 'docs/notes.txt',
+      size: 10,
+      destinationPrefix: 'docs/',
+    });
+  });
+
+  it('points a loose file at the root with an empty prefix', async () => {
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ individualFiles: [makeFile('notes.txt')] }), '', apiS3);
+
+    // toCacheKey turns '' into '/', which is how the root listing is keyed.
+    expect(uploads()['upload-0']).toMatchObject({
+      key: 'notes.txt',
+      destinationPrefix: '',
+    });
+  });
+
+  it('points a folder at the listing above it', async () => {
+    const dispatchDrop = dispatch();
+
+    const { dispatched } = await dispatchDrop(
+      drop({ folderStructures: [folder('photos')] }),
+      'docs',
+      apiS3
+    );
+
+    // The plan's own prefix is 'docs/photos/' - it already ends with the
+    // folder's name. The row for it goes one level up.
+    expect(uploads()[dispatched[0]!.taskId]).toMatchObject({
+      name: 'photos',
+      destinationPrefix: 'docs/',
+    });
+  });
+
+  it('points a folder dropped at the root at the root', async () => {
+    const dispatchDrop = dispatch();
+
+    const { dispatched } = await dispatchDrop(
+      drop({ folderStructures: [folder('photos')] }),
+      '',
+      apiS3
+    );
+
+    expect(uploads()[dispatched[0]!.taskId]).toMatchObject({
+      name: 'photos',
+      destinationPrefix: '',
+    });
+  });
+
+  it('names a renamed folder by the name it was actually stored under', async () => {
+    mockFolderExists.mockImplementation(async (_api, prefix: string) => prefix === 'photos/');
+    const dispatchDrop = dispatch();
+
+    const { dispatched } = await dispatchDrop(
+      drop({ folderStructures: [folder('photos')] }),
+      '',
+      apiS3
+    );
+
+    // Adding a row called "photos" for a folder stored as "photos (1)" would
+    // put a folder in the listing that nobody can open.
+    expect(uploads()[dispatched[0]!.taskId]).toMatchObject({
+      name: 'photos (1)',
+      destinationPrefix: '',
+    });
+  });
+
+  it('gives a file inside a folder no destination of its own', async () => {
+    const dispatchDrop = dispatch();
+
+    await dispatchDrop(drop({ folderStructures: [folder('photos')] }), 'docs', apiS3);
+
+    // These are never added one at a time: the folder card adds a single row
+    // for all of them once the last one lands. A destination here would put a
+    // loose file row into a folder listing that is about to be created.
+    expect(uploads()['upload-0']).toMatchObject({ key: 'docs/photos/a.jpg', size: 10 });
+    expect(uploads()['upload-0']!.destinationPrefix).toBeUndefined();
+  });
+});

--- a/frontend/src/features/upload/hooks/use-upload-dispatch.ts
+++ b/frontend/src/features/upload/hooks/use-upload-dispatch.ts
@@ -29,6 +29,7 @@ import { useUploadStore } from '../stores/use-upload-store';
 import { useUploadExecutor } from '../context/upload-context';
 import type { DispatchResult } from '../services/upload-executor';
 import { objectExists, objectKey } from '@/services/object-existence';
+import { getParentPrefix } from '@/features/folder-navigation/folder-navigation';
 import { generateUniqueFileName } from '../utils/unique-filename';
 
 export interface DropOutcome {
@@ -213,6 +214,9 @@ export function useUploadDispatch() {
             progress: 0,
             type: 'folder',
             fileIds: result.files.map((file) => file.uploadId),
+            // A folder plan's prefix already ends with the folder's resolved
+            // name, so the listing that gains a row for it is the one above.
+            destinationPrefix: getParentPrefix(result.plan.prefix),
           });
 
           for (const file of result.files) {
@@ -225,6 +229,11 @@ export function useUploadDispatch() {
               progress: 0,
               type: 'file',
               parentFolderId: result.taskId,
+              key: file.key,
+              size: file.file.size,
+              // Deliberately no destinationPrefix. These files are not added to
+              // any listing one at a time - the folder card above adds a single
+              // row for all of them once the last one lands.
             });
           }
         } else {
@@ -236,6 +245,12 @@ export function useUploadDispatch() {
               status: 'queued',
               progress: 0,
               type: 'file',
+              key: file.key,
+              size: file.file.size,
+              // Read back off the key that will actually be written rather than
+              // taken from the plan, so the prefix is the one the finished row
+              // will be looked up under whatever the key turned out to be.
+              destinationPrefix: getParentPrefix(file.key),
             });
           }
         }

--- a/frontend/src/features/upload/stores/use-upload-store.test.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.test.ts
@@ -4,7 +4,8 @@
  *
  * `@opndrive/s3-api` is mocked at the module boundary - it has its own suite and
  * nothing here should depend on real S3 behaviour. The data context is mocked
- * too, because completing an upload asks it to refresh.
+ * too, because completing an upload reaches into it: to add the row it just
+ * produced, or - when the card cannot say where it landed - to re-read.
  *
  * NOTE: this store also keeps a module-scope `refreshState` object that lives
  * OUTSIDE zustand, so the automatic store reset does not clear it. It debounces
@@ -16,8 +17,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useUploadStore } from './use-upload-store';
 
-const { refreshCurrentData } = vi.hoisted(() => ({
+const { refreshCurrentData, addFile, addFolder, removeFiles } = vi.hoisted(() => ({
   refreshCurrentData: vi.fn(async () => {}),
+  addFile: vi.fn(() => () => {}),
+  addFolder: vi.fn(() => () => {}),
+  removeFiles: vi.fn(() => () => {}),
 }));
 
 vi.mock('@opndrive/s3-api', () => ({
@@ -27,7 +31,7 @@ vi.mock('@opndrive/s3-api', () => ({
 }));
 
 vi.mock('@/context/data-context', () => ({
-  useDriveStore: { getState: () => ({ refreshCurrentData }) },
+  useDriveStore: { getState: () => ({ refreshCurrentData, addFile, addFolder, removeFiles }) },
 }));
 
 const store = () => useUploadStore.getState();
@@ -587,5 +591,163 @@ describe('duplicate prompt queue', () => {
   it('ignores a dismiss when nothing is queued', () => {
     expect(() => store().hideDuplicateDialog()).not.toThrow();
     expect(store().duplicateQueue).toEqual([]);
+  });
+});
+
+/**
+ * Placing the row a finished upload produced.
+ *
+ * The tests above still pass because their cards carry no destination - which
+ * is the fallback, and stays throttled. These cover the path that replaced it.
+ */
+describe('placing the finished row', () => {
+  // Same discipline as 'refresh on completion': the 3s debounce lives outside
+  // zustand, so each test gets a clock that has definitively moved past it.
+  let clock = Date.UTC(2026, 6, 1);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clock += 10 * 60 * 1000;
+    vi.setSystemTime(clock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('adds a loose file to the prefix it landed in', () => {
+    store().addUpload(
+      'u1',
+      upload({
+        status: 'uploading',
+        key: 'docs/a.txt',
+        size: 120,
+        destinationPrefix: 'docs/',
+      })
+    );
+
+    store().updateUpload('u1', { status: 'completed' });
+
+    expect(addFile).toHaveBeenCalledWith('docs/', { key: 'docs/a.txt', size: 120 });
+    // The whole point: the folder the user is standing in is not re-listed
+    // just because something finished somewhere else.
+    expect(refreshCurrentData).not.toHaveBeenCalled();
+  });
+
+  it('clears any row the upload replaced before adding the new one', () => {
+    store().addUpload(
+      'u1',
+      upload({ status: 'uploading', key: 'docs/a.txt', size: 9, destinationPrefix: 'docs/' })
+    );
+
+    store().updateUpload('u1', { status: 'completed' });
+
+    // Answering the duplicate prompt with "replace" overwrites an object that
+    // is already listed. Inserting alone would find the key present and leave
+    // the row describing the version that was replaced.
+    expect(removeFiles).toHaveBeenCalledWith(['docs/a.txt']);
+    expect(removeFiles.mock.invocationCallOrder[0]).toBeLessThan(
+      addFile.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it('places every file of a batch, however fast they land', () => {
+    const ids = Array.from({ length: 10 }, (_, index) => `u${index}`);
+
+    for (const id of ids) {
+      store().addUpload(
+        id,
+        upload({
+          id,
+          status: 'uploading',
+          key: `docs/${id}.txt`,
+          size: 1,
+          destinationPrefix: 'docs/',
+        })
+      );
+    }
+
+    // No clock movement between them: this is ten uploads finishing inside the
+    // same instant, which is exactly what the 3s debounce used to swallow. Nine
+    // of these rows would simply never have appeared.
+    for (const id of ids) store().updateUpload(id, { status: 'completed' });
+
+    expect(addFile).toHaveBeenCalledTimes(10);
+    expect(refreshCurrentData).not.toHaveBeenCalled();
+  });
+
+  it('adds one folder row rather than a row per file', () => {
+    store().addUpload(
+      'folder',
+      upload({
+        id: 'folder',
+        name: 'photos',
+        type: 'folder',
+        status: 'uploading',
+        destinationPrefix: 'docs/',
+      })
+    );
+
+    store().updateUpload('folder', { status: 'completed' });
+
+    expect(addFolder).toHaveBeenCalledWith('docs/', 'photos');
+    expect(addFile).not.toHaveBeenCalled();
+  });
+
+  it('adds nothing for a file still inside an unfinished folder', () => {
+    store().addUpload(
+      'folder',
+      upload({ id: 'folder', type: 'folder', fileIds: ['a', 'b'], destinationPrefix: 'docs/' })
+    );
+    store().addUpload('a', upload({ id: 'a', parentFolderId: 'folder', key: 'docs/p/a.txt' }));
+    store().addUpload('b', upload({ id: 'b', parentFolderId: 'folder', key: 'docs/p/b.txt' }));
+
+    store().updateUpload('a', { status: 'completed' });
+
+    expect(addFile).not.toHaveBeenCalled();
+    expect(addFolder).not.toHaveBeenCalled();
+  });
+
+  it('adds the folder row once its last file lands', () => {
+    store().addUpload(
+      'folder',
+      upload({
+        id: 'folder',
+        name: 'photos',
+        type: 'folder',
+        fileIds: ['a', 'b'],
+        destinationPrefix: 'docs/',
+      })
+    );
+    store().addUpload('a', upload({ id: 'a', parentFolderId: 'folder', status: 'completed' }));
+    store().addUpload('b', upload({ id: 'b', parentFolderId: 'folder' }));
+
+    store().updateUpload('b', { status: 'completed' });
+
+    expect(addFolder).toHaveBeenCalledWith('docs/', 'photos');
+    expect(refreshCurrentData).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a re-read when the card cannot say where it landed', async () => {
+    // A card raised for a dispatch the manager refused never reached the
+    // executor, so it has no key and no destination to place anything with.
+    store().addUpload('u1', upload({ status: 'uploading' }));
+
+    store().updateUpload('u1', { status: 'completed' });
+
+    expect(addFile).not.toHaveBeenCalled();
+    expect(refreshCurrentData).toHaveBeenCalledOnce();
+    await Promise.resolve();
+  });
+
+  it('re-reads silently, over rows that are already up', async () => {
+    store().addUpload('u1', upload({ status: 'uploading' }));
+
+    store().updateUpload('u1', { status: 'completed' });
+
+    // Announcing it as loading, or letting a failure write an error over a
+    // listing the user is reading, is the blanking this change exists to avoid.
+    expect(refreshCurrentData).toHaveBeenCalledWith({ silent: true });
+    await Promise.resolve();
   });
 });

--- a/frontend/src/features/upload/stores/use-upload-store.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.ts
@@ -50,6 +50,57 @@ interface UploadProgress {
   error?: string;
   parentFolderId?: string; // For files that belong to a folder
   fileIds?: string[]; // For folders, track their file IDs
+
+  /**
+   * Where this upload lands, and what it will be once it has.
+   *
+   * A card used to carry nothing but progress, which is why finishing one could
+   * do no better than re-list whatever prefix the user happened to be standing
+   * in - the wrong folder entirely once they had walked away from the one they
+   * uploaded into, and two full listings of a thousand objects either way.
+   * These three are what let a finished upload add its own row instead.
+   *
+   * `destinationPrefix` is the listing that gains a row: for a file the prefix
+   * holding it, for a folder the prefix *above* it, since the folder's own name
+   * is already in `name`. `key` and `size` describe the object itself and are a
+   * file's alone.
+   *
+   * All optional, because a card can exist without ever having reached the
+   * executor - the one raised for a dispatch the manager refused has no
+   * destination to speak of, and falls back to a re-read.
+   */
+  key?: string;
+  size?: number;
+  destinationPrefix?: string;
+}
+
+/**
+ * Adds the row a finished upload produced to the listing it landed in.
+ *
+ * @returns false when the card does not carry enough to place a row, leaving
+ * the caller to fall back to a re-read.
+ */
+function placeFinishedUpload(upload: UploadProgress): boolean {
+  if (upload.destinationPrefix === undefined) return false;
+
+  const { addFile, addFolder, removeFiles } = useDriveStore.getState();
+
+  if (upload.type === 'folder') {
+    addFolder(upload.destinationPrefix, upload.name);
+    return true;
+  }
+
+  if (upload.key === undefined) return false;
+
+  // Out and back in rather than a plain insert. An upload that answered the
+  // duplicate prompt with "replace" has overwritten an object that is already
+  // listed, and inserting would find the key present and leave that row showing
+  // the size and time of the version it replaced. Removing first is a no-op
+  // when there was nothing there, which is the ordinary case.
+  removeFiles([upload.key]);
+  addFile(upload.destinationPrefix, { key: upload.key, size: upload.size });
+
+  return true;
 }
 
 interface DeleteProgress {
@@ -57,13 +108,30 @@ interface DeleteProgress {
   name: string;
   status: 'queued' | 'deleting' | 'completed' | 'failed' | 'cancelled';
   progress: number;
-  type: 'file' | 'folder';
+  /**
+   * What is being deleted, which is what picks the card's icon.
+   *
+   * 'mixed' exists because a multi-select is not necessarily either. Batch
+   * deletes used to hardcode 'folder' here to get *an* icon, so deleting a
+   * single photo drew a folder - and a selection of eight files drew a folder
+   * too, next to a label that correctly read "Deleting 8 files".
+   */
+  type: 'file' | 'folder' | 'mixed';
   size?: number;
   totalFiles?: number;
   completedFiles?: number;
   operationLabel?: string;
   extension?: string;
   isCalculatingSize?: boolean;
+  /**
+   * The names of what is being deleted, for a card that would otherwise only
+   * say how many.
+   *
+   * Precomputed to a single string rather than an array: the operations panel
+   * memoises each row on shallow-equal props, and an array rebuilt on every
+   * render defeats that for every row at once.
+   */
+  detail?: string;
   /**
    * Created and owned by the store, never by a component. See
    * `startDeleteOperation` for why.
@@ -208,19 +276,28 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
       },
     }));
 
-    // Smart refresh on upload completion
+    // A finished upload adds its own row. Only a card that cannot say where it
+    // landed falls back to re-listing.
     if (updates.status === 'completed') {
       const { refreshDataAfterUploadBatch } = get();
       const state = get();
       const completedUpload = state.uploads[id];
 
-      if (completedUpload.type === 'file' && !completedUpload.parentFolderId) {
-        // Individual file completed (not part of a folder) - refresh immediately
+      const placeOrRefresh = (upload: UploadProgress) => {
+        if (placeFinishedUpload(upload)) return;
+
         refreshDataAfterUploadBatch().catch(() => {
           // Silently handle refresh errors
         });
+      };
+
+      if (completedUpload.type === 'file' && !completedUpload.parentFolderId) {
+        // A loose file, which is one row in the prefix it was dropped into.
+        placeOrRefresh(completedUpload);
       } else if (completedUpload.type === 'file' && completedUpload.parentFolderId) {
-        // File is part of a folder - check if entire folder is complete
+        // A file inside a folder. Nothing is added for it on its own: the
+        // listing that changes is the one *above* the folder, and it gains a
+        // single row for the folder itself, once every file in it has landed.
         const parentFolderId = completedUpload.parentFolderId;
         const folderUpload = state.uploads[parentFolderId];
 
@@ -231,17 +308,10 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
             return fileUpload && fileUpload.status === 'completed';
           });
 
-          if (allFilesCompleted) {
-            refreshDataAfterUploadBatch().catch(() => {
-              // Silently handle refresh errors
-            });
-          }
+          if (allFilesCompleted) placeOrRefresh(folderUpload);
         }
       } else if (completedUpload.type === 'folder') {
-        // Folder upload completed - refresh immediately
-        refreshDataAfterUploadBatch().catch(() => {
-          // Silently handle refresh errors
-        });
+        placeOrRefresh(completedUpload);
       }
     }
   },
@@ -469,7 +539,17 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
       duplicateQueue: state.duplicateQueue.slice(1),
     })),
 
-  // Simple immediate data refresh on upload completion
+  /**
+   * The fallback, for an upload that finished without enough on its card to
+   * place a row of its own.
+   *
+   * Still throttled, because this is the expensive path - two full listings of
+   * the prefix - and several landing together would each pay for it.
+   *
+   * Nothing throttles the row placement this now stands behind, and nothing
+   * may: ten files finishing inside the same second each add their own row, and
+   * a throttle there would silently drop nine of them.
+   */
   refreshDataAfterUploadBatch: async (): Promise<void> => {
     const now = Date.now();
 
@@ -487,7 +567,11 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
     try {
       // Get refreshCurrentData function from data context
       const { refreshCurrentData } = useDriveStore.getState();
-      await refreshCurrentData();
+
+      // Silent: this runs over a listing that is already on screen, so it must
+      // not announce itself as loading, and a failure must not replace those
+      // rows with an error notice.
+      await refreshCurrentData({ silent: true });
     } finally {
       refreshState.isRefreshing = false;
     }
@@ -498,7 +582,7 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
 
     try {
       const { refreshCurrentData } = useDriveStore.getState();
-      await refreshCurrentData();
+      await refreshCurrentData({ silent: true });
     } finally {
       refreshState.isRefreshing = false;
       refreshState.lastRefreshAttempt = Date.now();

--- a/frontend/src/shared/components/custom-aria-label.tsx
+++ b/frontend/src/shared/components/custom-aria-label.tsx
@@ -116,7 +116,11 @@ export function CustomAriaLabel({
 
     if (triggerRef.current) {
       const temp = document.createElement('div');
-      temp.className = `custom-aria-label ${position} ${multiline ? 'multiline' : ''}`;
+      // `className` included, because it is part of what the tooltip is
+      // rendered with below. Measuring without it sizes a different element
+      // than the one that appears, so a caller whose class changes the width -
+      // a list, say - gets positioned off the edge it was supposed to avoid.
+      temp.className = `custom-aria-label ${position} ${multiline ? 'multiline' : ''} ${className}`;
       Object.assign(temp.style, {
         visibility: 'hidden',
         position: 'fixed',


### PR DESCRIPTION
Every file operation ended in `refreshCurrentData`, which re-lists a whole prefix **twice** — once for the directory, once for the recent-items panel, each up to 1000 objects — and always the prefix the *user* is standing in, whatever prefix the *operation* actually touched.

## What that cost

- **Drag & drop into another folder.** You're in `/Documents`, you drop a file on the `Photos/` row. `/Documents` gets re-listed — the folder that didn't change — and `Photos/` is never updated, so walking into it later shows stale data.
- **Delete 20 files** → a refresh awaited *per file*, in series. 40 full listings for one action.
- **Create one folder** → 3 full listings. `createFolder` did its own, then all three of its callers added `refreshCurrentData` on top.
- **Drop 10 files at once** → a 3s debounce on the post-upload refresh swallowed nine of them, so those rows simply never appeared.

## What replaces it

The drive store edits the rows it already knows changed: `removeFiles`, `addFile`, `addFolder`, `renameFile`, `renameFolder`. Each rewrites the affected listing — and the recent list behind it, pagination offsets included — and returns **the inverse of what it did**, so an operation whose request then fails puts back what it took and nothing else.

Inverse-operation rather than snapshot-restore, deliberately: restoring the array a row sat in would also restore everything a *concurrent* operation had removed from it. Delete two files while an upload is in flight, let the upload fail, and both deleted files come back. There's a test for exactly that interleaving.

Uploads now carry the key, size and destination they landed at, so a finished upload adds its own row instead of asking where the user happens to be.

A re-read still happens where the outcome is genuinely unknown — a partly-failed batch delete, a folder rename that left copies behind — but **silently**: it doesn't announce itself as loading, and a failure no longer replaces rows that are still on screen with a full-page error notice.

## Also in here

Same operations, surfaced while working on them:

- **The delete card** drew a folder icon for everything (`type: 'folder'` was hardcoded "for batch operations"), painted success in the same red as failure, and showed **no reason at all** for a failed delete — it matched on status `'error'`, which deletes never use, so every `describeFailures` summary was built, stored, and dropped at the last step. It now names what it's deleting, lists the files behind an info icon, and reports which objects S3 refused and why. None of that costs a request: S3 returns per-object failures inline in the same `DeleteObjects` response.
- **The multi-select confirmation** listed every name comma-joined into one paragraph with no cap, and never mentioned that deleting a folder takes its contents with it.
- **`RenameProvider`** declared its hooks after two early returns, so signing out would have crashed the dashboard on a changed hook count. Hooks now come first; `renameService` is memoised, which also settles a stale closure that would have kept talking to the previous bucket after a switch.

---

# How to test

Open **DevTools → Network** and filter for the S3 list request (`ListObjectsV2`, or the POST to your bucket). **That request count is the whole test.**

One thing *not* to look for: there was never a visible "skeleton flash" during these refreshes — a listing that already had rows stayed on screen. What you're checking is **network calls, speed, and whether the right folder updates**.

### 1. Drag & drop into a folder you're not inside — the headline fix

Stand in `/Documents`. Drag a file from your desktop onto the `Photos/` folder row.

- **Before:** `/Documents` re-lists twice (~2000 objects) though nothing in it changed, and `Photos/` is never updated.
- **Now:** zero list requests. Open `Photos/` → your file is there.

### 2. Upload 10 files at once

Drag 10 small files in together.

- **Before:** the 3s debounce fired one refresh and swallowed nine. Some rows never appeared.
- **Now:** all 10 rows appear. Zero list requests.

### 3. Delete

| Action | Expect |
| --- | --- |
| Delete one file | Row vanishes **immediately**, before the request finishes. 0 listings |
| Multi-select 20 → delete | All 20 vanish at once. One batch call, 0 listings |
| Delete a folder | Row goes, 0 listings |
| Delete the folder you're *inside* | You're moved to the parent (that redirect is intentional) |

### 4. Create a folder

Sidebar → New Folder.

- **Before:** three full listings for one folder. **Now:** zero. Row appears instantly, in correct sorted position.

### 5. Rename

Rename `zebra.txt` → `apple.txt`. Zero listings — and check the row **moves to its correct alphabetical position**, not just relabels in place.

### 6. The delete card

- Delete **8 JSON files** → JSON icon (not a folder, not a `?`), "8 items", and an **ⓘ** beside it. Hover the ⓘ → the eight filenames, one per line. Tab to it too — it should show on focus.
- Delete **8 files of mixed types** → stacked-files icon instead, since no single icon is true of all of them.
- Delete **one** file → its own name and icon, no ⓘ (the name *is* the file).
- A finished delete should read **muted, not red**. Red is now reserved for actual failures.

### 7. The delete confirmation

- Multi-select 8 files → Delete. Names are listed **one per line**, capped at 8 with "and N more" — not one comma-joined paragraph.
- Select a **folder** among them → the dialog must say "Deleting a folder also deletes everything inside it." Folders show with a trailing `/`.

### 8. Rollbacks — force the failures

DevTools → Network → **Offline**, then act. Turn it off afterwards.

| Do this offline | Expect |
| --- | --- |
| Delete one file | Row vanishes → **comes back** + error toast |
| Rename a file | Name changes → **reverts** + error toast |
| Create a folder | Row appears → **disappears** |
| Multi-select delete | Rows vanish → **all come back** (nothing reached the bucket) |

That last row is the bug fixed by moving `anyDispatched` after the request. Previously it read a first-batch failure as a partial success and resynced — and the resync is silent, so offline it changed nothing and the rows stayed gone having never been deleted.

**The concurrency case worth doing by hand:** start a large upload, and *while it's uploading*, delete two other files. Then kill the upload (go Offline). The two deleted files should stay gone. A snapshot-restoring rollback would resurrect them.

### 9. Regression checks

- **Folder with >1000 objects:** "Show more" still pages correctly. Delete a row, then "Show more" — no duplicates, no skipped items.
- **Recent items** on `/dashboard`: upload a file → appears at the top; "View more" doesn't repeat or skip an entry.
- **Search** a prefix, then delete a file from those results — you stay on the results page.
- **Sign out while on the dashboard** — should not crash. This is the `RenameProvider` hook-order fix; before, the hook count changed between renders and React threw.
- **Log out mid-delete** — no error toast, no resurrected rows.

---

## Verification

- `tsc --noEmit` clean, `eslint frontend/` 0 errors, Prettier clean
- **77 files, 1465 tests passing** (up from 1385 on main)

Roughly 60 new tests, weighted toward the failure paths since that's where the risk is: rollback under a concurrent delete, a first-batch failure reverting rather than resyncing, restoring the last row of a truncated listing, renaming onto a name that's already taken.

Several bugs were found by *writing* the test rather than by reading the code — the `lastModified` drop in `renameFile`, and a truncation bug in the forward rename path that made renaming the last row of a large folder look like a deletion. Component-level tests for the delete card exist because that bug was "computed but never displayed", which no store test can catch.

## Review notes

- Built on #199, so it uses `drive-item.ts` — the local `isFolderish` helper I'd been carrying is gone in favour of `isFile` / `isFolderLike`.
- The second commit is my own read-through of the branch: dropped `invalidatePrefix` (superseded by `addFile`, no callers left) and corrected two comments that described code which had since moved.
- `browse/page.tsx` selects `state.cache` whole, so it still re-renders on any mutation. That's deliberate there — it indexes by prefix — and left alone as a separate ticket.
