### PR TITLE
fix: make the empty state artwork a background image

### DIFF
--- a/.changeset/empty-state-artwork.md
+++ b/.changeset/empty-state-artwork.md
@@ -1,0 +1,14 @@
+---
+'frontend': patch
+---
+
+Stop the empty state artwork from eating a drag
+
+The "no files or folders" illustration was an `<img>`, so the browser treated it
+as draggable content of its own. Dropping files onto the middle of the empty
+page, which is where the artwork sits, started an image drag instead of an
+upload, and dragging the picture around the page was possible for no reason.
+
+It is a background image now, which the browser will not pick up, and the whole
+empty state block ignores pointer events so the dropzone underneath receives the
+drag wherever you aim it.

--- a/frontend/src/features/dashboard/components/views/home/empty-state-dropzone.tsx
+++ b/frontend/src/features/dashboard/components/views/home/empty-state-dropzone.tsx
@@ -57,24 +57,21 @@ export function EmptyStateDropzone({ onFilesDropped, className = '' }: EmptyStat
         ></div>
       ) : null}
 
-      {/* Empty State Content */}
-      <div className="text-center mx-auto py-16">
+      {/* Empty State Content. Purely decorative, so it never swallows a drag:
+          the artwork is a background image (an <img> can be picked up and
+          dragged around by the browser) and the whole block ignores pointers. */}
+      <div className="text-center mx-auto py-16 pointer-events-none select-none">
         {/* Home Image */}
         <div className="mb-2 flex justify-center">
-          <div
-            className="relative w-80 rounded-lg overflow-hidden"
-            style={
-              {
-                //   background: 'var(--muted)',
-                //   border: '1px solid var(--border)'
-              }
-            }
-          >
-            <img
-              src="/home.png"
-              alt="Welcome to Opndrive"
-              className="w-full h-full object-contain p-4"
-              style={{ filter: 'brightness(0.9)' }}
+          <div className="w-80 p-4">
+            <div
+              role="img"
+              aria-label="Welcome to Opndrive"
+              className="w-full aspect-[1024/853] bg-contain bg-center bg-no-repeat"
+              style={{
+                backgroundImage: 'url(/home.png)',
+                filter: 'brightness(0.9)',
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
The "no files or folders" illustration was an `<img>`, so the browser let you pick it up and drag it around. Dropping files onto the middle of the empty page, which is exactly where the artwork sits, started an image drag instead of an upload.

It is a background image now, which the browser will not drag, and the empty state block ignores pointer events so the dropzone underneath gets the drag wherever you aim it. Layout is unchanged.