### PR TITLE
fix: clip the grid card's thumbnail to its rounded corners

### DIFF
--- a/.changeset/grid-card-thumbnail-corners.md
+++ b/.changeset/grid-card-thumbnail-corners.md
@@ -1,0 +1,18 @@
+---
+'frontend': patch
+---
+
+Clip the grid card's thumbnail to the card's rounded corners
+
+The card is `rounded-lg` but never clipped its children, and the thumbnail is a
+square box sitting flush in the top two corners. So the radius only ever applied
+to the background, and the thumbnail painted straight over the curve.
+
+It was only obvious on files with an image preview, because those fill the box
+edge to edge with an opaque photo, while a file without one gets a pale tint
+that hides the same overflow. Selecting made it worse again: a selected card
+draws a 2px outline, outlines follow `border-radius`, so a clean rounded corner
+had two square image corners crossing it.
+
+The grid skeleton has always drawn its placeholder with `rounded-t-lg`, so this
+is the shape the card was meant to have all along.

--- a/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
+++ b/frontend/src/features/dashboard/components/ui/items/file-item-grid.tsx
@@ -165,7 +165,16 @@ export function FileItemGrid({
       role="button"
       tabIndex={0}
       aria-label={`${file.name}, file${selected ? ', selected' : ''}`}
-      className="group relative rounded-lg bg-secondary/50 hover:bg-secondary/80 transition-all cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-primary"
+      /* overflow-hidden because the thumbnail is a square box sitting flush in
+         the top corners, so without it the card's radius is only on the
+         background and the image paints straight over the curve. It shows up
+         worst when selected, where the outline traces a clean rounded corner
+         and the image crosses it. The grid skeleton already draws its
+         placeholder with rounded-t-lg, which is the shape being matched here.
+         Nothing else is clipped by this: the focus ring is a box-shadow and
+         the selected outline is drawn outside the border box, and the overflow
+         menu portals out to the body. */
+      className="group relative overflow-hidden rounded-lg bg-secondary/50 hover:bg-secondary/80 transition-all cursor-pointer select-none focus-visible:ring-2 focus-visible:ring-primary"
       style={{
         outline: selected ? '2px solid var(--primary)' : 'none',
         background: selected ? 'var(--accent)' : undefined,


### PR DESCRIPTION
The grid card is `rounded-lg` but never clipped its children, and the thumbnail is a square box sitting flush in the top two corners. So the radius only applied to the background and the thumbnail painted over the curve.

Only visible on files with an image preview, since those fill the box with an opaque photo while other files get a pale tint that hides the same overflow. Worst when selected, because the selected outline follows the radius and the square image corners cross it.

Fixed by adding `overflow-hidden` to the card. Covers both the Suggested Files grid and the search page, since they share the component.

## How to test

Dashboard, Suggested Files in grid layout. Select an image file and a non image file and compare their top corners. They should now match.
