### PR TITLE
fix: stop a cancelled upload from starting the ones behind it

### DIFF
--- a/.changeset/cancel-does-not-start-new-uploads.md
+++ b/.changeset/cancel-does-not-start-new-uploads.md
@@ -1,0 +1,31 @@
+---
+'@opndrive/s3-api': patch
+'frontend': patch
+---
+
+Stop a cancelled upload from starting the uploads behind it
+
+Cancelling a folder mid-upload cancels its files one after another, and for the
+whole of that pass the queue is still full of files that are about to be
+cancelled too. `cancelUpload` pumped the queue on its way out, which handed the
+slots the running uploads had just given up straight to them: each one started,
+a `CreateMultipartUpload` and a CORS preflight apiece, moments before its own
+cancellation arrived. Cancelling 3000 files fired off 1498 uploads it then had
+to abort. The pump is deferred by a microtask now, so it runs after the caller
+has finished cancelling and only work nobody cancelled is left to start.
+
+Half of those doomed uploads were also leaked. `MultipartUploader.cancel()`
+aborts the session S3 has open, but only if it has an upload id yet - and these
+were cancelled while `CreateMultipartUpload` was still in flight, so it had
+nothing to abort and returned. The id arrived a moment later with nobody left to
+use it, leaving an incomplete multipart upload in the bucket that no listing
+shows and nothing ever closes, billed until a lifecycle rule expires it.
+`start()` now sends that abort itself, and skips the create entirely when the
+cancel got there first.
+
+The freeze itself was mostly somewhere else. Every one of those events was
+written into the upload store on its own, and each write copied the whole record
+and woke every subscriber, so a cancelled folder cost N copies of an N-entry
+object. Measured over 3000 files that was 9.3 seconds of blocked main thread.
+Manager events are now collected per tick and applied in one write: the same
+3000 files take 9ms. Progress ticks during an ordinary upload go the same way.

--- a/frontend/src/features/upload/context/upload-context.test.tsx
+++ b/frontend/src/features/upload/context/upload-context.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/hooks/use-auth', () => ({
 }));
 
 import { UploadProvider, useUploadExecutor } from './upload-context';
+import { useUploadStore } from '../stores/use-upload-store';
 import { useUploadQueueStore, type PlannedUpload } from '../stores/use-upload-queue-store';
 import type { UploadExecutor } from '../services/upload-executor';
 
@@ -145,5 +146,81 @@ describe('executor lifecycle', () => {
     const { executor } = mountProvider(false);
 
     expect(executor()).toBeNull();
+  });
+});
+
+describe('manager events into the store', () => {
+  /** One queued card per id, so the store has something to update. */
+  const seedUploads = (count: number) => {
+    const { addUpload } = useUploadStore.getState();
+    for (let i = 0; i < count; i++) {
+      addUpload(`u-${i}`, {
+        id: `u-${i}`,
+        name: `f${i}.txt`,
+        status: 'queued',
+        progress: 0,
+        type: 'file',
+      });
+    }
+  };
+
+  beforeEach(() => {
+    useUploadStore.setState({ uploads: {} });
+  });
+
+  it('writes one batch for a burst of events', async () => {
+    mountProvider(false);
+    seedUploads(50);
+
+    let writes = 0;
+    const stop = useUploadStore.subscribe(() => {
+      writes++;
+    });
+
+    // What cancelling a folder looks like from here: every file reporting in,
+    // one after another, inside a single tick.
+    await act(async () => {
+      for (let i = 0; i < 50; i++) {
+        manager.emit('statusChange', { id: `u-${i}`, status: 'cancelled', progress: 0 });
+      }
+    });
+    stop();
+
+    // Fifty separate writes each copied the whole uploads record and woke every
+    // subscriber. That is the quadratic cost that froze the tab.
+    expect(writes).toBe(1);
+    expect(
+      Object.values(useUploadStore.getState().uploads).every((u) => u.status === 'cancelled')
+    ).toBe(true);
+  });
+
+  it('keeps only the last state a file reported in a tick', async () => {
+    mountProvider(false);
+    seedUploads(1);
+
+    await act(async () => {
+      manager.emit('statusChange', { id: 'u-0', status: 'uploading', progress: 0 });
+      manager.emit('progress', { id: 'u-0', status: 'uploading', progress: 60 });
+      manager.emit('statusChange', { id: 'u-0', status: 'completed', progress: 100 });
+    });
+
+    const upload = useUploadStore.getState().uploads['u-0']!;
+    expect(upload.status).toBe('completed');
+    expect(upload.progress).toBe(100);
+  });
+
+  it('writes what is still buffered when the manager goes away', () => {
+    const { unmount } = mountProvider(false);
+    seedUploads(1);
+
+    // No tick between the event and the teardown, which is what disposing the
+    // managers on logout does. Dropping it would leave the card at 'uploading'
+    // with nothing left to move it.
+    act(() => {
+      manager.emit('statusChange', { id: 'u-0', status: 'cancelled', progress: 0 });
+      unmount();
+    });
+
+    expect(useUploadStore.getState().uploads['u-0']!.status).toBe('cancelled');
   });
 });

--- a/frontend/src/features/upload/context/upload-context.tsx
+++ b/frontend/src/features/upload/context/upload-context.tsx
@@ -25,7 +25,7 @@ const UploadContext = createContext<UploadContextValue>({ executor: null });
 export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   // Field selector: this provider wraps the whole dashboard, so subscribing to
   // the entire upload store would re-render every page on each progress tick.
-  const updateUpload = useUploadStore((state) => state.updateUpload);
+  const updateUploads = useUploadStore((state) => state.updateUploads);
   const uploadManager = useActiveUploadManager();
 
   const [executor, setExecutor] = useState<UploadExecutor | null>(null);
@@ -63,8 +63,48 @@ export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     };
   }, [uploadManager]);
 
+  /**
+   * Manager events into the store, a tick at a time.
+   *
+   * One event arrives per file, and the manager can emit thousands of them in a
+   * single synchronous burst - cancelling a folder is exactly that. Writing
+   * each one straight into the store copied the whole `uploads` record and woke
+   * every subscriber, once per file, which is quadratic work in the size of the
+   * drop and is what made the tab stop responding.
+   *
+   * So events are collected and written once per tick instead. A microtask is
+   * late enough to catch a whole synchronous burst and early enough that a
+   * single upload's progress still lands in the same tick it happened, so
+   * nothing on screen lags behind.
+   */
   useEffect(() => {
     if (!uploadManager) return;
+
+    let pending = new Map<string, { status: UploadStatus; progress: number }>();
+    let flushScheduled = false;
+
+    const flush = () => {
+      flushScheduled = false;
+      if (pending.size === 0) return;
+
+      const batch = [...pending].map(([id, changes]) => ({ id, changes }));
+      // Swapped rather than cleared, so an event emitted by a subscriber
+      // reacting to this write starts a fresh batch instead of being dropped
+      // from the one being sent.
+      pending = new Map();
+      updateUploads(batch);
+    };
+
+    const record = (id: string, status: UploadStatus, progress: number) => {
+      // Last write wins per file: within one tick an upload can go queued ->
+      // uploading -> completed, and only where it ended up matters.
+      pending.set(id, { status, progress });
+
+      if (flushScheduled) return;
+      flushScheduled = true;
+      queueMicrotask(flush);
+    };
+
     const handleStatusChange = ({
       id,
       status,
@@ -74,7 +114,7 @@ export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       status: UploadStatus;
       progress: number;
     }) => {
-      updateUpload(id, { status, progress });
+      record(id, status, progress);
     };
 
     const handleProgress = ({
@@ -86,7 +126,7 @@ export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       progress: number;
       status: UploadStatus;
     }) => {
-      updateUpload(id, { progress, status });
+      record(id, status, progress);
     };
 
     uploadManager.on('statusChange', handleStatusChange);
@@ -96,8 +136,12 @@ export const UploadProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     return () => {
       uploadManager.off('statusChange', handleStatusChange);
       uploadManager.off('progress', handleProgress);
+      // Whatever is still buffered is usually the terminal event for an upload
+      // the manager has just given up on, so it is written rather than dropped
+      // - otherwise a card sits at 'uploading' with nothing left to move it.
+      flush();
     };
-  }, [uploadManager, updateUpload]);
+  }, [uploadManager, updateUploads]);
 
   const value = useMemo(() => ({ executor }), [executor]);
 

--- a/frontend/src/features/upload/stores/use-upload-store.test.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.test.ts
@@ -131,6 +131,85 @@ describe('upload tracking', () => {
   });
 });
 
+describe('updating many uploads at once', () => {
+  it('applies every change in a single write', () => {
+    for (let i = 0; i < 20; i++) {
+      store().addUpload(`u${i}`, upload({ id: `u${i}`, status: 'uploading' }));
+    }
+
+    let writes = 0;
+    const stop = useUploadStore.subscribe(() => {
+      writes++;
+    });
+
+    store().updateUploads(
+      Array.from({ length: 20 }, (_, i) => ({ id: `u${i}`, changes: { status: 'cancelled' } }))
+    );
+    stop();
+
+    // One copy of the record and one notification, not twenty of each. Applied
+    // one at a time this is quadratic in the size of the drop, which is what
+    // locked the tab up when a large folder was cancelled.
+    expect(writes).toBe(1);
+    expect(Object.values(store().uploads).every((u) => u.status === 'cancelled')).toBe(true);
+  });
+
+  it('ignores changes for uploads it is no longer tracking', () => {
+    store().addUpload('u1', upload({ status: 'uploading' }));
+
+    store().updateUploads([
+      { id: 'u1', changes: { status: 'cancelled' } },
+      { id: 'gone', changes: { status: 'cancelled' } },
+    ]);
+
+    // Disposing the managers on logout emits a trailing 'cancelled' per
+    // in-flight item, and those can land after the session was wiped. Merging
+    // one onto nothing would resurrect it as a card with no name or type.
+    expect(store().uploads.gone).toBeUndefined();
+    expect(store().uploads.u1!.status).toBe('cancelled');
+  });
+
+  it('does not write at all when nothing in the batch applies', () => {
+    let writes = 0;
+    const stop = useUploadStore.subscribe(() => {
+      writes++;
+    });
+
+    store().updateUploads([{ id: 'gone', changes: { status: 'cancelled' } }]);
+    stop();
+
+    expect(writes).toBe(0);
+  });
+
+  it('adds a folder row once when its last files finish together', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 6, 2));
+
+    store().addUpload(
+      'folder',
+      upload({
+        id: 'folder',
+        type: 'folder',
+        name: 'photos',
+        destinationPrefix: '',
+        fileIds: ['a', 'b'],
+      })
+    );
+    store().addUpload('a', upload({ id: 'a', parentFolderId: 'folder', key: 'photos/a.jpg' }));
+    store().addUpload('b', upload({ id: 'b', parentFolderId: 'folder', key: 'photos/b.jpg' }));
+
+    store().updateUploads([
+      { id: 'a', changes: { status: 'completed' } },
+      { id: 'b', changes: { status: 'completed' } },
+    ]);
+
+    // Both files see a folder with everything in, because the batch is written
+    // before any of them looks. Only the first of them places the row.
+    expect(addFolder).toHaveBeenCalledTimes(1);
+    expect(addFolder).toHaveBeenCalledWith('', 'photos');
+  });
+});
+
 describe('clearing', () => {
   beforeEach(() => {
     store().addUpload('done', upload({ id: 'done', status: 'completed' }));

--- a/frontend/src/features/upload/stores/use-upload-store.ts
+++ b/frontend/src/features/upload/stores/use-upload-store.ts
@@ -82,6 +82,12 @@ interface UploadProgress {
   destinationPrefix?: string;
 }
 
+/** One entry of a batched `updateUploads` call. */
+export interface UploadChange {
+  id: string;
+  changes: Partial<UploadProgress>;
+}
+
 /**
  * Adds the row a finished upload produced to the listing it landed in.
  *
@@ -226,6 +232,19 @@ interface UploadStore {
   setUploads: (uploads: Record<string, UploadProgress>) => void;
   addUpload: (id: string, upload: UploadProgress) => void;
   updateUpload: (id: string, updates: Partial<UploadProgress>) => void;
+  /**
+   * Applies changes to many uploads in a single write.
+   *
+   * The manager reports one event per file, and a folder holds as many files as
+   * the user dropped. Applied one at a time, each event copied the whole
+   * `uploads` record and woke every subscriber - so a burst of N events cost N
+   * copies of an N-entry object, which is quadratic in the size of the drop.
+   * Cancelling a few thousand files was several million property copies in one
+   * go, and that is the half of the freeze that had nothing to do with the
+   * network. `upload-context` coalesces a tick's worth of events and sends them
+   * through here instead.
+   */
+  updateUploads: (changes: readonly UploadChange[]) => void;
   removeUpload: (id: string) => void;
   clearCompleted: () => void;
   clearAll: () => void;
@@ -329,60 +348,74 @@ export const useUploadStore = create<UploadStore>((set, get) => ({
       },
     })),
 
-  updateUpload: (id: string, updates: Partial<UploadProgress>) => {
+  updateUpload: (id: string, updates: Partial<UploadProgress>) =>
+    get().updateUploads([{ id, changes: updates }]),
+
+  updateUploads: (changes: readonly UploadChange[]) => {
+    const current = get().uploads;
+
     // Ignore events for uploads we are no longer tracking. Disposing the upload
     // managers on logout emits a trailing 'cancelled' per in-flight item, which
     // can arrive after clearSessionData() has already run - spreading onto an
     // absent entry would resurrect it as a malformed card with no name or type.
-    if (!get().uploads[id]) return;
+    const applicable = changes.filter(({ id }) => current[id]);
+    if (applicable.length === 0) return;
 
-    set((state) => ({
-      uploads: {
-        ...state.uploads,
-        [id]: {
-          ...state.uploads[id],
-          ...updates,
-        },
-      },
-    }));
+    // One copy of the record and one notification, however many files the batch
+    // carries. Mutating `next` is safe because it is not the state object - it
+    // is a fresh copy nothing has been handed yet.
+    const next = { ...current };
+    for (const { id, changes: updates } of applicable) {
+      next[id] = { ...next[id]!, ...updates };
+    }
+    set({ uploads: next });
 
-    // A finished upload adds its own row. Only a card that cannot say where it
-    // landed falls back to re-listing.
-    if (updates.status === 'completed') {
-      const { refreshDataAfterUploadBatch } = get();
-      const state = get();
-      const completedUpload = state.uploads[id];
+    const completed = applicable.filter(({ changes: updates }) => updates.status === 'completed');
+    if (completed.length === 0) return;
 
-      const placeOrRefresh = (upload: UploadProgress) => {
-        if (placeFinishedUpload(upload)) return;
+    // Read back after the write, so a folder's "are all my files in yet?" check
+    // sees the whole batch rather than the part of it applied so far.
+    const settled = get().uploads;
+    const { refreshDataAfterUploadBatch } = get();
 
-        refreshDataAfterUploadBatch().catch(() => {
-          // Silently handle refresh errors
-        });
-      };
+    // Two files of the same folder finishing in the same batch both find the
+    // folder complete, and both would add its row. Only the first one does.
+    const placed = new Set<string>();
+    const placeOrRefresh = (upload: UploadProgress) => {
+      if (placed.has(upload.id)) return;
+      placed.add(upload.id);
 
-      if (completedUpload.type === 'file' && !completedUpload.parentFolderId) {
-        // A loose file, which is one row in the prefix it was dropped into.
-        placeOrRefresh(completedUpload);
-      } else if (completedUpload.type === 'file' && completedUpload.parentFolderId) {
-        // A file inside a folder. Nothing is added for it on its own: the
-        // listing that changes is the one *above* the folder, and it gains a
-        // single row for the folder itself, once every file in it has landed.
-        const parentFolderId = completedUpload.parentFolderId;
-        const folderUpload = state.uploads[parentFolderId];
+      // A finished upload adds its own row. Only a card that cannot say where
+      // it landed falls back to re-listing.
+      if (placeFinishedUpload(upload)) return;
 
-        if (folderUpload && folderUpload.fileIds) {
-          // Check if all files in the folder are completed
-          const allFilesCompleted = folderUpload.fileIds.every((fileId) => {
-            const fileUpload = state.uploads[fileId];
-            return fileUpload && fileUpload.status === 'completed';
-          });
+      refreshDataAfterUploadBatch().catch(() => {
+        // Silently handle refresh errors
+      });
+    };
 
-          if (allFilesCompleted) placeOrRefresh(folderUpload);
-        }
-      } else if (completedUpload.type === 'folder') {
-        placeOrRefresh(completedUpload);
+    for (const { id } of completed) {
+      const upload = settled[id];
+      if (!upload) continue;
+
+      if (upload.type === 'folder' || !upload.parentFolderId) {
+        // A folder, or a loose file - one row in the prefix it was dropped
+        // into, either way.
+        placeOrRefresh(upload);
+        continue;
       }
+
+      // A file inside a folder. Nothing is added for it on its own: the listing
+      // that changes is the one *above* the folder, and it gains a single row
+      // for the folder itself, once every file in it has landed.
+      const folderUpload = settled[upload.parentFolderId];
+      if (!folderUpload?.fileIds) continue;
+
+      const allFilesCompleted = folderUpload.fileIds.every(
+        (fileId) => settled[fileId]?.status === 'completed'
+      );
+
+      if (allFilesCompleted) placeOrRefresh(folderUpload);
     }
   },
 

--- a/s3-api/src/utils/multipartUploader.test.ts
+++ b/s3-api/src/utils/multipartUploader.test.ts
@@ -571,6 +571,79 @@ describe('cancel', () => {
     expect(s3Mock).not.toHaveReceivedCommand(AbortMultipartUploadCommand);
   });
 
+  it('opens nothing at all when it was cancelled before it started', async () => {
+    stubHappyPath();
+    const uploader = makeUploader();
+
+    await uploader.cancel();
+    await uploader.start(makeFile(1 * MB));
+
+    // The manager cancels queued files it never got round to starting. Opening
+    // a multipart upload just to abort it on the next line is a round-trip
+    // nobody asked for, and a few thousand of them is what the queue holds
+    // when a folder is cancelled.
+    expect(s3Mock).not.toHaveReceivedCommand(CreateMultipartUploadCommand);
+  });
+
+  it('aborts a session that was opened while the cancel was in flight', async () => {
+    stubHappyPath();
+    const uploader = makeUploader();
+
+    // A create that has not answered yet, exactly as it is when a cancel
+    // arrives in the same tick the upload started.
+    let answerCreate!: () => void;
+    s3Mock.on(CreateMultipartUploadCommand).callsFake(async () => {
+      await new Promise<void>((resolve) => {
+        answerCreate = resolve;
+      });
+      return { UploadId: 'upload-1' };
+    });
+
+    const started = uploader.start(makeFile(1 * MB));
+    await settle();
+
+    // cancel() finds no uploadId to abort with, so it cannot clean up itself.
+    await uploader.cancel();
+    answerCreate();
+    await started;
+
+    // Without start() aborting on its own behalf, S3 is left holding an
+    // incomplete multipart upload that no listing shows and nothing ever
+    // closes - billed until a lifecycle rule expires it.
+    expect(s3Mock).toHaveReceivedCommandExactlyOnceWith(AbortMultipartUploadCommand, {
+      Bucket: 'test-bucket',
+      Key: 'users/alice/big.bin',
+      UploadId: 'upload-1',
+    });
+    expect(s3Mock).not.toHaveReceivedCommand(UploadPartCommand);
+    expect(s3Mock).not.toHaveReceivedCommand(CompleteMultipartUploadCommand);
+  });
+
+  it('reports a failed clean-up rather than losing it', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubHappyPath();
+    s3Mock.on(AbortMultipartUploadCommand).rejects(new Error('abort failed'));
+    const uploader = makeUploader();
+
+    let answerCreate!: () => void;
+    s3Mock.on(CreateMultipartUploadCommand).callsFake(async () => {
+      await new Promise<void>((resolve) => {
+        answerCreate = resolve;
+      });
+      return { UploadId: 'upload-1' };
+    });
+
+    const started = uploader.start(makeFile(1 * MB));
+    await settle();
+    await uploader.cancel();
+    answerCreate();
+
+    // Nothing is waiting on this path, and the manager reads a rejection from a
+    // cancelled upload as expected noise, so it has to say so itself.
+    await expect(started).resolves.toBeUndefined();
+    expect(error.mock.calls.flat().join(' ')).toMatch(/orphaned/);
+  });
+
   it('clears the resume state', async () => {
     stubHappyPath();
     const uploader = makeUploader();

--- a/s3-api/src/utils/multipartUploader.ts
+++ b/s3-api/src/utils/multipartUploader.ts
@@ -52,6 +52,11 @@ export class MultipartUploader {
   }
 
   async start(file: File, onProgress?: (p: number) => void) {
+    // Cancelled before the queue ever reached this file. Opening a multipart
+    // upload only to abort it on the next line is a round-trip nobody asked
+    // for.
+    if (this.isCancelled) return;
+
     if (!this.uploadId) {
       const { UploadId } = await this.s3.send(
         new CreateMultipartUploadCommand({
@@ -71,6 +76,31 @@ export class MultipartUploader {
       }
 
       this.uploadId = UploadId;
+
+      // cancel() ran while that request was in flight. It looked for an
+      // uploadId, found none, and returned having aborted nothing - so unless
+      // this cleans up now, the upload S3 has just opened is never closed. It
+      // stays in the bucket as an incomplete multipart upload, invisible in
+      // any listing and billed for, until a lifecycle rule expires it. The
+      // window is not theoretical: cancelling a queued file used to start the
+      // next one, so uploads were routinely opened and cancelled inside the
+      // same tick.
+      if (this.isCancelled) {
+        // Reported here rather than thrown on: the cancel that set the flag
+        // resolved long ago and the manager treats a rejection from a cancelled
+        // upload as expected noise, so a failure would otherwise leave the
+        // orphan with nothing said about it anywhere.
+        try {
+          await this.abortUpload();
+        } catch (err) {
+          console.error(
+            `Failed to abort the multipart upload for ${this.key} after it was ` +
+              'cancelled mid-start. It may now be orphaned in the bucket:',
+            err
+          );
+        }
+        return;
+      }
     }
 
     await this.uploadParts(file, onProgress);
@@ -201,19 +231,34 @@ export class MultipartUploader {
     this.controllers = [];
   }
 
+  /**
+   * Tells S3 to throw away the upload it has open, if it has one yet.
+   *
+   * Shared with start(), which has to send this itself when a cancel lands
+   * while CreateMultipartUpload is still in flight - at that point cancel()
+   * has no uploadId to work with.
+   */
+  private async abortUpload() {
+    if (!this.uploadId) return;
+
+    await this.s3.send(
+      new AbortMultipartUploadCommand({
+        Bucket: this.bucket,
+        Key: this.key,
+        UploadId: this.uploadId,
+      })
+    );
+  }
+
   async cancel() {
     this.isCancelled = true;
     this.controllers.forEach((c) => c.abort());
     this.controllers = [];
-    if (this.uploadId) {
-      await this.s3.send(
-        new AbortMultipartUploadCommand({
-          Bucket: this.bucket,
-          Key: this.key,
-          UploadId: this.uploadId,
-        })
-      );
-    }
+    // Deliberately not awaiting an in-flight CreateMultipartUpload to learn its
+    // uploadId first: cancelling a folder cancels its files one after another,
+    // and a network round-trip per file is exactly the wait that made this feel
+    // frozen. start() sends the abort for that case instead, on its own time.
+    await this.abortUpload();
     localStorage.removeItem(`upload:${this.fileName}:${this.key}`);
   }
 }

--- a/s3-api/src/utils/signedUrlUploadManager.test.ts
+++ b/s3-api/src/utils/signedUrlUploadManager.test.ts
@@ -214,6 +214,48 @@ describe('queue', () => {
 });
 
 describe('cancel', () => {
+  it('starts nothing new when a whole batch is cancelled', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 3 });
+    const ids = Array.from({ length: 40 }, (_, i) =>
+      manager.addUpload(makeFile(`f${i}.txt`), { key: `k${i}` })
+    );
+    await settle();
+
+    expect(uploaderInstances.filter((u) => u.upload.mock.calls.length > 0)).toHaveLength(3);
+
+    await Promise.allSettled(ids.map(async (id) => manager.cancelUpload(id)));
+    await settle();
+
+    // Worse here than in UploadManager: nothing in this cancelUpload() awaits,
+    // so the synchronous pump ran while the caller was still part-way through
+    // the folder and EVERY remaining file was started - a signed-URL request
+    // and a PUT each - before its own cancellation arrived.
+    expect(uploaderInstances.filter((u) => u.upload.mock.calls.length > 0)).toHaveLength(3);
+    expect(ids.every((id) => manager.getStatus(id)!.status === 'cancelled')).toBe(true);
+  });
+
+  it('still fills every slot a cancelled batch freed', async () => {
+    const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 3 });
+    const doomed = Array.from({ length: 3 }, (_, i) =>
+      manager.addUpload(makeFile(`doomed${i}.txt`), { key: `doomed${i}` })
+    );
+    const survivors = Array.from({ length: 3 }, (_, i) =>
+      manager.addUpload(makeFile(`s${i}.txt`), { key: `s${i}` })
+    );
+    await settle();
+
+    await Promise.allSettled(doomed.map(async (id) => manager.cancelUpload(id)));
+    await settle();
+
+    // Deferring the pump must not mean dropping it, and one pump per freed slot
+    // rather than one in total.
+    expect(survivors.map((id) => manager.getStatus(id)!.status)).toEqual([
+      'uploading',
+      'uploading',
+      'uploading',
+    ]);
+  });
+
   it('cancels an in-flight upload and frees its slot', async () => {
     const manager = SignedUrlUploadManager.getInstance({ ...config, maxConcurrency: 1 });
     const first = manager.addUpload(makeFile('a.txt'), { key: 'a' });

--- a/s3-api/src/utils/signedUrlUploadManager.ts
+++ b/s3-api/src/utils/signedUrlUploadManager.ts
@@ -39,6 +39,8 @@ export class SignedUrlUploadManager {
   private listeners = new Map<UploadEvent, Set<EventListener>>();
   // See UploadManager.isDisposed for why this exists.
   private isDisposed = false;
+  // Whether a deferred queue pump is already booked. See schedulePump().
+  private pumpScheduled = false;
 
   private constructor(config: SignedUrlUploadManagerConfig) {
     this.apiProvider = config.apiProvider;
@@ -186,7 +188,7 @@ export class SignedUrlUploadManager {
 
     this.updateItemStatus(id, 'cancelled');
     this.releaseResources(id);
-    this.processQueue();
+    this.schedulePump();
   }
 
   /** See UploadManager.releaseResources - same leak, same reasoning. */
@@ -236,6 +238,24 @@ export class SignedUrlUploadManager {
       allStatuses[id] = { status: item.status, progress: item.progress };
     }
     return allStatuses;
+  }
+
+  /**
+   * See UploadManager.schedulePump. The reason bites harder here: nothing in
+   * this cancelUpload() awaits, so a synchronous pump ran while the caller was
+   * still only part-way through the folder - and every remaining file was
+   * started before its own cancellation arrived, not merely half of them.
+   */
+  private schedulePump(): void {
+    if (this.pumpScheduled) return;
+    this.pumpScheduled = true;
+
+    queueMicrotask(() => {
+      this.pumpScheduled = false;
+      for (let slot = this.activeUploads; slot < this.maxConcurrency; slot++) {
+        this.processQueue();
+      }
+    });
   }
 
   /**

--- a/s3-api/src/utils/uploadManager.test.ts
+++ b/s3-api/src/utils/uploadManager.test.ts
@@ -319,6 +319,85 @@ describe('pause, resume, and cancel', () => {
     expect(manager.getStatus(last)!.status).toBe('queued');
   });
 
+  it('starts nothing new when a whole batch is cancelled', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 3 });
+    const ids = Array.from({ length: 40 }, (_, i) =>
+      manager.addUpload(makeFile(`f${i}.txt`), { key: `k${i}` })
+    );
+    await settle();
+
+    const startedBefore = uploaderInstances.filter((u) => u.start.mock.calls.length > 0).length;
+    expect(startedBefore).toBe(3);
+
+    // What cancelling a folder card does: every file, in one pass.
+    await Promise.allSettled(ids.map(async (id) => manager.cancelUpload(id)));
+    await settle();
+
+    // Cancelling used to pump the queue synchronously, handing the slots the
+    // running uploads had just given up to files that were themselves about to
+    // be cancelled. Roughly half the folder was started - a CreateMultipartUpload
+    // and a CORS preflight each - purely so it could be aborted again, and for a
+    // few thousand files that is what froze the tab.
+    const startedAfter = uploaderInstances.filter((u) => u.start.mock.calls.length > 0).length;
+    expect(startedAfter).toBe(startedBefore);
+    expect(ids.every((id) => manager.getStatus(id)!.status === 'cancelled')).toBe(true);
+  });
+
+  it('starts nothing new when a batch is cancelled without awaiting', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 3 });
+    const ids = Array.from({ length: 40 }, (_, i) =>
+      manager.addUpload(makeFile(`f${i}.txt`), { key: `k${i}` })
+    );
+    await settle();
+
+    // The folder cards cancel like this - fire and forget, no await anywhere -
+    // so the fix cannot rely on the caller pausing between files.
+    ids.forEach((id) => void manager.cancelUpload(id));
+    await settle();
+
+    expect(uploaderInstances.filter((u) => u.start.mock.calls.length > 0)).toHaveLength(3);
+  });
+
+  it('still fills every slot a cancelled batch freed', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 3 });
+    const doomed = Array.from({ length: 5 }, (_, i) =>
+      manager.addUpload(makeFile(`doomed${i}.txt`), { key: `doomed${i}` })
+    );
+    const survivor = manager.addUpload(makeFile('survivor.txt'), { key: 'survivor' });
+    await settle();
+
+    await Promise.allSettled(doomed.map(async (id) => manager.cancelUpload(id)));
+    await settle();
+
+    // Deferring the pump must not mean dropping it: work that was NOT cancelled
+    // has to take the freed slot, or a cancelled folder would leave everything
+    // queued behind it stuck until something else happened to finish.
+    expect(manager.getStatus(survivor)!.status).toBe('uploading');
+  });
+
+  it('fills more than one freed slot at a time', async () => {
+    const manager = UploadManager.getInstance({ ...config, maxConcurrency: 3 });
+    const doomed = Array.from({ length: 3 }, (_, i) =>
+      manager.addUpload(makeFile(`doomed${i}.txt`), { key: `doomed${i}` })
+    );
+    const survivors = Array.from({ length: 3 }, (_, i) =>
+      manager.addUpload(makeFile(`s${i}.txt`), { key: `s${i}` })
+    );
+    await settle();
+
+    await Promise.allSettled(doomed.map(async (id) => manager.cancelUpload(id)));
+    await settle();
+
+    // One pump per slot the cancellations freed. A single processQueue() call
+    // starts one upload, so cancelling three would otherwise restart only one
+    // and leave two slots idle.
+    expect(survivors.map((id) => manager.getStatus(id)!.status)).toEqual([
+      'uploading',
+      'uploading',
+      'uploading',
+    ]);
+  });
+
   it('cancels a queued upload without touching the uploader', async () => {
     const manager = UploadManager.getInstance({ ...config, maxConcurrency: 1 });
     manager.addUpload(makeFile('a.txt'), { key: 'a' });

--- a/s3-api/src/utils/uploadManager.ts
+++ b/s3-api/src/utils/uploadManager.ts
@@ -26,6 +26,8 @@ export class UploadManager {
   // over from a previous session/bucket must refuse new work rather than upload to
   // credentials the caller no longer intends to use.
   private isDisposed = false;
+  // Whether a deferred queue pump is already booked. See schedulePump().
+  private pumpScheduled = false;
 
   // --- Part Concurrency ---
   // This is the max parts for a SINGLE file upload.
@@ -270,7 +272,7 @@ export class UploadManager {
       this.releaseResources(id);
     }
 
-    this.processQueue();
+    this.schedulePump();
   }
 
   public getStatus(id: string): { status: UploadStatus; progress: number } | undefined {
@@ -286,11 +288,49 @@ export class UploadManager {
     return allStatuses;
   }
 
+  /**
+   * Refills the slots a cancellation freed - but not until the caller has
+   * finished cancelling.
+   *
+   * Cancelling a folder means cancelling its files one after another, and for
+   * the whole of that pass the queue is still full of files that are about to
+   * be cancelled too. Pumping the queue from inside cancelUpload() handed the
+   * freed slots straight to them: each one STARTED - CreateMultipartUpload,
+   * CORS preflight and all - a moment before its own cancellation reached it.
+   * Cancelling a few thousand files therefore fired off roughly half that many
+   * uploads it then had to abort, which is what locked the tab up for a moment,
+   * and the ones still waiting on CreateMultipartUpload had no uploadId for
+   * cancel() to abort with, so they were left orphaned in the bucket accruing
+   * storage charges.
+   *
+   * A microtask is late enough to land after any synchronous cancel pass, by
+   * which point every cancelled file has been marked and spliced out of the
+   * queue so only somebody else's work is left to start, and early enough that
+   * a single cancel still refills its slot within the same tick. Deferring
+   * rather than skipping is what makes this hold for callers that cancel
+   * without awaiting, which the folder cards do.
+   */
+  private schedulePump(): void {
+    if (this.pumpScheduled) return;
+    this.pumpScheduled = true;
+
+    queueMicrotask(() => {
+      this.pumpScheduled = false;
+      // processQueue() starts at most one upload, so it takes one call per
+      // slot the cancellations freed. The bound is read once, before any of
+      // them runs; calls beyond what the queue can fill return immediately.
+      for (let slot = this.activeUploads; slot < this.maxConcurrency; slot++) {
+        this.processQueue();
+      }
+    });
+  }
+
   private async processQueue(): Promise<void> {
-    // cancelUpload() calls this after every cancellation, including the mass
-    // cancellation inside disposeInstance(). Without this guard, cancelling a
-    // queued item would pull the NEXT queued item off and start uploading it to
-    // the very bucket being torn down.
+    // Every cancellation books a pump, including the mass cancellation inside
+    // disposeInstance(). Without this guard that pump would pull the next
+    // queued item off and start uploading it to the very bucket being torn
+    // down - and since the pump is deferred, it lands after disposal rather
+    // than during it, so the guard is doing more work than it used to.
     if (this.isDisposed) return;
 
     if (this.activeUploads >= this.maxConcurrency || this.queue.length === 0) {


### PR DESCRIPTION
Fixes the draft issue about POST and OPTIONS calls still going out after a cancel.

## What was wrong

Cancelling a folder cancels its files one by one. While that is happening the queue is still full of files that are about to be cancelled too, and the old code refilled the queue after every single cancel. So the free slots went straight to files that were seconds away from being cancelled themselves. Each one started for real, which is the POST and the OPTIONS you saw in the network tab.

Cancelling 3000 files started 1498 uploads that nobody wanted.

Two more things came out of the same bug:

1. Those uploads were started and cancelled so fast that S3 had not replied yet with the upload id. Without that id the cancel could not tell S3 to throw the upload away, so it stayed in the bucket as an incomplete multipart upload. You cannot see these in any file listing but AWS still charges for them.

2. The bigger reason the page froze was not the network at all. Every cancelled file wrote to the upload store on its own, and every write copied the whole list of uploads. With 3000 files that is 3000 copies of a 3000 item list. Measured, it blocked the browser for 9.3 seconds. Now it is one write for the whole batch and the same 3000 files take 9 milliseconds.

## How to test this

You need a decent number of files, a few hundred at least. The bug gets more obvious the more files there are.

1. Open the dashboard and open the browser DevTools Network tab.
2. Drag in a folder with a lot of files, or select a lot of files with the New button. A few thousand small text files is what shows it best.
3. Wait until you can see uploads actually running.
4. Cancel it. Either hit the X on the folder card in the operations panel, or cancel the individual files.
5. Watch the Network tab while it cancels.

What you should see now:

- No new POST calls with `?uploads=` after you hit cancel, and no OPTIONS calls either. The only new requests should be the aborts for the two or three files that were genuinely uploading at that moment.
- The page stays responsive the whole time. You can scroll, click around, open menus while it cancels. Before this it would lock up for a moment and the longer the file list the longer the lockup.
- Every card in the operations panel goes to cancelled. None of them get stuck showing uploading or queued.

Also worth checking that nothing normal broke:

- Upload a folder and let it finish. It should still appear in the listing when it is done, and the progress bars should still move smoothly while it uploads.
- Start two folders uploading, cancel only the first one. The second one should carry on and keep using all the upload slots, not slow down to one file at a time.
- Try it in both upload modes. Settings has a Multipart and a Signed URL option and both had this bug, signed URL slightly worse.
- Pause and resume a large file, then cancel it, and check it still behaves.

If you have access to the bucket, a nice extra check is `aws s3api list-multipart-uploads --bucket <your bucket>` after cancelling a big folder. It should come back empty or close to it. Before this fix it would list hundreds of leftover uploads.

## What changed

- `s3-api/src/utils/uploadManager.ts` and `signedUrlUploadManager.ts`: refilling the queue after a cancel now waits until the caller has finished cancelling, so only work nobody cancelled can start.
- `s3-api/src/utils/multipartUploader.ts`: if the cancel arrives before S3 hands back the upload id, the upload aborts itself once the id shows up. It also skips opening an upload at all if the cancel got there first.
- `frontend/src/features/upload/context/upload-context.tsx` and `stores/use-upload-store.ts`: upload events are collected for a tick and written to the store in one go instead of one write per file.

15 new tests, and all 2039 existing tests still pass.
