### PR TITLE
feat: delete the selection with the Delete key

### DIFF
--- a/.changeset/delete-key-deletes-selection.md
+++ b/.changeset/delete-key-deletes-selection.md
@@ -1,0 +1,23 @@
+---
+'frontend': patch
+---
+
+Delete the selection with the Delete key
+
+Selecting files or folders and pressing Delete now does what the toolbar's
+delete button does, confirmation dialog and all. A key that is quick to hit is
+the last one that should skip the warning about a folder taking everything
+inside it.
+
+The listener is mounted by the multi-select toolbar and only while something is
+selected, rather than sitting on the window for the whole session.
+
+Four presses are deliberately left alone: a held key, which would otherwise
+stack a confirmation per repeat; any modifier combination, which belongs to the
+browser or the operating system; a press while typing in a field, since removing
+a character in the search box must not remove the files behind it; and a press
+while a dialog is open, which matters most for the confirmation this raises
+itself, where it would let one press start the next delete.
+
+Backspace is not bound. It is "go back" in too many places to take over for
+something that cannot be undone.

--- a/frontend/src/features/dashboard/components/ui/multi-select-toolbar.tsx
+++ b/frontend/src/features/dashboard/components/ui/multi-select-toolbar.tsx
@@ -15,6 +15,7 @@ import {
 import { FolderOpen } from 'lucide-react';
 import { AriaLabel } from '@/shared/components/custom-aria-label';
 import { useMultiSelectActions } from '../../hooks/use-multi-select-actions';
+import { useDeleteKey } from '../../hooks/use-delete-key';
 import { FileItem } from '../../types/file';
 import { Folder } from '../../types/folder';
 import { generateFolderUrl } from '@/features/folder-navigation/folder-navigation';
@@ -126,6 +127,16 @@ export function MultiSelectToolbar({
     setMoreMenuAnchor(event.currentTarget as HTMLElement);
     setIsMoreMenuOpen(true);
   };
+
+  /**
+   * Delete does what the toolbar's own delete button does, confirmation and
+   * all. Declared above the `count === 0` return below, because a hook cannot
+   * sit behind one - and gated on `canDelete` instead, which is the same
+   * condition the button is disabled by.
+   */
+  useDeleteKey(() => {
+    void handleDeleteItems(selectedItems);
+  }, canDelete);
 
   const handleMoreMenuClose = () => {
     setIsMoreMenuOpen(false);

--- a/frontend/src/features/dashboard/hooks/use-delete-key.test.tsx
+++ b/frontend/src/features/dashboard/hooks/use-delete-key.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Delete removes the selection, and the cases where it must not.
+ *
+ * The guards are the whole substance of this hook: the delete itself is the
+ * toolbar's existing path. What is worth pinning is every press that has to be
+ * left alone, because getting one of those wrong destroys a user's files.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDeleteKey } from './use-delete-key';
+
+function press(key: string, init: KeyboardEventInit = {}, target?: Element) {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init });
+  (target ?? window).dispatchEvent(event);
+  return event;
+}
+
+let onDelete: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  onDelete = vi.fn();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('useDeleteKey', () => {
+  it('deletes the selection on Delete', () => {
+    renderHook(() => useDeleteKey(onDelete, true));
+
+    press('Delete');
+
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it('stops the browser acting on the same press', () => {
+    renderHook(() => useDeleteKey(onDelete, true));
+
+    expect(press('Delete').defaultPrevented).toBe(true);
+  });
+
+  it('does nothing without a selection', () => {
+    // The toolbar is mounted on every dashboard page and renders nothing until
+    // something is selected, so the flag is what keeps this off the window.
+    renderHook(() => useDeleteKey(onDelete, false));
+
+    press('Delete');
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('ignores every other key', () => {
+    renderHook(() => useDeleteKey(onDelete, true));
+
+    press('Backspace');
+    press('Enter');
+    press('d');
+
+    // Backspace especially: it is "go back" in too many places to take over
+    // for something that cannot be undone.
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('ignores a held key', () => {
+    renderHook(() => useDeleteKey(onDelete, true));
+
+    press('Delete', { repeat: true });
+
+    // Otherwise leaning on the key stacks one confirmation per repeat.
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it.each(['altKey', 'ctrlKey', 'metaKey', 'shiftKey'] as const)(
+    'ignores Delete held with %s',
+    (modifier) => {
+      renderHook(() => useDeleteKey(onDelete, true));
+
+      press('Delete', { [modifier]: true });
+
+      expect(onDelete).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['input', 'textarea', 'select'])('ignores a press while typing in a %s', (tag) => {
+    const field = document.createElement(tag);
+    document.body.appendChild(field);
+    renderHook(() => useDeleteKey(onDelete, true));
+
+    press('Delete', {}, field);
+
+    // Removing a character in the search box must not remove the files behind
+    // it, and both are reachable at the same time.
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('ignores a press in a contenteditable', () => {
+    const field = document.createElement('div');
+    field.contentEditable = 'true';
+    Object.defineProperty(field, 'isContentEditable', { value: true });
+    document.body.appendChild(field);
+    renderHook(() => useDeleteKey(onDelete, true));
+
+    press('Delete', {}, field);
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('ignores a press while a dialog is open', () => {
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    document.body.appendChild(dialog);
+    renderHook(() => useDeleteKey(onDelete, true));
+
+    press('Delete');
+
+    // This one matters most for the confirmation the delete itself raises:
+    // without it the press that confirmed one delete would start the next.
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('acts again once the dialog is gone', () => {
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    document.body.appendChild(dialog);
+    renderHook(() => useDeleteKey(onDelete, true));
+
+    press('Delete');
+    dialog.remove();
+    press('Delete');
+
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it('calls the newest handler, not the one it mounted with', () => {
+    const replacement = vi.fn();
+    const { rerender } = renderHook(({ handler }) => useDeleteKey(handler, true), {
+      initialProps: { handler: onDelete as () => void },
+    });
+
+    rerender({ handler: replacement as () => void });
+    press('Delete');
+
+    // The toolbar re-renders on every selection change, so the handler is a
+    // fresh closure each time and the listener must not hold the stale one.
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(replacement).toHaveBeenCalledOnce();
+  });
+
+  it('stops listening once unmounted', () => {
+    const { unmount } = renderHook(() => useDeleteKey(onDelete, true));
+
+    unmount();
+    press('Delete');
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/dashboard/hooks/use-delete-key.ts
+++ b/frontend/src/features/dashboard/hooks/use-delete-key.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Whether this press is somebody typing rather than acting on a selection.
+ *
+ * Delete is an ordinary editing key. The search box, the rename dialog and the
+ * create-folder field are all reachable while a selection exists, and removing
+ * a character in one of them must not remove the files behind it.
+ */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+/**
+ * Whether a modal is up, in which case the key belongs to it.
+ *
+ * Both kinds in this app carry `role="dialog"` - Radix's own and the
+ * hand-rolled preview modal - and neither is in the document while closed. It
+ * matters most for the confirmation this very feature raises: without it, the
+ * press that confirmed one delete could start the next.
+ */
+function aDialogIsOpen(): boolean {
+  return document.querySelector('[role="dialog"]') !== null;
+}
+
+/**
+ * Runs `onDelete` when Delete is pressed, while `enabled`.
+ *
+ * The toolbar that mounts this is rendered on every dashboard page and returns
+ * null without a selection, so the flag is what keeps the listener off the
+ * window for the whole session rather than only while there is something to
+ * act on.
+ *
+ * Backspace is deliberately not bound. It is "go back" in too many places to
+ * take over for a destructive action.
+ */
+export function useDeleteKey(onDelete: () => void, enabled: boolean): void {
+  // Kept in a ref so a toolbar re-render - which happens on every selection
+  // change - does not tear the listener down and put an identical one back.
+  const latest = useRef(onDelete);
+  useEffect(() => {
+    latest.current = onDelete;
+  }, [onDelete]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Delete') return;
+      // A held key would otherwise stack a confirmation per repeat.
+      if (event.repeat) return;
+      // Modifier combinations belong to the browser or the OS.
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+      if (isTypingTarget(event.target)) return;
+      if (aDialogIsOpen()) return;
+
+      event.preventDefault();
+      latest.current();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [enabled]);
+}


### PR DESCRIPTION
Select files or folders, press **Delete**. Runs the same path as the toolbar's delete button, so the confirmation dialog and the folder warning still apply.

The listener lives on the multi-select toolbar and only while something is selected. Backspace is not bound.

Four presses are ignored: a held key, any modifier combination, typing in a field, and any press while a dialog is open.

## How to check

1. Select a file, press Delete. Same confirm dialog as the toolbar button.
2. Press Delete again **while that dialog is open**. Nothing should happen.
3. Select a file, click into the search box, type, press Delete. It edits your text, nothing is deleted.
4. Select a file and hold Delete. Exactly one dialog.
5. Press Delete with nothing selected. Nothing happens.

Steps 2 and 3 are where this usually goes wrong.

Note: verified by tests and typecheck, not in a browser.
